### PR TITLE
1507743: Support namespace in output. Support default category.

### DIFF
--- a/glean_parser/__main__.py
+++ b/glean_parser/__main__.py
@@ -44,15 +44,29 @@ from . import validate_ping
     type=click.Choice(mod_translate.OUTPUTTERS.keys()),
     required=True,
 )
-def translate(input, format, output):
+@click.option(
+    '--option',
+    '-s',
+    help='backend-specific option. Must be of the form key=value',
+    type=str,
+    multiple=True,
+    required=False,
+)
+def translate(input, format, output, option):
     """
     Translate metrics.yaml files to other formats.
     """
+    option_dict = {}
+    for opt in option:
+        key, val = opt.split('=', 1)
+        option_dict[key] = val
+
     sys.exit(
         mod_translate.translate(
             [Path(x) for x in input],
             format,
-            Path(output)
+            Path(output),
+            option_dict
         )
     )
 

--- a/glean_parser/kotlin.py
+++ b/glean_parser/kotlin.py
@@ -59,11 +59,16 @@ def kotlin_datatypes_filter(value):
     return fd.getvalue()
 
 
-def output_kotlin(metrics, output_dir):
+def output_kotlin(metrics, output_dir, options={}):
     """
     Given a tree of `metrics`, output Kotlin code to `output_dir`.
-    """
 
+    :param metrics: A tree of metrics, as returns from `parser.parse_metrics`.
+    :param output_dir: Path to an output directory to write to.
+    :param options: options dictionary, with the following optional keys:
+        - `namespace`: The package namespace to declare at the top of the
+          generated files. Defaults to `GleanMetrics`.
+    """
     template = util.get_jinja2_template(
         'kotlin.jinja2',
         filters=(('kotlin', kotlin_datatypes_filter),)
@@ -83,6 +88,8 @@ def output_kotlin(metrics, output_dir):
         'allowed_extra_keys'
     ]
 
+    namespace = options.get('namespace', 'GleanMetrics')
+
     for category_key, category_val in metrics.items():
         filename = util.Camelize(category_key) + '.kt'
         filepath = output_dir / filename
@@ -98,6 +105,7 @@ def output_kotlin(metrics, output_dir):
                     metrics=category_val,
                     metric_types=metric_types,
                     extra_args=extra_args,
+                    namespace=namespace,
                 )
             )
             # Jinja2 squashes the final newline, so we explicitly add it

--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -86,6 +86,9 @@ class Metric:
             for error in parser.validate(data):
                 raise ValueError(error)
 
+        if self.category == 'glean.internal.metrics':
+            self.category = ''
+
     type: str
 
     # Metadata

--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -86,6 +86,8 @@ class Metric:
             for error in parser.validate(data):
                 raise ValueError(error)
 
+        # Metrics in the special category "glean.internal.metrics" need to have
+        # an empty category string when identifying the metrics in the ping.
         if self.category == 'glean.internal.metrics':
             self.category = ''
 

--- a/glean_parser/templates/kotlin.jinja2
+++ b/glean_parser/templates/kotlin.jinja2
@@ -9,7 +9,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 @file:Suppress("PackageNaming")
-package GleanMetrics
+package {{ namespace }}
 
 import mozilla.components.service.glean.Lifetime
 {% for metric_type in metric_types -%}

--- a/glean_parser/translate.py
+++ b/glean_parser/translate.py
@@ -20,10 +20,16 @@ OUTPUTTERS = {
 }
 
 
-def translate(input_filepaths, output_format, output_dir):
+def translate(input_filepaths, output_format, output_dir, options={}):
     """
     Translate the files in `input_filepaths` to the given `output_format` and
     put the results in `output_dir`.
+
+    :param input_filepaths: list of paths to input metrics.yaml files
+    :param output_format: the name of the output formats
+    :param output_dir: the path to the output directory
+    :param options: dictionary of options. The available options are backend
+        format specific.
     """
     if output_format not in OUTPUTTERS:
         raise ValueError(f"Unknown output format '{output_format}'")
@@ -38,5 +44,5 @@ def translate(input_filepaths, output_format, output_dir):
         return 1
     if not output_dir.is_dir():
         os.makedirs(output_dir)
-    OUTPUTTERS[output_format](all_metrics.value, output_dir)
+    OUTPUTTERS[output_format](all_metrics.value, output_dir, options)
     return 0

--- a/tests/data/core.yaml
+++ b/tests/data/core.yaml
@@ -250,3 +250,14 @@ dotted.category:
       - 1137353
     notification_emails:
       - telemetry-client-dev@mozilla.com
+
+glean.internal.metrics:
+  internal:
+    type: string
+    lifetime: application
+    description: >
+      internal metric
+    bugs:
+      - 1137353
+    notification_emails:
+      - telemetry-client-dev@mozilla.com

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,7 +35,9 @@ def test_translate(tmpdir):
             '-o',
             str(tmpdir),
             '-f',
-            'kotlin'
+            'kotlin',
+            '-s',
+            'namespace=Foo'
         ]
     )
     assert result.exit_code == 0
@@ -45,9 +47,15 @@ def test_translate(tmpdir):
             'CorePing.kt',
             'Telemetry.kt',
             'Environment.kt',
-            'DottedCategory.kt'
+            'DottedCategory.kt',
+            'GleanInternalMetrics.kt'
         ])
     )
+    for filename in os.listdir(tmpdir):
+        path = tmpdir / filename
+        with open(path) as fd:
+            content = fd.read()
+        assert 'package Foo' in content
 
 
 def test_translate_errors(tmpdir):

--- a/tests/test_kotlin.py
+++ b/tests/test_kotlin.py
@@ -19,7 +19,12 @@ def test_parser(tmpdir):
     """Test translating metrics to Kotlin files."""
     tmpdir = Path(tmpdir)
 
-    translate.translate(ROOT / "data" / "core.yaml", 'kotlin', tmpdir)
+    translate.translate(
+        ROOT / "data" / "core.yaml",
+        'kotlin',
+        tmpdir,
+        {'namespace': 'Foo'}
+    )
 
     assert (
         set(x.name for x in tmpdir.iterdir()) ==
@@ -27,7 +32,8 @@ def test_parser(tmpdir):
             'CorePing.kt',
             'Telemetry.kt',
             'Environment.kt',
-            'DottedCategory.kt'
+            'DottedCategory.kt',
+            'GleanInternalMetrics.kt'
         ])
     )
 
@@ -36,10 +42,16 @@ def test_parser(tmpdir):
         content = fd.read()
         assert ('True if the user has set Firefox as the default browser.'
                 in content)
+        # Make sure the namespace option is in effect
+        assert 'package Foo' in content
 
     with open(tmpdir / 'Telemetry.kt', 'r', encoding='utf-8') as fd:
         content = fd.read()
         assert 'جمع 搜集' in content
+
+    with open(tmpdir / 'GleanInternalMetrics.kt', 'r', encoding='utf-8') as fd:
+        content = fd.read()
+        assert 'category = ""' in content
 
     # Only run this test if ktlint is on the path
     if shutil.which('ktlint'):

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -26,4 +26,4 @@ def test_translate_missing_directory(tmpdir):
 
     translate.translate(ROOT / 'data' / 'core.yaml', 'kotlin', output)
 
-    assert len(os.listdir(output)) == 4
+    assert len(os.listdir(output)) == 5


### PR DESCRIPTION
This is the glean_parser side of the changes necessary to have a `metrics.yaml` that belongs to the glean library itself.

- Ability to (optionally) set a Kotlin namespace that the output will live in.
- Provide a default file/class name when the category name is empty.