### PR TITLE
1569765: Add check for special case of "all_pings"

### DIFF
--- a/glean_parser/parser.py
+++ b/glean_parser/parser.py
@@ -172,6 +172,16 @@ def _instantiate_metrics(all_objects, sources, content, filepath, config):
                     str(e)
                 )
                 metric_obj = None
+            else:
+                if (not config.get('allow_reserved') and
+                        'all_pings' in metric_obj.send_in_pings):
+                    yield util.format_error(
+                        filepath,
+                        f'On instance {category_key}.{metric_key}',
+                        f'Only internal metrics may specify "all_pings" '
+                        f'in "send_in_pings"'
+                    )
+                    metric_obj = None
 
             already_seen = sources.get((category_key, metric_key))
             if already_seen is not None:

--- a/glean_parser/schemas/metrics.1-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.1-0-0.schema.yaml
@@ -175,6 +175,10 @@ definitions:
           is sent on the "default ping", which is the `events` ping for events,
           and the `metrics` ping for everything else. Most metrics don't need to
           specify this.
+
+          (There is an additional special value of `all_pings` for internal
+          Glean metrics only that is used to indicate that a metric may appear
+          in any ping.)
         type: array
         items:
           $ref: "#/definitions/snake_case"

--- a/glean_parser/schemas/pings.1-0-0.schema.yaml
+++ b/glean_parser/schemas/pings.1-0-0.schema.yaml
@@ -18,9 +18,12 @@ definitions:
 type: object
 
 propertyNames:
-  anyOf:
-    - $ref: "#/definitions/dotted_snake_case"
-    - enum: ['$schema']
+  allOf:
+    - anyOf:
+      - $ref: "#/definitions/dotted_snake_case"
+      - enum: ['$schema']
+    - not:
+        enum: ['all_pings']
 
 properties:
   $schema:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -394,3 +394,42 @@ def test_geckoview_only_on_valid_metrics():
     all_metrics = parser.parse_objects(contents)
     errs = list(all_metrics)
     assert len(errs) == 1
+
+
+def test_all_pings_reserved():
+    # send_in_pings: [all_pings] is only allowed for internal metrics
+    contents = [
+        {
+            'category': {
+                'metric': {
+                    'type': 'string',
+                    'send_in_pings': ['all_pings']
+                },
+            },
+        },
+    ]
+
+    contents = [util.add_required(x) for x in contents]
+    all_metrics = parser.parse_objects(contents)
+    errors = list(all_metrics)
+    assert len(errors) == 1
+    assert "On instance category.metric" in errors[0]
+    assert "Only internal metrics" in errors[0]
+
+    all_metrics = parser.parse_objects(contents, {'allow_reserved': True})
+    errors = list(all_metrics)
+    assert len(errors) == 0
+
+    # A custom ping called "all_pings" is not allowed
+    contents = [
+        {
+            'all_pings': {
+                'include_client_id': True
+            },
+        },
+    ]
+    contents = [util.add_required_ping(x) for x in contents]
+    all_pings = parser.parse_objects(contents)
+    errors = list(all_pings)
+    assert len(errors) == 1
+    assert "is not allowed for 'all_pings'"


### PR DESCRIPTION
This just ensures that other libraries can't use the special "all_pings" value that is required for error metrics.