### PR TITLE
Make glean namespace configurable

### DIFF
--- a/glean_parser/kotlin.py
+++ b/glean_parser/kotlin.py
@@ -102,6 +102,9 @@ def output_kotlin(objs, output_dir, options={}):
 
         - `namespace`: The package namespace to declare at the top of the
           generated files. Defaults to `GleanMetrics`.
+        - `glean_namespace`: The package namespace of the glean library itself.
+          This is where glean objects will be imported from in the generated
+          code.
     """
     template = util.get_jinja2_template(
         'kotlin.jinja2',
@@ -127,6 +130,10 @@ def output_kotlin(objs, output_dir, options={}):
     ]
 
     namespace = options.get('namespace', 'GleanMetrics')
+    glean_namespace = options.get(
+        'glean_namespace',
+        'mozilla.components.service.glean'
+    )
 
     for category_key, category_val in objs.items():
         filename = util.Camelize(category_key) + '.kt'
@@ -149,6 +156,7 @@ def output_kotlin(objs, output_dir, options={}):
                     extra_args=extra_args,
                     namespace=namespace,
                     has_labeled_metrics=has_labeled_metrics,
+                    glean_namespace=glean_namespace,
                 )
             )
             # Jinja2 squashes the final newline, so we explicitly add it

--- a/glean_parser/templates/kotlin.jinja2
+++ b/glean_parser/templates/kotlin.jinja2
@@ -20,14 +20,14 @@
 @file:Suppress("PackageNaming")
 package {{ namespace }}
 
-import mozilla.components.service.glean.private.Lifetime // ktlint-disable no-unused-imports
-import mozilla.components.service.glean.private.TimeUnit // ktlint-disable no-unused-imports
-import mozilla.components.service.glean.private.NoExtraKeys // ktlint-disable no-unused-imports
+import {{ glean_namespace }}.private.Lifetime // ktlint-disable no-unused-imports
+import {{ glean_namespace }}.private.TimeUnit // ktlint-disable no-unused-imports
+import {{ glean_namespace }}.private.NoExtraKeys // ktlint-disable no-unused-imports
 {% for obj_type in obj_types %}
-import mozilla.components.service.glean.private.{{ obj_type }}
+import {{ glean_namespace }}.private.{{ obj_type }}
 {% endfor %}
 {% if has_labeled_metrics %}
-import mozilla.components.service.glean.private.LabeledMetricType
+import {{ glean_namespace }}.private.LabeledMetricType
 {% endif %}
 
 internal object {{ category_name|Camelize }} {

--- a/tests/test_kotlin.py
+++ b/tests/test_kotlin.py
@@ -145,3 +145,30 @@ def test_duplicate(tmpdir):
         assert content.count(
             "import mozilla.components.service.glean.private.CounterMetricType"
         ) == 1
+
+
+def test_glean_namespace(tmpdir):
+    """
+    Test that setting the glean namespace works.
+    """
+    tmpdir = Path(tmpdir)
+
+    translate.translate(
+        ROOT / "data" / "duplicate_labeled.yaml",
+        'kotlin',
+        tmpdir,
+        {'namespace': 'Foo', 'glean_namespace': 'Bar'},
+    )
+
+    assert (
+        set(x.name for x in tmpdir.iterdir()) ==
+        set([
+            'Category.kt',
+        ])
+    )
+
+    with open(tmpdir / 'Category.kt', 'r', encoding='utf-8') as fd:
+        content = fd.read()
+        assert content.count(
+            "import Bar.private.CounterMetricType"
+        ) == 1


### PR DESCRIPTION
This is needed since `glean.rs` exists in a different Kotlin namespace.