### PR TITLE
Fix 1516538: Clean out old files when generating source

### DIFF
--- a/tests/data/smaller.yaml
+++ b/tests/data/smaller.yaml
@@ -1,0 +1,16 @@
+$schema: moz://mozilla.org/schemas/glean/metrics/1-0-0
+
+telemetry:
+  client_id:
+    type: uuid
+    lifetime: user
+    description: >
+      A UUID identifying a profile and allowing user-oriented
+      Correlation of data.
+      Some Unicode: جمع 搜集
+    bugs:
+      - 1137353
+    notification_emails:
+      - telemetry-client-dev@mozilla.com
+    send_in_pings:
+      - core

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -3,7 +3,6 @@
 # Any copyright is dedicated to the Public Domain.
 # http://creativecommons.org/publicdomain/zero/1.0/
 
-import os
 from pathlib import Path
 
 import pytest
@@ -26,4 +25,16 @@ def test_translate_missing_directory(tmpdir):
 
     translate.translate(ROOT / 'data' / 'core.yaml', 'kotlin', output)
 
-    assert len(os.listdir(output)) == 5
+    assert len(list(output.iterdir())) == 5
+
+
+def test_translate_remove_obsolete_files(tmpdir):
+    output = Path(tmpdir) / 'foo'
+
+    translate.translate(ROOT / 'data' / 'core.yaml', 'kotlin', output)
+
+    assert len(list(output.iterdir())) == 5
+
+    translate.translate(ROOT / 'data' / 'smaller.yaml', 'kotlin', output)
+
+    assert len(list(output.iterdir())) == 1


### PR DESCRIPTION
This writes out all output to a temporary directory, then deletes the output directory (if any) and moves copies all contents over.  That way we should get a freshly generated tree each time.

Note that this means we must completely *own* the output directory as anything already in there will be deleted.  This fits in fine with how we currently use `glean_parser` within `android-components`, but just wanted to flag that.