### PR TITLE
Make new pings metadata fields optional

### DIFF
--- a/glean_parser/schemas/pings.1-0-0.schema.yaml
+++ b/glean_parser/schemas/pings.1-0-0.schema.yaml
@@ -94,8 +94,10 @@ additionalProperties:
   required:
     - description
     - include_client_id
-    - bugs
-    - notification_emails
-    - data_reviews
+    # Reinstate these as required once all downstream users have updated their
+    # pings.yaml
+    # - bugs
+    # - notification_emails
+    # - data_reviews
 
   additionalProperties: false


### PR DESCRIPTION
It suddenly occurred to me that we have a much easier path to getting [1547967](https://bugzilla.mozilla.org/show_bug.cgi?id=1547967)

1. Define the new metadata fields, but make them optional
2. Update a-c to use this version of `glean_parser` and adding the new fields.  <-- This should not break Fenix, since the new fields are optional (https://github.com/mozilla-mobile/android-components/pull/2890)
4. Submit a PR against Fenix to add the new fields (https://github.com/mozilla-mobile/fenix/pull/2472).  This should work once the a-c snapshot is made and pulled into Fenix
5. Make these new fields required, as we want (to make sure data review is being performed and all that jazz...)
6. Update a-c to pull in the glean_parser making these fields required.  This shouldn't break Fenix because the new fields are already there.

At no point do we have to carefully coordinate merging of pull requests.