### PR TITLE
1540844: Rename metrics -> private

### DIFF
--- a/glean_parser/templates/kotlin.jinja2
+++ b/glean_parser/templates/kotlin.jinja2
@@ -20,14 +20,14 @@
 @file:Suppress("PackageNaming")
 package {{ namespace }}
 
-import mozilla.components.service.glean.metrics.Lifetime
-import mozilla.components.service.glean.metrics.TimeUnit // ktlint-disable no-unused-imports
-import mozilla.components.service.glean.metrics.NoExtraKeys // ktlint-disable no-unused-imports
+import mozilla.components.service.glean.private.Lifetime
+import mozilla.components.service.glean.private.TimeUnit // ktlint-disable no-unused-imports
+import mozilla.components.service.glean.private.NoExtraKeys // ktlint-disable no-unused-imports
 {% for metric_type in metric_types %}
-import mozilla.components.service.glean.metrics.{{ metric_type|Camelize }}MetricType
+import mozilla.components.service.glean.private.{{ metric_type|Camelize }}MetricType
 {% endfor %}
 {% if has_labeled_metrics %}
-import mozilla.components.service.glean.metrics.LabeledMetricType
+import mozilla.components.service.glean.private.LabeledMetricType
 {% endif %}
 
 internal object {{ category_name|Camelize }} {


### PR DESCRIPTION
This puts the "public-not-public" API under the namespace `private` to make that more obvious.