### PR TITLE
Allow for '-' in metrics labels

### DIFF
--- a/glean_parser/schemas/metrics.1-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.1-0-0.schema.yaml
@@ -40,7 +40,7 @@ definitions:
 
   labeled_metric_id:
     type: string
-    pattern: "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$"
+    pattern: "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$"
     maxLength: 61
 
   metric:

--- a/tests/data/core.yaml
+++ b/tests/data/core.yaml
@@ -85,6 +85,15 @@ core_ping:
     description: >
       The search use counts for each search source and engine
       combination, e.g. “engine.source” = 3.
+    labels:
+      - this.is.fine
+      - this_is_fine_too
+      - this.is_still_fine
+      - thisisfine
+      - this.is_fine.2
+      - _.is_fine
+      - this.is-fine
+      - this-is-fine
     bugs:
       - 1137353
     data_reviews:


### PR DESCRIPTION
This is related to mozilla-services/mozilla-pipeline-schemas#356 . It's the second part to the fix for [this bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1566764).