### PR TITLE
1507792: Better error message when metrics.yaml is empty

### DIFF
--- a/glean_parser/parser.py
+++ b/glean_parser/parser.py
@@ -98,6 +98,10 @@ def _load_metrics_file(filepath):
         yield f"{filepath}: {str(e)}"
         return {}
 
+    if metrics_content is None:
+        yield f"{filepath}: metrics file can not be empty."
+        return {}
+
     has_error = False
     for error in validate(metrics_content, filepath):
         has_error = True

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -42,6 +42,14 @@ def test_parser_schema_violation():
     assert len(errors) == 5
 
 
+def test_parser_empty():
+    """1507792: Get a good error message if the metrics.yaml file is empty."""
+    all_metrics = parser.parse_metrics(ROOT / "data" / "empty.yaml")
+    errors = list(all_metrics)
+    assert len(errors) == 1
+    assert 'metrics file can not be empty' in errors[0]
+
+
 def test_invalid_schema():
     all_metrics = parser.parse_metrics([{
         "$schema": "This is wrong"


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1507792

@georgf