### PR TITLE
1504677: Handle default stores at build-time in glean_parser

### DIFF
--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -27,6 +27,7 @@ class Lifetime(enum.Enum):
 class Metric:
     glean_internal_metric_cat = 'glean.internal.metrics'
     metric_types = {}
+    default_store_names = ['metrics']
 
     def __init_subclass__(cls, **kwargs):
         # Create a mapping of all of the subclasses of this class
@@ -255,6 +256,7 @@ class Rate(Metric):
 @dataclass
 class Event(Metric):
     typename = 'event'
+    default_store_names = ['events']
 
     extra_keys: Dict[str, str] = field(default_factory=dict)
 

--- a/glean_parser/translate.py
+++ b/glean_parser/translate.py
@@ -31,6 +31,12 @@ def _preprocess_objects(objs):
             if hasattr(obj, 'is_disabled'):
                 obj.disabled = obj.is_disabled()
 
+            if hasattr(obj, 'send_in_pings'):
+                if 'default' in obj.send_in_pings:
+                    obj.send_in_pings = obj.default_store_names + [
+                        x for x in obj.send_in_pings if x != 'default'
+                    ]
+
 
 def translate(
         input_filepaths,

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -88,3 +88,33 @@ def test_translate_expires():
     assert objs['metrics']['b'].disabled is True
     assert objs['metrics']['c'].disabled is True
     assert objs['metrics']['d'].disabled is False
+
+
+def test_translate_send_in_pings(tmpdir):
+    contents = [
+        {
+            'baseline': {
+                'counter': {
+                    'type': 'counter'
+                },
+                'event': {
+                    'type': 'event'
+                },
+                'c': {
+                    'type': 'counter',
+                    'send_in_pings': ['default', 'custom']
+                }
+            }
+        }
+    ]
+    contents = [util.add_required(x) for x in contents]
+
+    objs = parser.parse_objects(contents)
+    assert len(list(objs)) == 0
+    objs = objs.value
+
+    translate._preprocess_objects(objs)
+
+    assert objs['baseline']['counter'].send_in_pings == ['metrics']
+    assert objs['baseline']['event'].send_in_pings == ['events']
+    assert objs['baseline']['c'].send_in_pings == ['metrics', 'custom']


### PR DESCRIPTION
Currently, the translation of the special store name "default" to "metrics" or "events" is handled at runtime.  Since this is a build-time constant, we can actually deal with this in glean_parser and remove some work from the client.