### PR TITLE
Enforce that event lifetime is ping

### DIFF
--- a/glean_parser/schemas/metrics.1-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.1-0-0.schema.yaml
@@ -1,4 +1,4 @@
-$schema: http://json-schema.org/draft-06/schema#
+$schema: http://json-schema.org/draft-07/schema#
 title: Metrics
 description: |
   Schema for the metrics.yaml files for Mozilla's glean telemetry SDK.
@@ -284,4 +284,13 @@ additionalProperties:
     anyOf:
       - $ref: "#/definitions/very_short_id"
   additionalProperties:
-    $ref: "#/definitions/metric"
+    allOf:
+      - $ref: "#/definitions/metric"
+      - if:
+          properties:
+            type:
+              const: event
+        then:
+          properties:
+            lifetime:
+              const: ping

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -156,3 +156,22 @@ def test_required_denominator():
     errors = list(all_metrics)
     assert len(errors) == 1
     assert 'denominator is required' in errors[0]
+
+
+def test_event_must_be_ping_lifetime():
+    contents = [
+        {
+            'category': {
+                'metric': {
+                    'type': 'event',
+                    'lifetime': 'user'
+                },
+            },
+        },
+    ]
+
+    contents = [util.add_required(x) for x in contents]
+    all_metrics = parser.parse_metrics(contents)
+    errors = list(all_metrics)
+    assert len(errors) == 1
+    assert "On instance['category']['metric']['lifetime']" in errors[0]


### PR DESCRIPTION
As discussed here: https://github.com/mozilla-mobile/android-components/pull/1308#discussion_r233093823

The event metric should always have a lifetime of ping.