### PR TITLE
Add Metric Identifier

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,7 +11,7 @@ Development Lead
 Contributors
 ------------
 
-None yet. Why not be the first?
+* Frank Bertsch <frank@mozilla.com>
 
 Acknowledgements
 ----------------

--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -27,6 +27,7 @@ class Lifetime(enum.Enum):
 
 @dataclass
 class Metric:
+    glean_internal_metric_cat = 'glean.internal.metrics'
     metric_types = {}
 
     def __init_subclass__(cls, **kwargs):
@@ -64,6 +65,16 @@ class Metric:
         del d['category']
         return d
 
+    def identifier(self):
+        """
+        Create an identifier unique for this metric.
+        Generally, category.name; however, glean internal
+        metrics only use name.
+        """
+        if not self.category:
+            return self.name
+        return '.'.join((self.category, self.name))
+
     def __post_init__(self, expires_after_build_date, _validated):
         # Convert enum fields to Python enums
         for f in dataclasses.fields(self):
@@ -94,7 +105,7 @@ class Metric:
 
         # Metrics in the special category "glean.internal.metrics" need to have
         # an empty category string when identifying the metrics in the ping.
-        if self.category == 'glean.internal.metrics':
+        if self.category == Metric.glean_internal_metric_cat:
             self.category = ''
 
     type: str

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -95,3 +95,37 @@ def test_timespan_time_unit():
             notification_emails=['nobody@nowhere.com'],
             description='description...',
         )
+
+
+def test_identifier():
+    """
+    Test that the identifier is created correctly.
+    """
+    m = metrics.Timespan(
+        type='timespan',
+        category='category',
+        name='metric',
+        bugs=[42],
+        time_unit='day',
+        notification_emails=['nobody@nowhere.com'],
+        description='description...',
+    )
+
+    assert m.identifier() == "category.metric"
+
+
+def test_identifier_glean_category():
+    """
+    Test that the glean-internal identifier is created correctly.
+    """
+    m = metrics.Timespan(
+        type='timespan',
+        category=metrics.Metric.glean_internal_metric_cat,
+        name='metric',
+        bugs=[42],
+        time_unit='day',
+        notification_emails=['nobody@nowhere.com'],
+        description='description...',
+    )
+
+    assert m.identifier() == "metric"


### PR DESCRIPTION
This is going to be used by the probe-scraper to properly identify metrics. See https://github.com/mozilla/probe-scraper/issues/67