### PR TITLE
1556684: Update label length

### DIFF
--- a/glean_parser/schemas/metrics.1-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.1-0-0.schema.yaml
@@ -41,7 +41,7 @@ definitions:
   labeled_metric_id:
     type: string
     pattern: "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$"
-    maxLength: 30
+    maxLength: 61
 
   metric:
     description: |


### PR DESCRIPTION
Related to https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/338

This updates the length limit of static labels defines in metrics.yaml to 61 characters, to be consistent with the requirement for Glean's own error reporting.