### PR TITLE
1509053: Improve glean_parser error messages

### DIFF
--- a/glean_parser/parser.py
+++ b/glean_parser/parser.py
@@ -77,6 +77,10 @@ def _pprint_validation_error(error):
 
 
 def _format_error(filepath, header, content):
+    if isinstance(filepath, Path):
+        filepath = filepath.resolve()
+    else:
+        filepath = '<string>'
     if header:
         return f'{filepath}: {header}:\n{_utils.indent(content)}'
     else:
@@ -178,10 +182,6 @@ def _merge_and_instantiate_metrics(filepaths, config):
 
     for filepath in filepaths:
         metrics_content = yield from _load_metrics_file(filepath)
-        if isinstance(filepath, Path):
-            filepath = filepath.resolve()
-        else:
-            filepath = '<string>'
         for category_key, category_val in metrics_content.items():
             if category_key.startswith('$'):
                 continue

--- a/glean_parser/schemas/metrics.1-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.1-0-0.schema.yaml
@@ -3,6 +3,10 @@ title: Metrics
 description: |
   Schema for the metrics.yaml files for Mozilla's glean telemetry SDK.
 
+  The top-level of the `metrics.yaml` file has a key defining each category of
+  metrics. Categories must be snake_case, and they may also have dots `.` to
+  define subcategories.
+
 $id: moz://mozilla.org/schemas/glean/metrics/1-0-0
 
 definitions:
@@ -35,6 +39,11 @@ definitions:
       - maxLength: 20
 
   metric:
+    description: |
+      Describes a single metric.
+
+      See https://mozilla.github.io/glean_parser/metrics-yaml.html
+
     type: object
 
     additionalProperties: false
@@ -265,7 +274,7 @@ definitions:
         anyOf:
           - type: array
             items:
-              $ref: "#/definitions/snake_case"
+              $ref: "#/definitions/long_id"
             maxItems: 16
           - type: "null"
 
@@ -328,11 +337,14 @@ additionalProperties:
   additionalProperties:
     allOf:
       - $ref: "#/definitions/metric"
-      - if:
+      -
+        if:
           properties:
             type:
               const: event
         then:
           properties:
             lifetime:
+              description: |
+                Event metrics must have ping lifetime.
               const: ping

--- a/tests/data/schema-violation.yaml
+++ b/tests/data/schema-violation.yaml
@@ -3,3 +3,13 @@ gleantest.foo:
 gleantest:
     test_event:
         type: event
+gleantest.lifetime:
+    test_event_inv_lt:
+        description: A event with an invalid lifetime
+        type: event
+        lifetime: user2
+        type: boolean
+        bugs: [123456789]
+        notification_emails: ['nobody@nowhere.com']
+        expires: never
+        data_reviews: ['http://zomobocom.com']


### PR DESCRIPTION
This makes the following improvements to messages about errors in metrics.yaml:

- The snippet that caused the error is printed inline as YAML, rather than
  Python repr (approx. JSON). This should match the input much better.

- The location of the error is now represented by adding context to the YAML
  (i.e. adding the dictionary keys that lead to the location of the source
  of the error).  Prior to this, this used a Pythonic syntax like
  ['category']['metric']

- The `description` field in the JSON schema chunk that didn't validate
  is printed with the error.

- If there are missing required properties, a single error is displayed showing
  all of the missing properties.  Prior to this, there was an error emitted for
  each missing property.

- The filepath is displayed as an absolute path so it should be clickable to go
  to the source in IDEs (including Android Studio) that support clickable file
  links in build log output.

- Other general consistency of error message fixes.