### PR TITLE
Update template import statements to add .metrics sub-package

### DIFF
--- a/glean_parser/templates/kotlin.jinja2
+++ b/glean_parser/templates/kotlin.jinja2
@@ -20,11 +20,11 @@
 @file:Suppress("PackageNaming")
 package {{ namespace }}
 
-import mozilla.components.service.glean.Lifetime
-import mozilla.components.service.glean.TimeUnit // ktlint-disable no-unused-imports
-import mozilla.components.service.glean.NoExtraKeys // ktlint-disable no-unused-imports
+import mozilla.components.service.glean.metrics.Lifetime
+import mozilla.components.service.glean.metrics.TimeUnit // ktlint-disable no-unused-imports
+import mozilla.components.service.glean.metrics.NoExtraKeys // ktlint-disable no-unused-imports
 {% for metric_type in metric_types %}
-import mozilla.components.service.glean.{{ metric_type|Camelize }}MetricType
+import mozilla.components.service.glean.metrics.{{ metric_type|Camelize }}MetricType
 {% endfor %}
 {% if has_labeled_metrics %}
 import mozilla.components.service.glean.LabeledMetricType


### PR DESCRIPTION
This must coincide with changes to the glean library, moving all metric types to a /metrics subdirectory.  I'll update this with the PR # from android-components as soon as it's filed.