### PR TITLE
Always write out arguments, even if set to defaults

### DIFF
--- a/glean_parser/kotlin.py
+++ b/glean_parser/kotlin.py
@@ -67,17 +67,17 @@ def output_kotlin(metrics, output_dir):
 
     # The metric parameters to pass to constructors
     extra_args = [
-        ('name', None),
-        ('category', None),
-        ('send_in_pings', ['default']),
-        ('user_property', False),
-        ('application_property', False),
-        ('disabled', False),
-        ('values', []),
-        ('denominator', ''),
-        ('time_unit', 'millisecond'),
-        ('objects', None),
-        ('allowed_extra_keys', []),
+        'name',
+        'category',
+        'send_in_pings',
+        'user_property',
+        'application_property',
+        'disabled',
+        'values',
+        'denominator',
+        'time_unit',
+        'objects',
+        'allowed_extra_keys'
     ]
 
     for category_key, category_val in metrics.items():

--- a/glean_parser/templates/kotlin.jinja2.kt
+++ b/glean_parser/templates/kotlin.jinja2.kt
@@ -19,7 +19,7 @@ object {{ category_name|Camelize }} {
      */
     val {{ metric.name|camelize }}: {{ metric.type|Camelize }}MetricType by lazy {
         {{ metric.type|Camelize }}MetricType(
-            {% for arg_name, default in extra_args if metric[arg_name] is defined and metric[arg_name] != default -%}
+            {% for arg_name in extra_args if metric[arg_name] is defined -%}
             {{ arg_name|camelize }}={{ metric[arg_name]|kotlin }}{{ "," if not loop.last }}
             {% endfor -%}
         )


### PR DESCRIPTION
As discussed [here](https://github.com/mozilla-mobile/android-components/pull/1171/files#r228514134), we should always write out every argument, even if it's set to a default value.  This lets us define the default values in a single place (`glean_parser`), rather than in multiple places throughout the glean metric code.