### PR TITLE
Use unresolvable URL as $schema id

### DIFF
--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -14,7 +14,6 @@ import datetime
 from typing import Dict, List, Union
 
 import isodate
-import jsonschema
 
 from . import parser
 
@@ -54,13 +53,13 @@ class Metric:
 
     def __post_init__(self, expires_after_build_date, _validated):
         if not _validated:
-            schema = parser._get_metrics_schema()
             data = {
                 self.category: {
                     self.name: self.serialize()
                 }
             }
-            jsonschema.validate(data, schema)
+            for error in parser.validate(data):
+                raise ValueError(error)
 
         if expires_after_build_date is not None:
             self.expires_after_build_date = isodate.parse_date(

--- a/glean_parser/schemas/metrics.1-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.1-0-0.schema.yaml
@@ -3,7 +3,7 @@ title: Metrics
 description: |
   Schema for the metrics.yaml files for Mozilla's glean telemetry SDK.
 
-$id: http://mozilla.org/schemas/glean/metrics
+$id: moz://mozilla.org/schemas/glean/metrics/1-0-0
 
 definitions:
   token:

--- a/tests/data/core.yaml
+++ b/tests/data/core.yaml
@@ -1,4 +1,4 @@
-$schema: http://mozilla.org/schemas/glean/metrics
+$schema: moz://mozilla.org/schemas/glean/metrics/1-0-0
 
 telemetry:
   client_id:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -5,7 +5,6 @@
 
 import datetime
 
-import jsonschema
 import pytest
 
 from glean_parser import parser
@@ -32,7 +31,7 @@ def test_enforcement():
 
     # Python dataclasses don't actually validate any types, so we
     # delegate to jsonschema
-    with pytest.raises(jsonschema.exceptions.ValidationError):
+    with pytest.raises(ValueError):
         metrics.Boolean(
             type='boolean',
             category='category',

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -32,24 +32,6 @@ def test_parser_invalid():
     assert 'could not determine a constructor for the tag' in errors[0]
 
 
-def test_no_schema():
-    """Expect error if no $schema specified in the input file."""
-    contents = [
-        {
-            'category1': {
-                'metric1': {}
-            },
-        },
-    ]
-
-    contents = [util.add_required(x) for x in contents]
-    del contents[0]['$schema']
-    all_metrics = parser._load_metrics_file(contents[0])
-    errors = list(all_metrics)
-    assert len(errors) == 1
-    assert '$schema key must be set to' in errors[0]
-
-
 def test_merge_metrics():
     """Merge multiple metrics.yaml files"""
     contents = [


### PR DESCRIPTION
Based on discussion in https://github.com/mdboom/mobile-telemetry-sdk-schemas/pull/2, this changes the `$schema` value to be an obviously unresolvable URL, and also make it optional.  This requires some workarounds for how JSON schema is used.

There will be some required changes in `android-components`, forthcoming.