### PR TITLE
Add a TimeUnit enum for time based metrics

### DIFF
--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -144,9 +144,19 @@ class Counter(Metric):
     typename = 'counter'
 
 
+class TimeUnit(enum.Enum):
+    nanosecond = 0
+    microsecond = 1
+    millisecond = 2
+    second = 3
+    minute = 4
+    hours = 5
+    day = 6
+
+
 @dataclass
 class TimeBase(Metric):
-    time_unit: str = 'millisecond'
+    time_unit: TimeUnit = 'millisecond'
 
 
 @dataclass

--- a/glean_parser/templates/kotlin.jinja2
+++ b/glean_parser/templates/kotlin.jinja2
@@ -14,7 +14,10 @@ package {{ namespace }}
 import mozilla.components.service.glean.Lifetime
 {% for metric_type in metric_types -%}
 import mozilla.components.service.glean.{{ metric_type|Camelize }}MetricType
-{% endfor %}
+{% endfor -%}
+{% if 'timespan' in metric_types or 'timing_distribution' in metric_types -%}
+import mozilla.components.service.glean.TimeUnit
+{% endif %}
 object {{ category_name|Camelize }} {
 {%- for metric in metrics.values() %}
     /**

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -67,3 +67,31 @@ def test_isodate():
             notification_emails=['nobody@nowhere.com'],
             description='description...',
         )
+
+
+def test_timespan_time_unit():
+    """
+    Test that the timespan's time_unit is coerced to an enum.
+    """
+    m = metrics.Timespan(
+        type='timespan',
+        category='category',
+        name='metric',
+        bugs=[42],
+        time_unit='day',
+        notification_emails=['nobody@nowhere.com'],
+        description='description...',
+    )
+    assert isinstance(m.time_unit, metrics.TimeUnit)
+    assert m.time_unit == metrics.TimeUnit.day
+
+    with pytest.raises(AttributeError):
+        m = metrics.Timespan(
+            type='timespan',
+            category='category',
+            name='metric',
+            bugs=[42],
+            time_unit='foo',
+            notification_emails=['nobody@nowhere.com'],
+            description='description...',
+        )


### PR DESCRIPTION
Timespan and TimingDistribution both require a time_unit parameter, which is an enum users can
pick the resolution from. This adds validation for the possible values and enforces the correct code
generation.