### PR TITLE
BUG: Make sure "expires" transfers to "disabled"

### DIFF
--- a/glean_parser/translate.py
+++ b/glean_parser/translate.py
@@ -27,7 +27,7 @@ def _preprocess_objects(objs):
     Preprocess the object tree before passing to the language generator.
     """
     for category in objs.values():
-        for obj in category:
+        for obj in category.values():
             if hasattr(obj, 'is_disabled'):
                 obj.disabled = obj.is_disabled()
 


### PR DESCRIPTION
This fixes a bug introduced a couple weeks ago with pings.yaml support was added.  The way in which the expiration parameter is turned into a disabled value was broken.  (Discovered while working on #62, but this is just the minimal bugfix).