### PR TITLE
Restrict ping names to be kebab-case

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,8 @@ History
 Unreleased
 ----------
 
+* Restrict ping names to be kebab-case and change `all_pings` to `all-pings`
+
 1.4.1 (2019-08-28)
 ------------------
 

--- a/glean_parser/parser.py
+++ b/glean_parser/parser.py
@@ -164,12 +164,12 @@ def _instantiate_metrics(all_objects, sources, content, filepath, config):
             else:
                 if (
                     not config.get("allow_reserved")
-                    and "all_pings" in metric_obj.send_in_pings
+                    and "all-pings" in metric_obj.send_in_pings
                 ):
                     yield util.format_error(
                         filepath,
                         f"On instance {category_key}.{metric_key}",
-                        f'Only internal metrics may specify "all_pings" '
+                        f'Only internal metrics may specify "all-pings" '
                         f'in "send_in_pings"',
                     )
                     metric_obj = None

--- a/glean_parser/schemas/metrics.1-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.1-0-0.schema.yaml
@@ -23,6 +23,10 @@ definitions:
     pattern: "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})*$"
     maxLength: 40
 
+  kebab_case:
+    type: string
+    pattern: "^[a-z][a-z0-9-]{0,29}$"
+
   long_id:
     allOf:
       - $ref: "#/definitions/snake_case"
@@ -186,12 +190,12 @@ definitions:
           and the `metrics` ping for everything else. Most metrics don't need to
           specify this.
 
-          (There is an additional special value of `all_pings` for internal
+          (There is an additional special value of `all-pings` for internal
           Glean metrics only that is used to indicate that a metric may appear
           in any ping.)
         type: array
         items:
-          $ref: "#/definitions/snake_case"
+          $ref: "#/definitions/kebab_case"
         default:
           - default
 

--- a/glean_parser/schemas/pings.1-0-0.schema.yaml
+++ b/glean_parser/schemas/pings.1-0-0.schema.yaml
@@ -5,25 +5,24 @@ description: |
 
   The top-level of the `pings.yaml` file has a key defining the name of each
   ping. The values contain metadata about that ping. Ping names must be
-  snake_case, though they may also have dots `.` to define subcategories.
+  kebab-case per https://docs.telemetry.mozilla.org/cookbooks/new_ping.html
 
 $id: moz://mozilla.org/schemas/glean/pings/1-0-0
 
 definitions:
-  dotted_snake_case:
+  kebab_case:
     type: string
-    pattern: "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})*$"
-    maxLength: 40
+    pattern: "^[a-z][a-z0-9-]{0,29}$"
 
 type: object
 
 propertyNames:
   allOf:
     - anyOf:
-      - $ref: "#/definitions/dotted_snake_case"
+      - $ref: "#/definitions/kebab_case"
       - enum: ['$schema']
     - not:
-        enum: ['all_pings']
+        enum: ['all-pings']
 
 properties:
   $schema:

--- a/tests/data/pings.yaml
+++ b/tests/data/pings.yaml
@@ -1,6 +1,6 @@
 $schema: moz://mozilla.org/schemas/glean/pings/1-0-0
 
-custom_ping:
+custom-ping:
     description:
         This is a custom ping
     include_client_id: false
@@ -11,7 +11,7 @@ custom_ping:
     notification_emails:
       - CHANGE-ME@test-only.com
 
-really_custom_ping:
+really-custom-ping:
     description:
         This is another custom ping
     include_client_id: true

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -81,8 +81,8 @@ def test_ping_desc():
     # If we have a custom ping cache, try look up the
     # description there.
     cache = {}
-    cache["cached_ping"] = pings.Ping(
-        name="cached_ping",
+    cache["cached-ping"] = pings.Ping(
+        name="cached-ping",
         description="the description for the custom ping\n with a surprise",
         bugs=["1234"],
         notification_emails=["email@example.com"],
@@ -91,7 +91,7 @@ def test_ping_desc():
     )
 
     assert (
-        markdown.ping_desc("cached_ping", cache)
+        markdown.ping_desc("cached-ping", cache)
         == "the description for the custom ping\n with a surprise"
     )
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -38,10 +38,10 @@ def test_parser():
                 assert isinstance(metric_val.labels, set)
 
     pings = all_metrics.value["pings"]
-    assert pings["custom_ping"].name == "custom_ping"
-    assert pings["custom_ping"].include_client_id is False
-    assert pings["really_custom_ping"].name == "really_custom_ping"
-    assert pings["really_custom_ping"].include_client_id is True
+    assert pings["custom-ping"].name == "custom-ping"
+    assert pings["custom-ping"].include_client_id is False
+    assert pings["really-custom-ping"].name == "really-custom-ping"
+    assert pings["really-custom-ping"].include_client_id is True
 
 
 def test_parser_invalid():
@@ -292,9 +292,9 @@ def test_geckoview_only_on_valid_metrics():
 
 
 def test_all_pings_reserved():
-    # send_in_pings: [all_pings] is only allowed for internal metrics
+    # send_in_pings: [all-pings] is only allowed for internal metrics
     contents = [
-        {"category": {"metric": {"type": "string", "send_in_pings": ["all_pings"]}}}
+        {"category": {"metric": {"type": "string", "send_in_pings": ["all-pings"]}}}
     ]
 
     contents = [util.add_required(x) for x in contents]
@@ -308,13 +308,13 @@ def test_all_pings_reserved():
     errors = list(all_metrics)
     assert len(errors) == 0
 
-    # A custom ping called "all_pings" is not allowed
-    contents = [{"all_pings": {"include_client_id": True}}]
+    # A custom ping called "all-pings" is not allowed
+    contents = [{"all-pings": {"include_client_id": True}}]
     contents = [util.add_required_ping(x) for x in contents]
     all_pings = parser.parse_objects(contents)
     errors = list(all_pings)
     assert len(errors) == 1
-    assert "is not allowed for 'all_pings'"
+    assert "is not allowed for 'all-pings'"
 
 
 def test_custom_distribution():


### PR DESCRIPTION
See background discussion in https://github.com/mozilla-services/mozilla-pipeline-schemas/issues/390

The only known cases of existing glean pings that do not already match this naming convention are in the [android components sync library metrics.yaml](https://github.com/mozilla-mobile/android-components/blob/master/components/browser/storage-sync/metrics.yaml) so my main concern is understanding exactly what the upgrade path is.

If this change is merged in the glean parser, will that start failing builds for android components and/or apps using the sync library? Do we need to stage changes for that whole stack and merge concurrently with this change?

Alternately, should we bump the schema version for pings.schema.yamlto ease the transition?

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
