### PR TITLE
1553186: Make pings metadata fields required.

### DIFF
--- a/glean_parser/schemas/pings.1-0-0.schema.yaml
+++ b/glean_parser/schemas/pings.1-0-0.schema.yaml
@@ -94,10 +94,8 @@ additionalProperties:
   required:
     - description
     - include_client_id
-    # Reinstate these as required once all downstream users have updated their
-    # pings.yaml
-    # - bugs
-    # - notification_emails
-    # - data_reviews
+    - bugs
+    - notification_emails
+    - data_reviews
 
   additionalProperties: false


### PR DESCRIPTION
Now that we have these fields everywhere that has a pings.yaml, let's make them officially required.  Any future custom pings will be forced to set these which is good for data stewardship.