### PR TITLE
Explicitly test for slash in names, categories and labels

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -214,3 +214,58 @@ def test_parser_reserved():
     all_metrics = parser.parse_metrics(contents, {'allow_reserved': True})
     errors = list(all_metrics)
     assert len(errors) == 0
+
+
+def test_parser_slash_in_name():
+    contents = [
+        {
+            'glean.baseline': {
+                'metric/with_slash': {
+                    'type': 'string',
+                },
+            },
+        },
+    ]
+
+    contents = [util.add_required(x) for x in contents]
+    all_metrics = parser.parse_metrics(contents)
+    errors = list(all_metrics)
+    assert len(errors) == 1
+    assert "metric/with_slash" in errors[0]
+
+
+def test_parser_slash_in_category():
+    contents = [
+        {
+            'glean.baseline/slash': {
+                'metric': {
+                    'type': 'string',
+                },
+            },
+        },
+    ]
+
+    contents = [util.add_required(x) for x in contents]
+    all_metrics = parser.parse_metrics(contents)
+    errors = list(all_metrics)
+    assert len(errors) == 1
+    assert "glean.baseline/slash" in errors[0]
+
+
+def test_parser_slash_in_labels():
+    contents = [
+        {
+            'glean.baseline': {
+                'metric': {
+                    'type': 'string',
+                    'labels': ['has/a_slash']
+                },
+            },
+        },
+    ]
+
+    contents = [util.add_required(x) for x in contents]
+    all_metrics = parser.parse_metrics(contents)
+    errors = list(all_metrics)
+    assert len(errors) == 1
+    assert "has/a_slash" in errors[0]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -263,7 +263,8 @@ def invalid_in_label(name):
 @pytest.mark.parametrize('name', [
     "name/with_slash",
     "name#with_pound",
-    "this_name_is_too_long_and_shouldnt_be_used"
+    "this_name_is_too_long_and_shouldnt_be_used",
+    ""
 ])
 def test_invalid_names(location, name):
     contents = location(name)


### PR DESCRIPTION
As mentioned [here](https://github.com/mozilla-mobile/android-components/pull/1984#discussion_r254790281) we should be extra careful that we don't get slashes into names, categories or labels.  This adds test for that at build time (it was already being checked for, but there weren't explicit tests for it).