### PR TITLE
1507793, 1507794, 1507795: Improve error messages

### DIFF
--- a/glean_parser/parser.py
+++ b/glean_parser/parser.py
@@ -24,6 +24,11 @@ _unset = _utils.Unset()
 
 
 def _less_verbose_validation_error(self):
+    """
+    A version of jsonschema's ValidationError __str__ method that doesn't
+    include the schema fragment that failed.  This makes the error messages
+    much more succinct.
+    """
     essential_for_verbose = (
         self.validator, self.validator_value, self.instance, self.schema,
     )

--- a/glean_parser/parser.py
+++ b/glean_parser/parser.py
@@ -6,8 +6,11 @@ Code for parsing metrics.yaml files.
 
 import functools
 from pathlib import Path
+import pprint
+import textwrap
 
 import jsonschema
+from jsonschema import _utils
 
 from .metrics import Metric
 from . import util
@@ -15,6 +18,33 @@ from . import util
 
 ROOT_DIR = Path(__file__).parent
 SCHEMAS_DIR = ROOT_DIR / 'schemas'
+
+
+_unset = _utils.Unset()
+
+
+def _less_verbose_validation_error(self):
+    essential_for_verbose = (
+        self.validator, self.validator_value, self.instance, self.schema,
+    )
+    if any(m is _unset for m in essential_for_verbose):
+        return self.message
+
+    pinstance = pprint.pformat(self.instance, width=72)
+    return self.message + textwrap.dedent("""
+
+        On %s%s:
+        %s
+        """.rstrip()
+    ) % (
+        self._word_for_instance_in_error_message,
+        _utils.format_as_index(self.relative_path),
+        _utils.indent(pinstance),
+    )
+
+
+jsonschema.exceptions._Error.__str__ = \
+    _less_verbose_validation_error
 
 
 @functools.lru_cache(maxsize=1)

--- a/glean_parser/parser.py
+++ b/glean_parser/parser.py
@@ -39,14 +39,15 @@ def _less_verbose_validation_error(self):
 
     pinstance = pprint.pformat(self.instance, width=72)
 
-    parts = []
-    parts.append('On {}{}:'.format(
-        self._word_for_instance_in_error_message,
-        _utils.format_as_index(self.relative_path),
-    ))
-    parts.append(_utils.indent(pinstance))
-    parts.append('')
-    parts.append(self.message)
+    parts = [
+        'On {}{}:'.format(
+            self._word_for_instance_in_error_message,
+            _utils.format_as_index(self.relative_path),
+        ),
+        _utils.indent(pinstance),
+        '',
+        self.message
+    ]
     if self.context:
         parts.extend(_utils.indent(x.message) for x in self.context)
 

--- a/glean_parser/parser.py
+++ b/glean_parser/parser.py
@@ -7,7 +7,6 @@ Code for parsing metrics.yaml files.
 import functools
 from pathlib import Path
 import pprint
-import textwrap
 
 import jsonschema
 from jsonschema import _utils

--- a/glean_parser/translate.py
+++ b/glean_parser/translate.py
@@ -32,7 +32,7 @@ def translate(input_filepaths, output_format, output_dir):
     found_error = False
     for error in all_metrics:
         found_error = True
-        print('=' * 78)
+        print('=' * 78, file=sys.stderr)
         print(error, file=sys.stderr)
     if found_error:
         return 1

--- a/glean_parser/translate.py
+++ b/glean_parser/translate.py
@@ -32,6 +32,7 @@ def translate(input_filepaths, output_format, output_dir):
     found_error = False
     for error in all_metrics:
         found_error = True
+        print('=' * 78)
         print(error, file=sys.stderr)
     if found_error:
         return 1

--- a/tests/data/schema-violation.yaml
+++ b/tests/data/schema-violation.yaml
@@ -1,2 +1,5 @@
 gleantest.foo:
     a: b
+gleantest:
+    test_event:
+        type: event

--- a/tests/data/schema-violation.yaml
+++ b/tests/data/schema-violation.yaml
@@ -1,0 +1,2 @@
+gleantest.foo:
+    a: b

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -16,7 +16,7 @@ def test_metrics_match_schema():
     Make sure the supported set of metric types in the schema matches the set
     in `metrics.py`
     """
-    schema = parser._get_metrics_schema()
+    schema, validator = parser._get_metrics_schema()
 
     assert (set(metrics.Metric.metric_types.keys()) ==
             set(schema['definitions']['metric']['properties']['type']['enum']))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -34,6 +34,14 @@ def test_parser_invalid():
     assert 'could not determine a constructor for the tag' in errors[0]
 
 
+def test_parser_schema_violation():
+    """1507792"""
+    all_metrics = parser.parse_metrics(ROOT / "data" / "schema-violation.yaml")
+    errors = list(all_metrics)
+    print('\n'.join(errors))
+    assert len(errors) == 2
+
+
 def test_invalid_schema():
     all_metrics = parser.parse_metrics([{
         "$schema": "This is wrong"
@@ -136,7 +144,7 @@ def test_multiple_errors():
     contents = [util.add_required(x) for x in contents]
     metrics = parser.parse_metrics(contents)
     errors = list(metrics)
-    assert len(errors) == 3
+    assert len(errors) == 2
 
 
 def test_required_denominator():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -39,7 +39,7 @@ def test_parser_schema_violation():
     all_metrics = parser.parse_metrics(ROOT / "data" / "schema-violation.yaml")
     errors = list(all_metrics)
     print('\n'.join(errors))
-    assert len(errors) == 2
+    assert len(errors) == 5
 
 
 def test_invalid_schema():
@@ -126,7 +126,6 @@ def test_snake_case_enforcement():
         metrics = parser._load_metrics_file(content)
         errors = list(metrics)
         assert len(errors) == 1
-        assert 'short_id' in errors[0]
 
 
 def test_multiple_errors():

--- a/tests/util.py
+++ b/tests/util.py
@@ -20,6 +20,6 @@ def add_required(chunk):
                 if default_name not in metric:
                     metric[default_name] = default_val
 
-    chunk['$schema'] = parser._get_metrics_schema()['$id']
+    chunk['$schema'] = parser._get_metrics_schema()[0]['$id']
 
     return chunk


### PR DESCRIPTION
When schema validation fails, in the interest of giving the user every possible error, that invalid data produces more obscure errors downstream.

This cuts things off after the schema validation errors if anything fails at that step, and only present the more specific downstream errors if validation itself passes.

This also removes the display of schema fragments when a schema validation fails.  I think those are useful for schema authors -- less useful for those trying to validate against it.  It also shows subschemas that failed, if any, on the same part of the document.

In addition, this checks the schema itself to ensure it's valid, and adds separator lines in the output to make it clear how the long schema validation messages are grouped.

@georgf