### PR TITLE
Handle send_in_pings preprocessing in `parse_objects`

### DIFF
--- a/glean_parser/parser.py
+++ b/glean_parser/parser.py
@@ -228,6 +228,23 @@ def _instantiate_pings(all_objects, sources, content, filepath, config):
             sources[ping_key] = filepath
 
 
+def _preprocess_objects(objs):
+    """
+    Preprocess the object tree to better set defaults.
+    """
+    for category in objs.values():
+        for obj in category.values():
+            if hasattr(obj, 'is_disabled'):
+                obj.disabled = obj.is_disabled()
+
+            if hasattr(obj, 'send_in_pings'):
+                if 'default' in obj.send_in_pings:
+                    obj.send_in_pings = obj.default_store_names + [
+                        x for x in obj.send_in_pings if x != 'default'
+                    ]
+    return objs
+
+
 @util.keep_value
 def parse_objects(filepaths, config={}):
     """
@@ -274,4 +291,5 @@ def parse_objects(filepaths, config={}):
                 filepath,
                 config
             )
-    return all_objects
+
+    return _preprocess_objects(all_objects)

--- a/glean_parser/translate.py
+++ b/glean_parser/translate.py
@@ -22,22 +22,6 @@ OUTPUTTERS = {
 }
 
 
-def _preprocess_objects(objs):
-    """
-    Preprocess the object tree before passing to the language generator.
-    """
-    for category in objs.values():
-        for obj in category.values():
-            if hasattr(obj, 'is_disabled'):
-                obj.disabled = obj.is_disabled()
-
-            if hasattr(obj, 'send_in_pings'):
-                if 'default' in obj.send_in_pings:
-                    obj.send_in_pings = obj.default_store_names + [
-                        x for x in obj.send_in_pings if x != 'default'
-                    ]
-
-
 def translate(
         input_filepaths,
         output_format,
@@ -68,8 +52,6 @@ def translate(
         print(error, file=sys.stderr)
     if found_error:
         return 1
-
-    _preprocess_objects(all_objects.value)
 
     # Write everything out to a temporary directory, and then move it to the
     # real directory, for transactional integrity.

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -82,8 +82,6 @@ def test_translate_expires():
     assert len(list(objs)) == 0
     objs = objs.value
 
-    translate._preprocess_objects(objs)
-
     assert objs['metrics']['a'].disabled is False
     assert objs['metrics']['b'].disabled is True
     assert objs['metrics']['c'].disabled is True
@@ -112,8 +110,6 @@ def test_translate_send_in_pings(tmpdir):
     objs = parser.parse_objects(contents)
     assert len(list(objs)) == 0
     objs = objs.value
-
-    translate._preprocess_objects(objs)
 
     assert objs['baseline']['counter'].send_in_pings == ['metrics']
     assert objs['baseline']['event'].send_in_pings == ['events']


### PR DESCRIPTION
The `send_in_pings` parameter defaults to `[metrics]` or `[events]` depending on the type of metric.  (As well, the `default` value maps to one of those).

This was only happening when generating bindings for Kotlin, but it should be happening earlier so other tools (`probe_scraper`) will also benefit from this behavior.  As it stands, the `schema-generator` currently has a bug that will cause some metrics to not show up if they don't explicitly specify the ping they are sent on.  This should resolve that (once merged and the dependency is bumped in `probe_scraper`).