### PR TITLE
Fix #45: NoExtraKeys should always be imported in generated code

### DIFF
--- a/glean_parser/templates/kotlin.jinja2
+++ b/glean_parser/templates/kotlin.jinja2
@@ -22,6 +22,7 @@ package {{ namespace }}
 
 import mozilla.components.service.glean.Lifetime
 import mozilla.components.service.glean.TimeUnit // ktlint-disable no-unused-imports
+import mozilla.components.service.glean.NoExtraKeys // ktlint-disable no-unused-imports
 {% for metric_type in metric_types %}
 import mozilla.components.service.glean.{{ metric_type|Camelize }}MetricType
 {% endfor %}


### PR DESCRIPTION
This will be tested by the corresponding PR in android-components, coming shortly.