### PR TITLE
Ensure gecko_datapoint only appears on timing_distribution

### DIFF
--- a/glean_parser/schemas/metrics.1-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.1-0-0.schema.yaml
@@ -387,3 +387,12 @@ additionalProperties:
               description: |
                 Event metrics must have ping lifetime.
               const: ping
+      -
+        if:
+          required:
+            - gecko_datapoint
+        then:
+          properties:
+            type:
+              enum:
+                - timing_distribution

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -361,3 +361,36 @@ def test_duplicate_send_in_pings():
 
     metric = all_metrics.value['telemetry']['test']
     assert metric.send_in_pings == ['core', 'metrics']
+
+
+def test_geckoview_only_on_valid_metrics():
+    contents = [
+        {
+            'category1': {
+                'metric1': {
+                    "type": "timing_distribution",
+                    "gecko_datapoint": "FOO"
+                },
+            },
+        },
+    ]
+    contents = [util.add_required(x) for x in contents]
+
+    all_metrics = parser.parse_objects(contents)
+    errs = list(all_metrics)
+
+    contents = [
+        {
+            'category1': {
+                'metric1': {
+                    "type": "event",
+                    "gecko_datapoint": "FOO"
+                },
+            },
+        },
+    ]
+    contents = [util.add_required(x) for x in contents]
+
+    all_metrics = parser.parse_objects(contents)
+    errs = list(all_metrics)
+    assert len(errs) == 1


### PR DESCRIPTION
As a follow-on to #75 that I just though of -- This should prevent users from putting a `gecko_datapoint` on an unsupported metric type.