### PR TITLE
Use example.com as a dummy domain

### DIFF
--- a/tests/data/core.yaml
+++ b/tests/data/core.yaml
@@ -11,9 +11,9 @@ telemetry:
     bugs:
       - 1137353
     data_reviews:
-      - http://nowhere.com/reviews
+      - http://example.com/reviews
     notification_emails:
-      - CHANGE-ME@test-only.com
+      - CHANGE-ME@example.com
     send_in_pings:
       - core
     expires: 2100-01-01
@@ -28,9 +28,9 @@ core_ping:
     bugs:
       - 1137353
     data_reviews:
-      - http://nowhere.com/reviews
+      - http://example.com/reviews
     notification_emails:
-      - CHANGE-ME@test-only.com
+      - CHANGE-ME@example.com
     send_in_pings:
       - core
     expires: 2100-01-01
@@ -43,9 +43,9 @@ core_ping:
     bugs:
       - 1137353
     data_reviews:
-      - http://nowhere.com/reviews
+      - http://example.com/reviews
     notification_emails:
-      - CHANGE-ME@test-only.com
+      - CHANGE-ME@example.com
     send_in_pings:
       - core
     expires: 2100-01-01
@@ -57,9 +57,9 @@ core_ping:
     bugs:
       - 1137353
     data_reviews:
-      - http://nowhere.com/reviews
+      - http://example.com/reviews
     notification_emails:
-      - CHANGE-ME@test-only.com
+      - CHANGE-ME@example.com
     send_in_pings:
       - core
     expires: 2100-01-01
@@ -73,9 +73,9 @@ core_ping:
     bugs:
       - 1137353
     data_reviews:
-      - http://nowhere.com/reviews
+      - http://example.com/reviews
     notification_emails:
-      - CHANGE-ME@test-only.com
+      - CHANGE-ME@example.com
     send_in_pings:
       - core
     expires: 2100-01-01
@@ -88,9 +88,9 @@ core_ping:
     bugs:
       - 1137353
     data_reviews:
-      - http://nowhere.com/reviews
+      - http://example.com/reviews
     notification_emails:
-      - CHANGE-ME@test-only.com
+      - CHANGE-ME@example.com
     send_in_pings:
       - core
     expires: 2100-01-01
@@ -103,9 +103,9 @@ core_ping:
     bugs:
       - 1137353
     data_reviews:
-      - http://nowhere.com/reviews
+      - http://example.com/reviews
     notification_emails:
-      - CHANGE-ME@test-only.com
+      - CHANGE-ME@example.com
     send_in_pings:
       - core
     expires: 2100-01-01
@@ -117,9 +117,9 @@ core_ping:
     bugs:
       - 1137353
     data_reviews:
-      - http://nowhere.com/reviews
+      - http://example.com/reviews
     notification_emails:
-      - CHANGE-ME@test-only.com
+      - CHANGE-ME@example.com
     send_in_pings:
       - core
     expires: 2100-01-01
@@ -132,9 +132,9 @@ environment:
     bugs:
       - 1137353
     data_reviews:
-      - http://nowhere.com/reviews
+      - http://example.com/reviews
     notification_emails:
-      - CHANGE-ME@test-only.com
+      - CHANGE-ME@example.com
     send_in_pings:
       - core
     expires: 2100-01-01
@@ -150,9 +150,9 @@ environment:
     bugs:
       - 1137353
     data_reviews:
-      - http://nowhere.com/reviews
+      - http://example.com/reviews
     notification_emails:
-      - CHANGE-ME@test-only.com
+      - CHANGE-ME@example.com
     send_in_pings:
       - core
     expires: 2100-01-01
@@ -164,9 +164,9 @@ environment:
     bugs:
       - 1137353
     data_reviews:
-      - http://nowhere.com/reviews
+      - http://example.com/reviews
     notification_emails:
-      - CHANGE-ME@test-only.com
+      - CHANGE-ME@example.com
     send_in_pings:
       - core
     expires: 2100-01-01
@@ -181,9 +181,9 @@ environment:
     bugs:
       - 1137353
     data_reviews:
-      - http://nowhere.com/reviews
+      - http://example.com/reviews
     notification_emails:
-      - CHANGE-ME@test-only.com
+      - CHANGE-ME@example.com
     send_in_pings:
       - core
     expires: 2100-01-01
@@ -198,9 +198,9 @@ environment:
     bugs:
       - 1137353
     data_reviews:
-      - http://nowhere.com/reviews
+      - http://example.com/reviews
     notification_emails:
-      - CHANGE-ME@test-only.com
+      - CHANGE-ME@example.com
     expires: 2100-01-01
 
   profile_date:
@@ -211,9 +211,9 @@ environment:
     bugs:
       - 1137353
     data_reviews:
-      - http://nowhere.com/reviews
+      - http://example.com/reviews
     notification_emails:
-      - CHANGE-ME@test-only.com
+      - CHANGE-ME@example.com
     send_in_pings:
       - core
     expires: 2100-01-01
@@ -226,9 +226,9 @@ environment:
     bugs:
       - 1137353
     data_reviews:
-      - http://nowhere.com/reviews
+      - http://example.com/reviews
     notification_emails:
-      - CHANGE-ME@test-only.com
+      - CHANGE-ME@example.com
     send_in_pings:
       - core
     expires: 2100-01-01
@@ -241,9 +241,9 @@ environment:
     bugs:
       - 1137353
     data_reviews:
-      - http://nowhere.com/reviews
+      - http://example.com/reviews
     notification_emails:
-      - CHANGE-ME@test-only.com
+      - CHANGE-ME@example.com
     send_in_pings:
       - core
     expires: 2100-01-01
@@ -256,9 +256,9 @@ environment:
     bugs:
       - 1137353
     data_reviews:
-      - http://nowhere.com/reviews
+      - http://example.com/reviews
     notification_emails:
-      - CHANGE-ME@test-only.com
+      - CHANGE-ME@example.com
     send_in_pings:
       - core
     expires: 2100-01-01
@@ -271,9 +271,9 @@ environment:
     bugs:
       - 1137353
     data_reviews:
-      - http://nowhere.com/reviews
+      - http://example.com/reviews
     notification_emails:
-      - CHANGE-ME@test-only.com
+      - CHANGE-ME@example.com
     send_in_pings:
       - core
     expires: 2100-01-01
@@ -285,9 +285,9 @@ environment:
     bugs:
       - 123456789
     data_reviews:
-      - http://nowhere.com/reviews
+      - http://example.com/reviews
     notification_emails:
-      - CHANGE-ME@test-only.com
+      - CHANGE-ME@example.com
     extra_keys:
       key1:
         description: "This is key one"
@@ -302,9 +302,9 @@ environment:
     bugs:
       - 123456789
     data_reviews:
-      - http://nowhere.com/reviews
+      - http://example.com/reviews
     notification_emails:
-      - CHANGE-ME@test-only.com
+      - CHANGE-ME@example.com
     expires: 2100-01-01
 
 dotted.category:
@@ -316,9 +316,9 @@ dotted.category:
     bugs:
       - 1137353
     data_reviews:
-      - http://nowhere.com/reviews
+      - http://example.com/reviews
     notification_emails:
-      - CHANGE-ME@test-only.com
+      - CHANGE-ME@example.com
     expires: 2100-01-01
 
 glean.internal.metrics:
@@ -330,7 +330,7 @@ glean.internal.metrics:
     bugs:
       - 1137353
     data_reviews:
-      - http://nowhere.com/reviews
+      - http://example.com/reviews
     notification_emails:
-      - CHANGE-ME@test-only.com
+      - CHANGE-ME@example.com
     expires: 2100-01-01

--- a/tests/data/duplicate_labeled.yaml
+++ b/tests/data/duplicate_labeled.yaml
@@ -9,9 +9,9 @@ category:
     bugs:
       - 1137353
     data_reviews:
-      - http://nowhere.com/reviews
+      - http://example.com/reviews
     notification_emails:
-      - CHANGE-ME@test-only.com
+      - CHANGE-ME@example.com
     send_in_pings:
       - core
     expires: 2100-01-01
@@ -24,9 +24,9 @@ category:
     bugs:
       - 1137353
     data_reviews:
-      - http://nowhere.com/reviews
+      - http://example.com/reviews
     notification_emails:
-      - CHANGE-ME@test-only.com
+      - CHANGE-ME@example.com
     send_in_pings:
       - core
     expires: 2100-01-01

--- a/tests/data/schema-violation.yaml
+++ b/tests/data/schema-violation.yaml
@@ -11,6 +11,6 @@ gleantest.lifetime:
         lifetime: user2
         type: boolean
         bugs: [123456789]
-        notification_emails: ['nobody@nowhere.com']
+        notification_emails: ['nobody@example.com']
         expires: never
-        data_reviews: ['http://zomobocom.com']
+        data_reviews: ['http://example.com']

--- a/tests/data/smaller.yaml
+++ b/tests/data/smaller.yaml
@@ -11,9 +11,9 @@ telemetry:
     bugs:
       - 1137353
     data_reviews:
-      - http://nowhere.com/reviews
+      - http://example.com/reviews
     notification_emails:
-      - CHANGE-ME@test-only.com
+      - CHANGE-ME@example.com
     send_in_pings:
       - core
     expires: 2100-01-01

--- a/tests/test_kotlin.py
+++ b/tests/test_kotlin.py
@@ -77,7 +77,7 @@ def test_metric_type_name():
         category='category',
         name='metric',
         bugs=[42],
-        notification_emails=['nobody@nowhere.com'],
+        notification_emails=['nobody@example.com'],
         description='description...',
         expires='never',
         extra_keys={'my_extra': {'description': 'an extra'}},
@@ -90,7 +90,7 @@ def test_metric_type_name():
         category='category',
         name='metric',
         bugs=[42],
-        notification_emails=['nobody@nowhere.com'],
+        notification_emails=['nobody@example.com'],
         description='description...',
         expires='never',
     )
@@ -102,7 +102,7 @@ def test_metric_type_name():
         category='category',
         name='metric',
         bugs=[42],
-        notification_emails=['nobody@nowhere.com'],
+        notification_emails=['nobody@example.com'],
         description='description...',
         expires='never'
     )

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -38,7 +38,7 @@ def test_enforcement():
             name='metric',
             bugs=[42],
             description=42,
-            notification_emails=['nobody@nowhere.com'],
+            notification_emails=['nobody@example.com'],
             expires='never'
         )
 
@@ -58,7 +58,7 @@ def test_expires():
             name='metric',
             bugs=[42],
             expires=date,
-            notification_emails=['nobody@nowhere.com'],
+            notification_emails=['nobody@example.com'],
             description='description...',
         )
         assert m.is_expired() == expired
@@ -70,7 +70,7 @@ def test_expires():
             name='metric',
             bugs=[42],
             expires='foo',
-            notification_emails=['nobody@nowhere.com'],
+            notification_emails=['nobody@example.com'],
             description='description...',
         )
 
@@ -85,7 +85,7 @@ def test_timespan_time_unit():
         name='metric',
         bugs=[42],
         time_unit='day',
-        notification_emails=['nobody@nowhere.com'],
+        notification_emails=['nobody@example.com'],
         description='description...',
         expires='never',
     )
@@ -99,7 +99,7 @@ def test_timespan_time_unit():
             name='metric',
             bugs=[42],
             time_unit='foo',
-            notification_emails=['nobody@nowhere.com'],
+            notification_emails=['nobody@example.com'],
             description='description...',
             expires='never',
         )
@@ -115,7 +115,7 @@ def test_identifier():
         name='metric',
         bugs=[42],
         time_unit='day',
-        notification_emails=['nobody@nowhere.com'],
+        notification_emails=['nobody@example.com'],
         description='description...',
         expires='never',
     )
@@ -133,7 +133,7 @@ def test_identifier_glean_category():
         name='metric',
         bugs=[42],
         time_unit='day',
-        notification_emails=['nobody@nowhere.com'],
+        notification_emails=['nobody@example.com'],
         description='description...',
         expires='never',
     )
@@ -152,7 +152,7 @@ def test_reserved_extra_keys():
             category='category',
             name='metric',
             bugs=[42],
-            notification_emails=['nobody@nowhere.com'],
+            notification_emails=['nobody@example.com'],
             description='description...',
             expires='never',
             extra_keys={'glean.internal': {'description': 'foo'}}
@@ -163,7 +163,7 @@ def test_reserved_extra_keys():
         category='category',
         name='metric',
         bugs=[42],
-        notification_emails=['nobody@nowhere.com'],
+        notification_emails=['nobody@example.com'],
         description='description...',
         expires='never',
         extra_keys={'glean.internal': {'description': 'foo'}},

--- a/tests/util.py
+++ b/tests/util.py
@@ -11,8 +11,8 @@ def add_required(chunk):
         'type': 'string',
         'bugs': [0],
         'description': 'DESCRIPTION...',
-        'notification_emails': ['nobody@nowhere.com'],
-        'data_reviews': ['https://nowhere.com/review/'],
+        'notification_emails': ['nobody@example.com'],
+        'data_reviews': ['https://example.com/review/'],
         'expires': 'never',
     }
 


### PR DESCRIPTION
Should be an easy review.  Just updates our "dummy" domains to "example.com" as @badboy suggested [here](https://github.com/mozilla-mobile/android-components/pull/2890#discussion_r280059610).