### PR TITLE
1523331: Make metrics internal to the package they are defined in

### DIFF
--- a/glean_parser/templates/kotlin.jinja2
+++ b/glean_parser/templates/kotlin.jinja2
@@ -18,7 +18,7 @@ import mozilla.components.service.glean.{{ metric_type|Camelize }}MetricType
 {% if 'timespan' in metric_types or 'timing_distribution' in metric_types -%}
 import mozilla.components.service.glean.TimeUnit
 {% endif %}
-object {{ category_name|Camelize }} {
+internal object {{ category_name|Camelize }} {
 {%- for metric in metrics.values() %}
     /**
      * {{ metric.description|wordwrap(wrapstring='\n     * ') }}


### PR DESCRIPTION
This makes the generated specific metrics internal to the package they are defined in.

This relies on https://github.com/mozilla-mobile/android-components/pull/1879 so that the metrics are defined in the correct package.  Then there will also need to be a follow-on PR to android-components to update the glean_parser so that compiler will actually enforce the fact that the metrics are internal.