### PR TITLE
1543487: Don't use Kotlin introspection

### DIFF
--- a/glean_parser/kotlin.py
+++ b/glean_parser/kotlin.py
@@ -115,7 +115,8 @@ def output_kotlin(metrics, output_dir, options={}):
         'lifetime',
         'values',
         'denominator',
-        'time_unit'
+        'time_unit',
+        'allowed_extra_keys'
     ]
 
     namespace = options.get('namespace', 'GleanMetrics')

--- a/glean_parser/templates/kotlin.jinja2
+++ b/glean_parser/templates/kotlin.jinja2
@@ -33,9 +33,9 @@ import mozilla.components.service.glean.private.LabeledMetricType
 internal object {{ category_name|Camelize }} {
 {% for metric in metrics.values() %}
     {% if metric.extra_keys|length %}
-    enum class {{ metric.name|camelize }}Keys(val value: String) {
+    enum class {{ metric.name|camelize }}Keys {
     {% for key in metric.allowed_extra_keys %}
-        {{ key|camelize }}({{ key|kotlin }}){{ "," if not loop.last }}
+        {{ key|camelize }}{{ "," if not loop.last }}
     {% endfor %}
     }
     {% endif %}


### PR DESCRIPTION
This is a workaround to not require Kotlin introspection.

We currently use introspection to get the string value of the extra key from the enum value.  The idea here is to not try to get the value directly from the enum, but just store a List of the strings with each event metric and use the enum's `ordinal` to look up the string in that List.