### PR TITLE
Allow dotted snake-case for labeled metric IDs

### DIFF
--- a/glean_parser/schemas/metrics.1-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.1-0-0.schema.yaml
@@ -38,6 +38,11 @@ definitions:
       - $ref: "#/definitions/snake_case"
       - maxLength: 20
 
+  labeled_metric_id:
+    type: string
+    pattern: "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$"
+    maxLength: 30
+
   metric:
     description: |
       Describes a single metric.
@@ -293,7 +298,7 @@ definitions:
         anyOf:
           - type: array
             items:
-              $ref: "#/definitions/long_id"
+              $ref: "#/definitions/labeled_metric_id"
             maxItems: 16
           - type: "null"
 


### PR DESCRIPTION
This expands the regex for labeled metrics to allow for dotted snake-case.