### PR TITLE
1529226: Add support for pings.yaml

### DIFF
--- a/glean_parser/__main__.py
+++ b/glean_parser/__main__.py
@@ -20,7 +20,7 @@ from . import validate_ping
 @click.argument(
     'input',
     type=click.Path(
-        exists=True,
+        exists=False,
         dir_okay=False,
         file_okay=True,
         readable=True,
@@ -62,7 +62,7 @@ from . import validate_ping
 )
 def translate(input, format, output, option, allow_reserved):
     """
-    Translate metrics.yaml files to other formats.
+    Translate metrics.yaml and pings.yaml files to other formats.
     """
     option_dict = {}
     for opt in option:

--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -112,6 +112,7 @@ class Metric:
         # validated (but not any of the Python-level validation).
         if not _validated:
             data = {
+                '$schema': parser.METRICS_ID,
                 self.category: {
                     self.name: self.serialize()
                 }

--- a/glean_parser/pings.py
+++ b/glean_parser/pings.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+Classes for managing the description of pings.
+"""
+
+from dataclasses import dataclass
+
+
+RESERVED_PING_NAMES = [
+    'baseline', 'metrics', 'events'
+]
+
+
+@dataclass
+class Ping:
+    type = 'ping'
+    name: str
+    description: str
+    include_client_id: bool = False

--- a/glean_parser/schemas/metrics.1-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.1-0-0.schema.yaml
@@ -340,7 +340,11 @@ type: object
 
 propertyNames:
   anyOf:
-    - $ref: "#/definitions/dotted_snake_case"
+    - allOf:
+        - $ref: "#/definitions/dotted_snake_case"
+        - not:
+            description: "'pings' is reserved as a category name."
+            const: pings
     - enum: ['$schema']
 
 properties:

--- a/glean_parser/schemas/pings.1-0-0.schema.yaml
+++ b/glean_parser/schemas/pings.1-0-0.schema.yaml
@@ -1,0 +1,53 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: Pings
+description: |
+  Schema for the pings.yaml files for Mozilla's glean telemetry SDK.
+
+  The top-level of the `pings.yaml` file has a key defining the name of each
+  ping. The values contain metadata about that ping. Ping names must be
+  snake_case, though they may also have dots `.` to define subcategories.
+
+$id: moz://mozilla.org/schemas/glean/pings/1-0-0
+
+definitions:
+  dotted_snake_case:
+    type: string
+    pattern: "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})*$"
+    maxLength: 40
+
+type: object
+
+propertyNames:
+  anyOf:
+    - $ref: "#/definitions/dotted_snake_case"
+    - enum: ['$schema']
+
+properties:
+  $schema:
+    type: string
+    format: url
+
+additionalProperties:
+  type: object
+  properties:
+    description:
+      title: Description
+      description: |
+        **Required.**
+
+        A textual description of the purpose of this ping and what it contains.
+      type: string
+
+    include_client_id:
+      title: Include client id
+      description: |
+        **Required.**
+
+        When `true`, include the `client_id` value in the ping.
+      type: boolean
+
+  required:
+    - description
+    - include_client_id
+
+  additionalProperties: false

--- a/glean_parser/templates/kotlin.jinja2
+++ b/glean_parser/templates/kotlin.jinja2
@@ -7,15 +7,15 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-{% macro metric_declaration(metric, suffix='', access='') %}
-{{ access }}val {{ metric.name|camelize }}{{ suffix }}: {{ metric|metric_type_name }} by lazy {
-        {{ metric|metric_type_name }}(
-            {% for arg_name in extra_args if metric[arg_name] is defined %}
-            {{ arg_name|camelize }} = {{ metric[arg_name]|kotlin }},
+{% macro obj_declaration(obj, suffix='', access='', lazy=False) %}
+{{ access }}val {{ obj.name|camelize }}{{ suffix }}: {{ obj|type_name }}{% if lazy %} by lazy { {%- else %} ={% endif %}
+
+        {{ obj|type_name }}(
+            {% for arg_name in extra_args if obj[arg_name] is defined %}
+            {{ arg_name|camelize }} = {{ obj[arg_name]|kotlin }}{{ "," if not loop.last }}
             {% endfor %}
-            disabled = {{ metric.is_disabled()|kotlin }}
         )
-    }{% endmacro %}
+{% if lazy %}    }{% endif %}{% endmacro %}
 
 @file:Suppress("PackageNaming")
 package {{ namespace }}
@@ -23,45 +23,45 @@ package {{ namespace }}
 import mozilla.components.service.glean.private.Lifetime
 import mozilla.components.service.glean.private.TimeUnit // ktlint-disable no-unused-imports
 import mozilla.components.service.glean.private.NoExtraKeys // ktlint-disable no-unused-imports
-{% for metric_type in metric_types %}
-import mozilla.components.service.glean.private.{{ metric_type|Camelize }}MetricType
+{% for obj_type in obj_types %}
+import mozilla.components.service.glean.private.{{ obj_type }}
 {% endfor %}
 {% if has_labeled_metrics %}
 import mozilla.components.service.glean.private.LabeledMetricType
 {% endif %}
 
 internal object {{ category_name|Camelize }} {
-{% for metric in metrics.values() %}
-    {% if metric.extra_keys|length %}
-    enum class {{ metric.name|camelize }}Keys {
-    {% for key in metric.allowed_extra_keys %}
+{% for obj in objs.values() %}
+    {% if obj.extra_keys|length %}
+    enum class {{ obj.name|camelize }}Keys {
+    {% for key in obj.allowed_extra_keys %}
         {{ key|camelize }}{{ "," if not loop.last }}
     {% endfor %}
     }
     {% endif %}
 {% endfor %}
-{% for metric in metrics.values() %}
-    {% if metric.labeled %}
-    {{ metric_declaration(metric, 'Label', 'private ') }}
+{% for obj in objs.values() %}
+    {% if obj.labeled %}
+    {{ obj_declaration(obj, 'Label', 'private ') }}
     /**
-     * {{ metric.description|wordwrap(wrapstring='\n     * ') }}
+     * {{ obj.description|wordwrap(wrapstring='\n     * ') }}
      */
-    val {{ metric.name|camelize }}: LabeledMetricType<{{ metric|metric_type_name }}> by lazy {
+    val {{ obj.name|camelize }}: LabeledMetricType<{{ obj|type_name }}> by lazy {
         LabeledMetricType(
-            category = {{ metric.category|kotlin }},
-            name = {{ metric.name|kotlin }},
-            subMetric = {{ metric.name|camelize }}Label,
-            disabled = {{ metric.is_disabled()|kotlin }},
-            lifetime = {{ metric.lifetime|kotlin }},
-            sendInPings = {{ metric.send_in_pings|kotlin }},
-            labels = {{ metric.labels|kotlin }}
+            category = {{ obj.category|kotlin }},
+            name = {{ obj.name|kotlin }},
+            subMetric = {{ obj.name|camelize }}Label,
+            disabled = {{ obj.is_disabled()|kotlin }},
+            lifetime = {{ obj.lifetime|kotlin }},
+            sendInPings = {{ obj.send_in_pings|kotlin }},
+            labels = {{ obj.labels|kotlin }}
         )
     }
     {% else %}
     /**
-     * {{ metric.description|wordwrap(wrapstring='\n     * ') }}
+     * {{ obj.description|wordwrap(wrapstring='\n     * ') }}
      */
-    {{ metric_declaration(metric) }}
+    {{ obj_declaration(obj, lazy=obj.type != 'ping') }}
     {% endif %}
 {%- endfor %}
 }

--- a/glean_parser/templates/kotlin.jinja2
+++ b/glean_parser/templates/kotlin.jinja2
@@ -20,7 +20,7 @@
 @file:Suppress("PackageNaming")
 package {{ namespace }}
 
-import mozilla.components.service.glean.private.Lifetime
+import mozilla.components.service.glean.private.Lifetime // ktlint-disable no-unused-imports
 import mozilla.components.service.glean.private.TimeUnit // ktlint-disable no-unused-imports
 import mozilla.components.service.glean.private.NoExtraKeys // ktlint-disable no-unused-imports
 {% for obj_type in obj_types %}

--- a/glean_parser/util.py
+++ b/glean_parser/util.py
@@ -64,6 +64,9 @@ def load_yaml_or_json(path):
     if TESTING_MODE and isinstance(path, dict):
         return path
 
+    if not path.is_file():
+        return {}
+
     if path.suffix == '.json':
         with open(path, 'r') as fd:
             return json.load(fd)

--- a/tests/data/pings.yaml
+++ b/tests/data/pings.yaml
@@ -1,0 +1,9 @@
+customPing:
+    description:
+        This is a custom ping
+    include_client_id: false
+
+reallyCustomPing:
+    description:
+        This is another custom ping
+    include_client_id: true

--- a/tests/data/pings.yaml
+++ b/tests/data/pings.yaml
@@ -1,9 +1,11 @@
-customPing:
+$schema: moz://mozilla.org/schemas/glean/pings/1-0-0
+
+custom_ping:
     description:
         This is a custom ping
     include_client_id: false
 
-reallyCustomPing:
+really_custom_ping:
     description:
         This is another custom ping
     include_client_id: true

--- a/tests/data/schema-violation.yaml
+++ b/tests/data/schema-violation.yaml
@@ -1,3 +1,4 @@
+$schema: moz://mozilla.org/schemas/glean/metrics/1-0-0
 gleantest.foo:
     a: b
 gleantest:

--- a/tests/test_kotlin.py
+++ b/tests/test_kotlin.py
@@ -9,6 +9,7 @@ import subprocess
 
 from glean_parser import kotlin
 from glean_parser import metrics
+from glean_parser import pings
 from glean_parser import translate
 
 
@@ -82,7 +83,7 @@ def test_metric_type_name():
         extra_keys={'my_extra': {'description': 'an extra'}},
     )
 
-    assert kotlin.metric_type_name(event) == 'EventMetricType<metricKeys>'
+    assert kotlin.type_name(event) == 'EventMetricType<metricKeys>'
 
     event = metrics.Event(
         type='event',
@@ -94,7 +95,7 @@ def test_metric_type_name():
         expires='never',
     )
 
-    assert kotlin.metric_type_name(event) == 'EventMetricType<NoExtraKeys>'
+    assert kotlin.type_name(event) == 'EventMetricType<NoExtraKeys>'
 
     boolean = metrics.Boolean(
         type='boolean',
@@ -105,8 +106,14 @@ def test_metric_type_name():
         description='description...',
         expires='never'
     )
+    assert kotlin.type_name(boolean) == 'BooleanMetricType'
 
-    assert kotlin.metric_type_name(boolean) == 'BooleanMetricType'
+    ping = pings.Ping(
+        name="custom",
+        description="description...",
+        include_client_id=True
+    )
+    assert kotlin.type_name(ping) == 'PingType'
 
 
 def test_duplicate(tmpdir):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -16,7 +16,7 @@ def test_metrics_match_schema():
     Make sure the supported set of metric types in the schema matches the set
     in `metrics.py`
     """
-    schema, validator = parser._get_metrics_schema()
+    schema, validator = parser._get_schema(parser.METRICS_ID)
 
     assert (set(metrics.Metric.metric_types.keys()) ==
             set(schema['definitions']['metric']['properties']['type']['enum']))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -23,22 +23,25 @@ def test_parser():
     all_metrics = parser.parse_objects([
         ROOT / "data" / "core.yaml",
         ROOT / "data" / "pings.yaml"
-    ])
-    for err in all_metrics:
-        pass
+    ], config={'allow_reserved': True})
+
+    errs = list(all_metrics)
+    assert len(errs) == 0
+
     for category_key, category_val in all_metrics.value.items():
         if category_key == 'pings':
-            for ping in category_val:
-                if ping.name == 'customPing':
-                    assert ping.include_client_id is False
-                elif ping.name == 'reallyCustomPing':
-                    assert ping.include_client_id is True
-        else:
-            for metric_key, metric_val in category_val.items():
-                assert isinstance(metric_val, metrics.Metric)
-                assert isinstance(metric_val.lifetime, metrics.Lifetime)
-                if getattr(metric_val, 'labels', None) is not None:
-                    assert isinstance(metric_val.labels, set)
+            continue
+        for metric_key, metric_val in category_val.items():
+            assert isinstance(metric_val, metrics.Metric)
+            assert isinstance(metric_val.lifetime, metrics.Lifetime)
+            if getattr(metric_val, 'labels', None) is not None:
+                assert isinstance(metric_val.labels, set)
+
+    pings = all_metrics.value['pings']
+    assert pings['custom_ping'].name == 'custom_ping'
+    assert pings['custom_ping'].include_client_id is False
+    assert pings['really_custom_ping'].name == 'really_custom_ping'
+    assert pings['really_custom_ping'].include_client_id is True
 
 
 def test_parser_invalid():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -20,21 +20,30 @@ ROOT = Path(__file__).parent
 
 def test_parser():
     """Test the basics of parsing a single file."""
-    all_metrics = parser.parse_metrics(ROOT / "data" / "core.yaml")
+    all_metrics = parser.parse_objects([
+        ROOT / "data" / "core.yaml",
+        ROOT / "data" / "pings.yaml"
+    ])
     for err in all_metrics:
         pass
     for category_key, category_val in all_metrics.value.items():
-        for metric_key, metric_val in category_val.items():
-            assert isinstance(metric_val, metrics.Metric)
-            assert isinstance(metric_val.lifetime,
-                              metrics.Lifetime)
-            if getattr(metric_val, 'labels', None) is not None:
-                assert isinstance(metric_val.labels, set)
+        if category_key == 'pings':
+            for ping in category_val:
+                if ping.name == 'customPing':
+                    assert ping.include_client_id is False
+                elif ping.name == 'reallyCustomPing':
+                    assert ping.include_client_id is True
+        else:
+            for metric_key, metric_val in category_val.items():
+                assert isinstance(metric_val, metrics.Metric)
+                assert isinstance(metric_val.lifetime, metrics.Lifetime)
+                if getattr(metric_val, 'labels', None) is not None:
+                    assert isinstance(metric_val.labels, set)
 
 
 def test_parser_invalid():
     """Test the basics of parsing a single file."""
-    all_metrics = parser.parse_metrics(ROOT / "data" / "invalid.yaml")
+    all_metrics = parser.parse_objects(ROOT / "data" / "invalid.yaml")
     errors = list(all_metrics)
     assert len(errors) == 1
     assert 'could not determine a constructor for the tag' in errors[0]
@@ -42,7 +51,7 @@ def test_parser_invalid():
 
 def test_parser_schema_violation():
     """1507792"""
-    all_metrics = parser.parse_metrics(ROOT / "data" / "schema-violation.yaml")
+    all_metrics = parser.parse_objects(ROOT / "data" / "schema-violation.yaml")
     errors = list(all_metrics)
 
     found_errors = set(
@@ -111,18 +120,19 @@ def test_parser_schema_violation():
 
 def test_parser_empty():
     """1507792: Get a good error message if the metrics.yaml file is empty."""
-    all_metrics = parser.parse_metrics(ROOT / "data" / "empty.yaml")
+    all_metrics = parser.parse_objects(ROOT / "data" / "empty.yaml")
     errors = list(all_metrics)
     assert len(errors) == 1
-    assert 'metrics file can not be empty' in errors[0]
+    assert 'file can not be empty' in errors[0]
 
 
 def test_invalid_schema():
-    all_metrics = parser.parse_metrics([{
+    all_metrics = parser.parse_objects([{
         "$schema": "This is wrong"
     }])
     errors = list(all_metrics)
-    assert any('key must be set to' in str(e) for e in errors)
+    print(errors)
+    assert any('key must be one of' in str(e) for e in errors)
 
 
 def test_merge_metrics():
@@ -148,7 +158,7 @@ def test_merge_metrics():
     ]
     contents = [util.add_required(x) for x in contents]
 
-    all_metrics = parser.parse_metrics(contents)
+    all_metrics = parser.parse_objects(contents)
     list(all_metrics)
     all_metrics = all_metrics.value
 
@@ -175,7 +185,7 @@ def test_merge_metrics_clash():
     ]
     contents = [util.add_required(x) for x in contents]
 
-    all_metrics = parser.parse_metrics(contents)
+    all_metrics = parser.parse_objects(contents)
     errors = list(all_metrics)
     assert len(errors) == 1
     assert 'Duplicate metric name' in errors[0]
@@ -198,8 +208,7 @@ def test_snake_case_enforcement():
 
     for content in contents:
         util.add_required(content)
-        metrics = parser._load_metrics_file(content)
-        errors = list(metrics)
+        errors = list(parser._load_file(content))
         assert len(errors) == 1
 
 
@@ -216,7 +225,7 @@ def test_multiple_errors():
     ]
 
     contents = [util.add_required(x) for x in contents]
-    metrics = parser.parse_metrics(contents)
+    metrics = parser.parse_objects(contents)
     errors = list(metrics)
     assert len(errors) == 2
 
@@ -234,7 +243,7 @@ def test_required_denominator():
     ]
 
     contents = [util.add_required(x) for x in contents]
-    all_metrics = parser.parse_metrics(contents)
+    all_metrics = parser.parse_objects(contents)
     errors = list(all_metrics)
     assert len(errors) == 1
     assert 'denominator is required' in errors[0]
@@ -253,7 +262,7 @@ def test_event_must_be_ping_lifetime():
     ]
 
     contents = [util.add_required(x) for x in contents]
-    all_metrics = parser.parse_metrics(contents)
+    all_metrics = parser.parse_objects(contents)
     errors = list(all_metrics)
     assert len(errors) == 1
     assert "Event metrics must have ping lifetime" in errors[0]
@@ -271,12 +280,12 @@ def test_parser_reserved():
     ]
 
     contents = [util.add_required(x) for x in contents]
-    all_metrics = parser.parse_metrics(contents)
+    all_metrics = parser.parse_objects(contents)
     errors = list(all_metrics)
     assert len(errors) == 1
     assert "For category 'glean.baseline'" in errors[0]
 
-    all_metrics = parser.parse_metrics(contents, {'allow_reserved': True})
+    all_metrics = parser.parse_objects(contents, {'allow_reserved': True})
     errors = list(all_metrics)
     assert len(errors) == 0
 
@@ -332,7 +341,7 @@ def invalid_in_label(name):
 def test_invalid_names(location, name):
     contents = location(name)
     contents = [util.add_required(x) for x in contents]
-    all_metrics = parser.parse_metrics(contents)
+    all_metrics = parser.parse_objects(contents)
     errors = list(all_metrics)
     assert len(errors) == 1
     assert name in errors[0]

--- a/tests/test_pings.py
+++ b/tests/test_pings.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+
+# Any copyright is dedicated to the Public Domain.
+# http://creativecommons.org/publicdomain/zero/1.0/
+
+from glean_parser import parser
+
+import util
+
+
+def test_reserved_ping_name():
+    """
+    Make sure external users can't use a reserved ping name.
+    """
+    content = {
+        '$schema': parser.PINGS_ID,
+        'baseline': {
+            'description': 'Description',
+            'include_client_id': True
+        }
+    }
+
+    errors = list(parser._instantiate_pings({}, {}, content, '', {}))
+    assert len(errors) == 1
+    assert 'Ping uses a reserved name' in errors[0]
+
+    errors = list(
+        parser._instantiate_pings(
+            {},
+            {},
+            content,
+            '',
+            {'allow_reserved': True}
+        )
+    )
+    assert len(errors) == 0
+
+
+def test_reserved_metrics_category():
+    """
+    The category "pings" can't be used by metrics -- it's reserved for pings.
+    """
+    content = {
+        'pings': {
+            'metric': {
+                'type': 'string'
+            }
+        }
+    }
+
+    util.add_required(content)
+    errors = list(parser.parse_objects(content))
+    assert len(errors) == 1
+    assert 'reserved as a category name' in errors[0]

--- a/tests/test_pings.py
+++ b/tests/test_pings.py
@@ -52,3 +52,16 @@ def test_reserved_metrics_category():
     errors = list(parser.parse_objects(content))
     assert len(errors) == 1
     assert 'reserved as a category name' in errors[0]
+
+
+def test_snake_case_ping_names():
+    content = {
+        '$schema': parser.PINGS_ID,
+        'camelCasePingName': {
+            'description': 'Description',
+            'include_client_id': True
+        }
+    }
+    errors = list(parser.parse_objects([content]))
+    assert len(errors) == 1
+    assert 'camelCasePingName' in errors[0]

--- a/tests/util.py
+++ b/tests/util.py
@@ -22,6 +22,6 @@ def add_required(chunk):
                 if default_name not in metric:
                     metric[default_name] = default_val
 
-    chunk['$schema'] = parser._get_metrics_schema()[0]['$id']
+    chunk['$schema'] = parser.METRICS_ID
 
     return chunk


### PR DESCRIPTION
This adds support for `pings.yaml` files to `glean_parser`, in support of describing pings so that they can indicate whether they should include the `client_info` block.