### PR TITLE
1525045: Fix code generation so TimeUnit is available to DatetimeMetricType

### DIFF
--- a/glean_parser/templates/kotlin.jinja2
+++ b/glean_parser/templates/kotlin.jinja2
@@ -12,14 +12,12 @@
 package {{ namespace }}
 
 import mozilla.components.service.glean.Lifetime
+import mozilla.components.service.glean.TimeUnit // ktlint-disable no-unused-imports
 {% for metric_type in metric_types -%}
 import mozilla.components.service.glean.{{ metric_type|Camelize }}MetricType
 {% endfor -%}
 {% if has_labeled_metrics -%}
 import mozilla.components.service.glean.LabeledMetricType
-{% endif -%}
-{% if 'timespan' in metric_types or 'timing_distribution' in metric_types -%}
-import mozilla.components.service.glean.TimeUnit
 {% endif -%}
 
 internal object {{ category_name|Camelize }} {


### PR DESCRIPTION
Simple fix required to generate code for the DatetimeMetricType added in https://github.com/mozilla-mobile/android-components/pull/2014.  This needs the `TimeUnit` enum.  Rather than adding all kinds of brittle logic of when to import it, just imports it always and adds a hint to `ktlint` to not complain.