### PR TITLE
 Enable parsing of the `gecko_datapoint` attribute in metrics.yaml 

### DIFF
--- a/docs/metrics-yaml.rst
+++ b/docs/metrics-yaml.rst
@@ -50,6 +50,8 @@ Metric parameters
 
 .. metric_parameter:: extra_keys
 
+.. metric_parameter:: gecko_datapoint
+
 JSON Schema
 -----------
 

--- a/glean_parser/kotlin.py
+++ b/glean_parser/kotlin.py
@@ -126,8 +126,7 @@ def output_kotlin(objs, output_dir, options={}):
         'time_unit',
         'allowed_extra_keys',
         'disabled',
-        'include_client_id',
-        'gecko_datapoint'
+        'include_client_id'
     ]
 
     namespace = options.get('namespace', 'GleanMetrics')
@@ -148,6 +147,13 @@ def output_kotlin(objs, output_dir, options={}):
             for metric in category_val.values()
         )
 
+        # Support exfiltration of Gecko metrics from products using both the
+        # Glean SDK and GeckoView. See bug 1566356 for more context.
+        has_gecko_datapoints = any(
+            getattr(metric, 'gecko_datapoint', False)
+            for metric in category_val.values()
+        )
+
         with open(filepath, 'w', encoding='utf-8') as fd:
             fd.write(
                 template.render(
@@ -157,6 +163,7 @@ def output_kotlin(objs, output_dir, options={}):
                     extra_args=extra_args,
                     namespace=namespace,
                     has_labeled_metrics=has_labeled_metrics,
+                    has_gecko_datapoints=has_gecko_datapoints,
                     glean_namespace=glean_namespace,
                 )
             )

--- a/glean_parser/kotlin.py
+++ b/glean_parser/kotlin.py
@@ -126,7 +126,8 @@ def output_kotlin(objs, output_dir, options={}):
         'time_unit',
         'allowed_extra_keys',
         'disabled',
-        'include_client_id'
+        'include_client_id',
+        'gecko_datapoint'
     ]
 
     namespace = options.get('namespace', 'GleanMetrics')

--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -208,6 +208,9 @@ class Timespan(TimeBase):
 @dataclass
 class TimingDistribution(TimeBase):
     typename = 'timing_distribution'
+    # The following is a Gecko-specific property for using the Glean SDK
+    # with GeckoView metrics. See bug 1566356 for more context.
+    gecko_datapoint: str = ''
 
 
 @dataclass

--- a/glean_parser/schemas/metrics.1-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.1-0-0.schema.yaml
@@ -333,6 +333,17 @@ definitions:
             - description
         default: {}
 
+      gecko_datapoint:
+        title: Gecko Datapoint
+        description: |
+          This is a Gecko-specific property. It is the name of the Gecko histogram to
+          accumulate the data from, when using the Glean SDK in a product using GeckoView.
+          See bug 1566356 for more context.
+
+          This is valid when `type`_ is `timing_distribution`.
+
+        type: string
+
     required:
       - type
       - bugs

--- a/glean_parser/templates/kotlin.jinja2
+++ b/glean_parser/templates/kotlin.jinja2
@@ -23,6 +23,9 @@ package {{ namespace }}
 import {{ glean_namespace }}.private.Lifetime // ktlint-disable no-unused-imports
 import {{ glean_namespace }}.private.TimeUnit // ktlint-disable no-unused-imports
 import {{ glean_namespace }}.private.NoExtraKeys // ktlint-disable no-unused-imports
+{% if has_gecko_datapoints %}
+import {{ glean_namespace }}.private.HistogramBase
+{% endif %}
 {% for obj_type in obj_types %}
 import {{ glean_namespace }}.private.{{ obj_type }}
 {% endfor %}
@@ -64,4 +67,18 @@ internal object {{ category_name|Camelize }} {
     {{ obj_declaration(obj, lazy=obj.type != 'ping') }}
     {% endif %}
 {%- endfor %}
+{% if has_gecko_datapoints %}
+    // Support exfiltration of Gecko metrics from products using both the
+    // Glean SDK and GeckoView. See bug 1566356 for more context.
+    operator fun get(geckoMetricName: String): HistogramBase? {
+        return when(geckoMetricName) {
+        {% for obj in objs.values() %}
+            {% if obj.gecko_datapoint %}
+            "{{ obj.gecko_datapoint }}" -> {{ obj.name|camelize }}
+            {% endif %}
+        {%- endfor %}
+            else -> null
+        }
+    }
+{% endif %}
 }

--- a/glean_parser/templates/kotlin.jinja2
+++ b/glean_parser/templates/kotlin.jinja2
@@ -20,12 +20,12 @@
 @file:Suppress("PackageNaming")
 package {{ namespace }}
 
-import {{ glean_namespace }}.private.Lifetime // ktlint-disable no-unused-imports
-import {{ glean_namespace }}.private.TimeUnit // ktlint-disable no-unused-imports
-import {{ glean_namespace }}.private.NoExtraKeys // ktlint-disable no-unused-imports
 {% if has_gecko_datapoints %}
 import {{ glean_namespace }}.private.HistogramBase
 {% endif %}
+import {{ glean_namespace }}.private.Lifetime // ktlint-disable no-unused-imports
+import {{ glean_namespace }}.private.NoExtraKeys // ktlint-disable no-unused-imports
+import {{ glean_namespace }}.private.TimeUnit // ktlint-disable no-unused-imports
 {% for obj_type in obj_types %}
 import {{ glean_namespace }}.private.{{ obj_type }}
 {% endfor %}
@@ -71,7 +71,7 @@ internal object {{ category_name|Camelize }} {
     // Support exfiltration of Gecko metrics from products using both the
     // Glean SDK and GeckoView. See bug 1566356 for more context.
     operator fun get(geckoMetricName: String): HistogramBase? {
-        return when(geckoMetricName) {
+        return when (geckoMetricName) {
         {% for obj in objs.values() %}
             {% if obj.gecko_datapoint %}
             "{{ obj.gecko_datapoint }}" -> {{ obj.name|camelize }}

--- a/tests/data/gecko.yaml
+++ b/tests/data/gecko.yaml
@@ -1,0 +1,47 @@
+$schema: moz://mozilla.org/schemas/glean/metrics/1-0-0
+
+gecko.imports:
+  page_load_time:
+    type: timing_distribution
+    gecko_datapoint: FX_PAGE_LOAD_MS_2
+    time_unit: millisecond
+    lifetime: application
+    description: >
+      A sample timing distribution metric exported from Gecko.
+    bugs:
+      - 1566356
+    data_reviews:
+      - http://example.com/reviews
+    notification_emails:
+      - CHANGE-ME@example.com
+    expires: 2100-01-01
+
+  startup_runtime:
+    type: timing_distribution
+    gecko_datapoint: GV_STARTUP_RUNTIME_MS
+    time_unit: millisecond
+    lifetime: application
+    description: >
+      Another sample timing distribution metric exported from Gecko.
+    bugs:
+      - 1566356
+    data_reviews:
+      - http://example.com/reviews
+    notification_emails:
+      - CHANGE-ME@example.com
+    expires: 2100-01-01
+
+non.gecko.metrics:
+  app_load_time:
+    type: timing_distribution
+    time_unit: millisecond
+    lifetime: application
+    description: >
+      A sample timing distribution that is not tied to a Gecko datapoint.
+    bugs:
+      - 1566356
+    data_reviews:
+      - http://example.com/reviews
+    notification_emails:
+      - CHANGE-ME@example.com
+    expires: 2100-01-01

--- a/tests/test_kotlin.py
+++ b/tests/test_kotlin.py
@@ -209,7 +209,7 @@ def test_gecko_datapoints(tmpdir):
         # below are important. Do not change them unless the file format
         # changes, otherwise validation will fail.
         expected_operator = """    operator fun get(geckoMetricName: String): HistogramBase? {
-        return when(geckoMetricName) {
+        return when (geckoMetricName) {
             "FX_PAGE_LOAD_MS_2" -> pageLoadTime
             "GV_STARTUP_RUNTIME_MS" -> startupRuntime
             else -> null

--- a/tests/test_kotlin.py
+++ b/tests/test_kotlin.py
@@ -206,8 +206,8 @@ def test_gecko_datapoints(tmpdir):
 
         # Validate the generated Gecko metric mapper Kotlin operator.
         # NOTE: Indentation, whitespaces  and text formatting of the block
-        # below are important. Do not change them unless the file format changes,
-        # otherwise validation will fail.
+        # below are important. Do not change them unless the file format
+        # changes, otherwise validation will fail.
         expected_operator = """    operator fun get(geckoMetricName: String): HistogramBase? {
         return when(geckoMetricName) {
             "FX_PAGE_LOAD_MS_2" -> pageLoadTime

--- a/tests/test_kotlin.py
+++ b/tests/test_kotlin.py
@@ -174,3 +174,55 @@ def test_glean_namespace(tmpdir):
         assert content.count(
             "import Bar.private.CounterMetricType"
         ) == 1
+
+
+def test_gecko_datapoints(tmpdir):
+    """Test translating metrics to Kotlin files."""
+    tmpdir = Path(tmpdir)
+
+    translate.translate(
+        ROOT / "data" / "gecko.yaml",
+        'kotlin',
+        tmpdir,
+        {'glean_namespace': 'Bar'},
+        {'allow_reserved': True}
+    )
+
+    assert (
+        set(x.name for x in tmpdir.iterdir()) ==
+        set([
+            'GeckoImports.kt',
+            'NonGeckoMetrics.kt'
+        ])
+    )
+
+    # Make sure descriptions made it in
+    with open(tmpdir / 'GeckoImports.kt', 'r', encoding='utf-8') as fd:
+        content = fd.read()
+        # Make sure we're adding the relevant Glean SDK import, once.
+        assert content.count(
+            "import Bar.private.HistogramBase"
+        ) == 1
+
+        # Validate the generated Gecko metric mapper Kotlin operator.
+        # NOTE: Indentation, whitespaces  and text formatting of the block
+        # below are important. Do not change them unless the file format changes,
+        # otherwise validation will fail.
+        expected_operator = """    operator fun get(geckoMetricName: String): HistogramBase? {
+        return when(geckoMetricName) {
+            "FX_PAGE_LOAD_MS_2" -> pageLoadTime
+            "GV_STARTUP_RUNTIME_MS" -> startupRuntime
+            else -> null
+        }
+    }"""
+
+        assert expected_operator in content
+
+    with open(tmpdir / 'NonGeckoMetrics.kt', 'r', encoding='utf-8') as fd:
+        content = fd.read()
+        assert 'HistogramBase' not in content
+
+    # Only run this test if ktlint is on the path
+    if shutil.which('ktlint'):
+        for filepath in tmpdir.glob('*.kt'):
+            subprocess.check_call(['ktlint', filepath])


### PR DESCRIPTION
This adds support for the `gecko_datapoint` property in the `metrics.yaml` file for the Glean SDK.

In addition, this updates the jinja2 template to produce a function to map Gecko metrics to Glean SDK metrics and adds test coverage.

See [this bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1566356) and the blocked meta bug for more context.