### PR TITLE
1535339, 1535341: Improvements to event extra metadata

### DIFF
--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -35,7 +35,14 @@ class Metric:
         super().__init_subclass__(**kwargs)
 
     @classmethod
-    def make_metric(cls, category, name, metric_info, config={}, validated=False):
+    def make_metric(
+            cls,
+            category,
+            name,
+            metric_info,
+            config={},
+            validated=False
+    ):
         """
         Given a metric_info dictionary from metrics.yaml, return a metric
         instance.

--- a/glean_parser/parser.py
+++ b/glean_parser/parser.py
@@ -140,7 +140,8 @@ def _merge_and_instantiate_metrics(filepaths, config):
             for metric_key, metric_val in category_val.items():
                 try:
                     metric_obj = Metric.make_metric(
-                        category_key, metric_key, metric_val, validated=True
+                        category_key, metric_key, metric_val,
+                        validated=True, config=config
                     )
                 except Exception as e:
                     yield f"{filepath}: {category_key}.{metric_key}: {e}"

--- a/glean_parser/schemas/metrics.1-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.1-0-0.schema.yaml
@@ -277,15 +277,22 @@ definitions:
         title: Extra keys
         description: |
           The acceptable keys on the "extra" object sent with events. This is an
-          object mapping the key to a description.
+          object mapping the key to an object containing metadata about the key.
+          This metadata object has the following keys:
+
+            - `description`: **Required.** A description of the key.
 
           Valid when `type`_ is `event`.
         type: object
         propertyNames:
-          $ref: "#/definitions/long_id"
+          $ref: "#/definitions/dotted_snake_case"
         additionalProperties:
-          type: string
-          maxLength: 100
+          type: object
+          properties:
+            description:
+              type: string
+          required:
+            - description
         default: {}
 
     required:

--- a/tests/data/core.yaml
+++ b/tests/data/core.yaml
@@ -290,8 +290,10 @@ environment:
     notification_emails:
       - telemetry-client-dev@mozilla.com
     extra_keys:
-      key1: "This is key one"
-      key2: "This is key two"
+      key1:
+        description: "This is key one"
+      key2:
+        description: "This is key two"
     expires: never
 
 dotted.category:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -139,3 +139,33 @@ def test_identifier_glean_category():
     )
 
     assert m.identifier() == "metric"
+
+
+def test_reserved_extra_keys():
+    """
+    Test that extra keys starting with 'glean.' are rejected for
+    non-internal metrics.
+    """
+    with pytest.raises(ValueError):
+        metrics.Event(
+            type='event',
+            category='category',
+            name='metric',
+            bugs=[42],
+            notification_emails=['nobody@nowhere.com'],
+            description='description...',
+            expires='never',
+            extra_keys={'glean.internal': {'description': 'foo'}}
+        )
+
+    metrics.Event(
+        type='event',
+        category='category',
+        name='metric',
+        bugs=[42],
+        notification_emails=['nobody@nowhere.com'],
+        description='description...',
+        expires='never',
+        extra_keys={'glean.internal': {'description': 'foo'}},
+        _config={'allow_reserved': True}
+    )


### PR DESCRIPTION
This ties up a couple of loose ends from the event API changes proposal.

1) It makes sure that event extra data keys starting with `glean.` are reserved for internal use.

2) It makes the entries in the extra_keys parameter an object rather than a string so we can attach other metadata in the future.

(It was easiest to handle these two bugs as a unit, since they are so closely related).