### PR TITLE
Use setuptools-scm instead of bumpversion

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,5 +1,8 @@
 .. highlight:: shell
 
+.. _bugzilla: https://bugzilla.mozilla.org/enter_bug.cgi?assigned_to=nobody%40mozilla.org&bug_ignored=0&bug_severity=normal&bug_status=NEW&cf_fission_milestone=---&cf_fx_iteration=---&cf_fx_points=---&cf_status_firefox65=---&cf_status_firefox66=---&cf_status_firefox67=---&cf_status_firefox_esr60=---&cf_status_thunderbird_esr60=---&cf_tracking_firefox65=---&cf_tracking_firefox66=---&cf_tracking_firefox67=---&cf_tracking_firefox_esr60=---&cf_tracking_firefox_relnote=---&cf_tracking_thunderbird_esr60=---&product=Data%20Platform%20and%20Tools&component=Glean%3A%20SDK&contenttypemethod=list&contenttypeselection=text%2Fplain&defined_groups=1&flag_type-203=X&flag_type-37=X&flag_type-41=X&flag_type-607=X&flag_type-721=X&flag_type-737=X&flag_type-787=X&flag_type-799=X&flag_type-800=X&flag_type-803=X&flag_type-835=X&flag_type-846=X&flag_type-855=X&flag_type-864=X&flag_type-916=X&flag_type-929=X&flag_type-930=X&flag_type-935=X&flag_type-936=X&flag_type-937=X&form_name=enter_bug&maketemplate=Remember%20values%20as%20bookmarkable%20template&op_sys=Unspecified&priority=P3&&rep_platform=Unspecified&status_whiteboard=%5Btelemetry%3Aglean-rs%3Am%3F%5D&target_milestone=---&version=unspecified
+
+
 ============
 Contributing
 ============
@@ -15,7 +18,7 @@ Types of Contributions
 Report Bugs
 ~~~~~~~~~~~
 
-Report bugs at TODO
+Report bugs at bugzilla_.
 
 If you are reporting a bug, please include:
 
@@ -125,7 +128,9 @@ Then run (assuming the main fork is in a git remote called `upstream`)::
 $ git checkout master
 $ git fetch upstream
 $ git rebase upstream/master
-$ bumpversion patch # possible: major / minor / patch
+$ git tag vX.X.X
 $ git push upstream master --tags
+
+Alternatively, the above tasks can be performed through the `Github new release UI <https://github.com/mozilla/glean_parser/releases/new>`__.
 
 Travis will then deploy to PyPI if tests pass.

--- a/glean_parser/__init__.py
+++ b/glean_parser/__init__.py
@@ -6,6 +6,12 @@
 
 """Top-level package for Glean parser."""
 
+from pkg_resources import get_distribution, DistributionNotFound
+try:
+    __version__ = get_distribution(__name__).version
+except DistributionNotFound:
+    # package is not installed
+    pass
+
 __author__ = """Michael Droettboom"""
 __email__ = 'mdroettboom@mozilla.com'
-__version__ = '0.30.0'

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,4 @@
 pip
-bumpversion==0.5.3
 wheel
 watchdog==0.9.0
 flake8==3.5.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,16 +1,3 @@
-[bumpversion]
-current_version = 0.30.0
-commit = True
-tag = True
-
-[bumpversion:file:setup.py]
-search = version='{current_version}'
-replace = version='{new_version}'
-
-[bumpversion:file:glean_parser/__init__.py]
-search = __version__ = '{current_version}'
-replace = __version__ = '{new_version}'
-
 [bdist_wheel]
 universal = 1
 
@@ -22,4 +9,3 @@ test = pytest
 
 [tool:pytest]
 collect_ignore = ['setup.py']
-

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ requirements = [
     'appdirs>=1.4.3'
 ]
 
-setup_requirements = ['pytest-runner', ]
+setup_requirements = ['pytest-runner', 'setuptools-scm']
 
 test_requirements = ['pytest', ]
 
@@ -66,6 +66,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/mozilla/glean_parser',
-    version='0.30.0',
     zip_safe=False,
+    use_scm_version=True
 )


### PR DESCRIPTION
This moves to use `setuptools-scm` instead of `bumpversion`.  Hoping this is more robust on Windows.  It also has the advantage that versions can be tagged using the Github UI so there's no complicated commandline steps that can fail.

@Dexterp37: Would you mind testing the following on Windows?

```
python setup.py --version
```

```
python setup.py test
```