### PR TITLE
Add instructions to use changelog, and backfill changelog

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+### Pull Request checklist ###
+<!-- Before submitting the PR, please address each item -->
+- [ ] **Quality**: This PR builds and tests run cleanly
+  - `make test` runs without emitting any warnings
+  - `make lint` runs without emitting any errors
+- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
+- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
+  - Any breaking changes to language binding APIs are noted explicitly

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -134,4 +134,4 @@ $ git push upstream master --tags
 
 Alternatively, the above tasks can be performed through the `Github new release UI <https://github.com/mozilla/glean_parser/releases/new>`__.
 
-Travis will then deploy to PyPI if tests pass.
+The continuous integration system will then deploy to PyPI if tests pass.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -109,6 +109,7 @@ Before you submit a pull request, check that it meets these guidelines:
    feature to the list in README.rst.
 3. The pull request should work for Python 3.7. Check TODO and make sure that
    the tests pass for all supported Python versions.
+4. The pull request should update the changelog in `HISTORY.rst`.
 
 Tips
 ----

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -123,7 +123,13 @@ Deploying
 ---------
 
 A reminder for the maintainers on how to deploy.
-Make sure all your changes are committed (including an entry in HISTORY.rst).
+
+- Update the header with the new version and date in HISTORY.rst.
+
+- (By using the setuptools-scm package, there is no need to update the version anywhere else).
+
+- Make sure all your changes are committed.
+
 Then run (assuming the main fork is in a git remote called `upstream`)::
 
 $ git checkout master
@@ -131,7 +137,5 @@ $ git fetch upstream
 $ git rebase upstream/master
 $ git tag vX.X.X
 $ git push upstream master --tags
-
-Alternatively, the above tasks can be performed through the `Github new release UI <https://github.com/mozilla/glean_parser/releases/new>`__.
 
 The continuous integration system will then deploy to PyPI if tests pass.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,8 @@
 History
 =======
 
+* `labeled_timespan` is no longer an allowed metric type.
+
 1.0.0 (2019-07-29)
 ------------------
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,9 @@
 History
 =======
 
+Unreleased
+----------
+
 * `labeled_timespan` is no longer an allowed metric type.
 
 1.0.0 (2019-07-29)


### PR DESCRIPTION
Yesterday, I tagged a 1.0.0 release, and with that comes strictly using semver and keeping a good changelog.

This just adds that to the PR template, and backfills the changelog with one thing that slipped through the cracks yesterday.