### PR TITLE
Don't emit duplicate imports

### DIFF
--- a/glean_parser/kotlin.py
+++ b/glean_parser/kotlin.py
@@ -126,7 +126,7 @@ def output_kotlin(metrics, output_dir, options={}):
         filepath = output_dir / filename
 
         metric_types = sorted(list(set(
-            metric.type for metric in category_val.values()
+            metric_type_class(metric.type) for metric in category_val.values()
         )))
         has_labeled_metrics = any(
             getattr(metric, 'labeled', False)

--- a/glean_parser/templates/kotlin.jinja2
+++ b/glean_parser/templates/kotlin.jinja2
@@ -24,7 +24,7 @@ import mozilla.components.service.glean.private.Lifetime
 import mozilla.components.service.glean.private.TimeUnit // ktlint-disable no-unused-imports
 import mozilla.components.service.glean.private.NoExtraKeys // ktlint-disable no-unused-imports
 {% for metric_type in metric_types %}
-import mozilla.components.service.glean.private.{{ metric_type|metric_type_class|Camelize }}MetricType
+import mozilla.components.service.glean.private.{{ metric_type|Camelize }}MetricType
 {% endfor %}
 {% if has_labeled_metrics %}
 import mozilla.components.service.glean.private.LabeledMetricType

--- a/tests/data/duplicate_labeled.yaml
+++ b/tests/data/duplicate_labeled.yaml
@@ -1,0 +1,32 @@
+$schema: moz://mozilla.org/schemas/glean/metrics/1-0-0
+
+category:
+  counter:
+    type: counter
+    lifetime: user
+    description: >
+      Foo
+    bugs:
+      - 1137353
+    data_reviews:
+      - http://nowhere.com/reviews
+    notification_emails:
+      - CHANGE-ME@test-only.com
+    send_in_pings:
+      - core
+    expires: 2100-01-01
+
+  labeled_counter:
+    type: labeled_counter
+    lifetime: user
+    description: >
+      Foo
+    bugs:
+      - 1137353
+    data_reviews:
+      - http://nowhere.com/reviews
+    notification_emails:
+      - CHANGE-ME@test-only.com
+    send_in_pings:
+      - core
+    expires: 2100-01-01

--- a/tests/test_kotlin.py
+++ b/tests/test_kotlin.py
@@ -107,3 +107,34 @@ def test_metric_type_name():
     )
 
     assert kotlin.metric_type_name(boolean) == 'BooleanMetricType'
+
+
+def test_duplicate(tmpdir):
+    """
+    Test that there aren't duplicate imports when using a labeled and
+    non-labeled version of the same metric.
+
+    https://github.com/mozilla-mobile/android-components/issues/2793
+    """
+
+    tmpdir = Path(tmpdir)
+
+    translate.translate(
+        ROOT / "data" / "duplicate_labeled.yaml",
+        'kotlin',
+        tmpdir,
+        {'namespace': 'Foo'},
+    )
+
+    assert (
+        set(x.name for x in tmpdir.iterdir()) ==
+        set([
+            'Category.kt',
+        ])
+    )
+
+    with open(tmpdir / 'Category.kt', 'r', encoding='utf-8') as fd:
+        content = fd.read()
+        assert content.count(
+            "import mozilla.components.service.glean.private.CounterMetricType"
+        ) == 1


### PR DESCRIPTION
The glean_parser side of fixing https://github.com/mozilla-mobile/android-components/issues/2793