### PR TITLE
Add support for Gecko scalars

### DIFF
--- a/glean_parser/kotlin.py
+++ b/glean_parser/kotlin.py
@@ -134,7 +134,7 @@ def output_gecko_lookup(objs, output_dir, options={}):
     gecko_metrics = defaultdict(lambda: defaultdict(list))
 
     # Define scalar-like types.
-    SCALAR_LIKE_TYPES = [ "boolean", "string", "quantity" ]
+    SCALAR_LIKE_TYPES = ["boolean", "string", "quantity"]
 
     for category_key, category_val in objs.items():
         # Support exfiltration of Gecko metrics from products using both the
@@ -145,7 +145,9 @@ def output_gecko_lookup(objs, output_dir, options={}):
                 continue
 
             # Put scalars in their own categories, histogram-like in "histograms".
-            type_category = "histograms" if metric.type not in SCALAR_LIKE_TYPES else metric.type
+            type_category = (
+                "histograms" if metric.type not in SCALAR_LIKE_TYPES else metric.type
+            )
 
             gecko_metrics[type_category][category_key].append(
                 {"gecko_datapoint": metric.gecko_datapoint, "name": metric.name}

--- a/glean_parser/kotlin.py
+++ b/glean_parser/kotlin.py
@@ -144,7 +144,7 @@ def output_gecko_lookup(objs, output_dir, options={}):
         # are found.
         return
 
-    filepath = output_dir / "GleanGeckoHistogramMapping.kt"
+    filepath = output_dir / "GleanGeckoMetricsMapping.kt"
     with open(filepath, "w", encoding="utf-8") as fd:
         fd.write(
             template.render(

--- a/glean_parser/kotlin.py
+++ b/glean_parser/kotlin.py
@@ -119,25 +119,37 @@ def output_gecko_lookup(objs, output_dir, options={}):
     glean_namespace = options.get("glean_namespace", "mozilla.components.service.glean")
 
     # Build a dictionary that contains data for metrics that are
-    # histogram-like and contain a gecko_datapoint, with this format:
+    # histogram-like/scalar-like and contain a gecko_datapoint, with this format:
     #
     # {
-    #  "category": [
-    #    {"gecko_datapoint": "the-datapoint", "name": "the-metric-name"},
-    #    ...
-    #  ],
-    #  ...
+    #   "histograms": {
+    #     "category": [
+    #       {"gecko_datapoint": "the-datapoint", "name": "the-metric-name"},
+    #       ...
+    #     ],
+    #     ...
+    #   },
+    #   "boolean": {}
     # }
-    gecko_metrics = defaultdict(list)
+    gecko_metrics = defaultdict(lambda: defaultdict(list))
+
+    # Define scalar-like types.
+    SCALAR_LIKE_TYPES = [ "boolean", "string", "quantity" ]
 
     for category_key, category_val in objs.items():
         # Support exfiltration of Gecko metrics from products using both the
         # Glean SDK and GeckoView. See bug 1566356 for more context.
         for metric in category_val.values():
-            if getattr(metric, "gecko_datapoint", False):
-                gecko_metrics[category_key].append(
-                    {"gecko_datapoint": metric.gecko_datapoint, "name": metric.name}
-                )
+            # This is not a Gecko metric, skip it.
+            if not getattr(metric, "gecko_datapoint", False):
+                continue
+
+            # Put scalars in their own categories, histogram-like in "histograms".
+            type_category = "histograms" if metric.type not in SCALAR_LIKE_TYPES else metric.type
+
+            gecko_metrics[type_category][category_key].append(
+                {"gecko_datapoint": metric.gecko_datapoint, "name": metric.name}
+            )
 
     if not gecko_metrics:
         # Bail out and don't create a file if no gecko metrics

--- a/glean_parser/schemas/metrics.1-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.1-0-0.schema.yaml
@@ -370,7 +370,7 @@ definitions:
       gecko_datapoint:
         title: Gecko Datapoint
         description: |
-          This is a Gecko-specific property. It is the name of the Gecko histogram to
+          This is a Gecko-specific property. It is the name of the Gecko metric to
           accumulate the data from, when using the Glean SDK in a product using GeckoView.
           See bug 1566356 for more context.
 
@@ -477,10 +477,12 @@ additionalProperties:
                   - custom_distribution
                   - memory_distribution
                   - quantity
+                  - boolean
+                  - string
         then:
           description: |
             `gecko_datapoint` is only allowed for `timing_distribution`, `custom_distribution`,
-            `memory_distribution` and `quantity`.
+            `memory_distribution`, `quantity`, `boolean` and `string`.
           properties:
             gecko_datapoint:
               maxLength: 0

--- a/glean_parser/templates/kotlin.geckoview.jinja2
+++ b/glean_parser/templates/kotlin.geckoview.jinja2
@@ -19,10 +19,10 @@ import {{ glean_namespace }}.private.HistogramMetricBase // ktlint-disable impor
  * This class performs the mapping between Gecko Histograms and Glean SDK
  * metric types.
  */
-internal object GleanGeckoHistogramMapping {
-    // Support exfiltration of Gecko metrics from products using both the
+internal object GleanGeckoMetricsMapping {
+    // Support exfiltration of Gecko histograms from products using both the
     // Glean SDK and GeckoView. See bug 1566356 for more context.
-    operator fun get(geckoMetricName: String): HistogramMetricBase? {
+    operator fun getHistogram(geckoMetricName: String): HistogramMetricBase? {
         return when (geckoMetricName) {
         {% for category in gecko_metrics.keys()|sort %}
             // From {{ category|Camelize }}.kt

--- a/glean_parser/templates/kotlin.geckoview.jinja2
+++ b/glean_parser/templates/kotlin.geckoview.jinja2
@@ -13,26 +13,77 @@ Jinja2 template is not. Please file bugs! #}
 @file:Suppress("PackageNaming")
 package {{ namespace }}
 
+import {{ glean_namespace }}.private.BooleanMetricType // ktlint-disable import-ordering no-unused-imports
 import {{ glean_namespace }}.private.HistogramMetricBase // ktlint-disable import-ordering no-unused-imports
+import {{ glean_namespace }}.private.StringMetricType // ktlint-disable import-ordering no-unused-imports
+import {{ glean_namespace }}.private.QuantityMetricType // ktlint-disable import-ordering no-unused-imports
 
 /*
  * This class performs the mapping between Gecko Histograms and Glean SDK
  * metric types.
  */
 internal object GleanGeckoMetricsMapping {
-{% if 'histograms' in gecko_metrics %}
     // Support exfiltration of Gecko histograms from products using both the
     // Glean SDK and GeckoView. See bug 1566356 for more context.
-    operator fun getHistogram(geckoMetricName: String): HistogramMetricBase? {
+    fun getHistogram(geckoMetricName: String): HistogramMetricBase? {
         return when (geckoMetricName) {
+    {% if 'histograms' in gecko_metrics %}
         {% for category in gecko_metrics['histograms'].keys()|sort %}
             // From {{ category|Camelize }}.kt
             {% for metric in gecko_metrics['histograms'][category] %}
             "{{ metric.gecko_datapoint }}" -> {{ category|Camelize }}.{{ metric.name|camelize }}
             {% endfor %}
         {%- endfor %}
+    {% endif %}
             else -> null
         }
     }
-{% endif %}
+
+    // Support exfiltration of Gecko boolean scalars from products using both the
+    // Glean SDK and GeckoView. See bug 1579365 for more context.
+    fun getBooleanScalar(geckoMetricName: String): BooleanMetricType? {
+        return when (geckoMetricName) {
+    {% if 'boolean' in gecko_metrics %}
+        {% for category in gecko_metrics['boolean'].keys()|sort %}
+            // From {{ category|Camelize }}.kt
+            {% for metric in gecko_metrics['boolean'][category] %}
+            "{{ metric.gecko_datapoint }}" -> {{ category|Camelize }}.{{ metric.name|camelize }}
+            {% endfor %}
+        {%- endfor %}
+    {% endif %}
+            else -> null
+        }
+    }
+
+    // Support exfiltration of Gecko string scalars from products using both the
+    // Glean SDK and GeckoView. See bug 1579365 for more context.
+    fun getStringScalar(geckoMetricName: String): StringMetricType? {
+        return when (geckoMetricName) {
+    {% if 'string' in gecko_metrics %}
+        {% for category in gecko_metrics['string'].keys()|sort %}
+            // From {{ category|Camelize }}.kt
+            {% for metric in gecko_metrics['string'][category] %}
+            "{{ metric.gecko_datapoint }}" -> {{ category|Camelize }}.{{ metric.name|camelize }}
+            {% endfor %}
+        {%- endfor %}
+    {% endif %}
+            else -> null
+        }
+    }
+
+    // Support exfiltration of Gecko quantity scalars from products using both the
+    // Glean SDK and GeckoView. See bug 1579365 for more context.
+    fun getQuantityScalar(geckoMetricName: String): QuantityMetricType? {
+        return when (geckoMetricName) {
+    {% if 'quantity' in gecko_metrics %}
+        {% for category in gecko_metrics['quantity'].keys()|sort %}
+            // From {{ category|Camelize }}.kt
+            {% for metric in gecko_metrics['quantity'][category] %}
+            "{{ metric.gecko_datapoint }}" -> {{ category|Camelize }}.{{ metric.name|camelize }}
+            {% endfor %}
+        {%- endfor %}
+    {% endif %}
+            else -> null
+        }
+    }
 }

--- a/glean_parser/templates/kotlin.geckoview.jinja2
+++ b/glean_parser/templates/kotlin.geckoview.jinja2
@@ -20,17 +20,19 @@ import {{ glean_namespace }}.private.HistogramMetricBase // ktlint-disable impor
  * metric types.
  */
 internal object GleanGeckoMetricsMapping {
+{% if 'histograms' in gecko_metrics %}
     // Support exfiltration of Gecko histograms from products using both the
     // Glean SDK and GeckoView. See bug 1566356 for more context.
     operator fun getHistogram(geckoMetricName: String): HistogramMetricBase? {
         return when (geckoMetricName) {
-        {% for category in gecko_metrics.keys()|sort %}
+        {% for category in gecko_metrics['histograms'].keys()|sort %}
             // From {{ category|Camelize }}.kt
-            {% for metric in gecko_metrics[category] %}
+            {% for metric in gecko_metrics['histograms'][category] %}
             "{{ metric.gecko_datapoint }}" -> {{ category|Camelize }}.{{ metric.name|camelize }}
             {% endfor %}
         {%- endfor %}
             else -> null
         }
     }
+{% endif %}
 }

--- a/glean_parser/templates/kotlin.jinja2
+++ b/glean_parser/templates/kotlin.jinja2
@@ -22,14 +22,14 @@ Jinja2 template is not. Please file bugs! #}
 @file:Suppress("PackageNaming")
 package {{ namespace }}
 
-import {{ glean_namespace }}.private.Lifetime // ktlint-disable no-unused-imports
-import {{ glean_namespace }}.private.NoExtraKeys // ktlint-disable no-unused-imports
-import {{ glean_namespace }}.private.TimeUnit // ktlint-disable no-unused-imports
+import {{ glean_namespace }}.private.Lifetime // ktlint-disable import-ordering no-unused-imports
+import {{ glean_namespace }}.private.NoExtraKeys // ktlint-disable import-ordering no-unused-imports
+import {{ glean_namespace }}.private.TimeUnit // ktlint-disable import-ordering no-unused-imports
 {% for obj_type in obj_types %}
-import {{ glean_namespace }}.private.{{ obj_type }}
+import {{ glean_namespace }}.private.{{ obj_type }} // ktlint-disable import-ordering
 {% endfor %}
 {% if has_labeled_metrics %}
-import {{ glean_namespace }}.private.LabeledMetricType
+import {{ glean_namespace }}.private.LabeledMetricType // ktlint-disable import-ordering
 {% endif %}
 
 internal object {{ category_name|Camelize }} {

--- a/tests/data/gecko.yaml
+++ b/tests/data/gecko.yaml
@@ -47,6 +47,50 @@ gfx.content.checkerboard:
       - CHANGE-ME@example.com
     expires: 2100-01-01
 
+gfx.info.adapter:
+  vendor_id:
+    type: string
+    gecko_datapoint: gfx_adapter.vendor_id
+    lifetime: application
+    description: >
+      A sample string metric. It's a string scalar exported from Gecko.
+    bugs:
+      - 1579365
+    data_reviews:
+      - http://example.com/reviews
+    notification_emails:
+      - CHANGE-ME@example.com
+    expires: 2100-01-01
+
+  stand_alone:
+    type: boolean
+    gecko_datapoint: gfx_adapter.stand_alone
+    lifetime: application
+    description: >
+      A sample boolean metric. It's a boolean scalar exported from Gecko.
+    bugs:
+      - 1579365
+    data_reviews:
+      - http://example.com/reviews
+    notification_emails:
+      - CHANGE-ME@example.com
+    expires: 2100-01-01
+
+  screen_width:
+    type: quantity
+    gecko_datapoint: gfx_adapter.width
+    unit: pixel
+    lifetime: application
+    description: >
+      A sample quantity metric. It's a uint scalar exported from Gecko.
+    bugs:
+      - 1579365
+    data_reviews:
+      - http://example.com/reviews
+    notification_emails:
+      - CHANGE-ME@example.com
+    expires: 2100-01-01
+
 non.gecko.metrics:
   app_load_time:
     type: timing_distribution

--- a/tests/test_kotlin.py
+++ b/tests/test_kotlin.py
@@ -176,7 +176,9 @@ def test_gecko_datapoints(tmpdir):
         {"allow_reserved": True},
     )
 
-    metrics_files = ["GfxContentCheckerboard.kt", "PagePerf.kt", "NonGeckoMetrics.kt"]
+    metrics_files = [
+        "GfxContentCheckerboard.kt", "GfxInfoAdapter.kt", "PagePerf.kt", "NonGeckoMetrics.kt"
+    ]
     assert set(x.name for x in tmpdir.iterdir()) == set(
         ["GleanGeckoMetricsMapping.kt"] + metrics_files
     )
@@ -187,11 +189,11 @@ def test_gecko_datapoints(tmpdir):
         # Make sure we're adding the relevant Glean SDK import, once.
         assert content.count("import Bar.private.HistogramMetricBase") == 1
 
-        # Validate the generated Gecko metric mapper Kotlin operator.
+        # Validate the generated Gecko metric mapper Kotlin functions.
         # NOTE: Indentation, whitespaces  and text formatting of the block
         # below are important. Do not change them unless the file format
         # changes, otherwise validation will fail.
-        expected_operator = """    operator fun get(geckoMetricName: String): HistogramMetricBase? {
+        expected_func = """    fun getHistogram(geckoMetricName: String): HistogramMetricBase? {
         return when (geckoMetricName) {
             // From GfxContentCheckerboard.kt
             "CHECKERBOARD_DURATION" -> GfxContentCheckerboard.duration
@@ -202,7 +204,37 @@ def test_gecko_datapoints(tmpdir):
         }
     }"""
 
-        assert expected_operator in content
+        assert expected_func in content
+
+        expected_func = """    fun getBooleanScalar(geckoMetricName: String): BooleanMetricType? {
+        return when (geckoMetricName) {
+            // From GfxInfoAdapter.kt
+            "gfx_adapter.stand_alone" -> GfxInfoAdapter.standAlone
+            else -> null
+        }
+    }"""
+
+        assert expected_func in content
+
+        expected_func = """    fun getStringScalar(geckoMetricName: String): StringMetricType? {
+        return when (geckoMetricName) {
+            // From GfxInfoAdapter.kt
+            "gfx_adapter.vendor_id" -> GfxInfoAdapter.vendorId
+            else -> null
+        }
+    }"""
+
+        assert expected_func in content
+
+        expected_func = """    fun getQuantityScalar(geckoMetricName: String): QuantityMetricType? {
+        return when (geckoMetricName) {
+            // From GfxInfoAdapter.kt
+            "gfx_adapter.width" -> GfxInfoAdapter.screenWidth
+            else -> null
+        }
+    }"""
+
+        assert expected_func in content
 
     for file_name in metrics_files:
         with open(tmpdir / file_name, "r", encoding="utf-8") as fd:

--- a/tests/test_kotlin.py
+++ b/tests/test_kotlin.py
@@ -177,7 +177,8 @@ def test_gecko_datapoints(tmpdir):
     )
 
     metrics_files = [
-        "GfxContentCheckerboard.kt", "GfxInfoAdapter.kt", "PagePerf.kt", "NonGeckoMetrics.kt"
+        "GfxContentCheckerboard.kt", "GfxInfoAdapter.kt", "PagePerf.kt",
+        "NonGeckoMetrics.kt"
     ]
     assert set(x.name for x in tmpdir.iterdir()) == set(
         ["GleanGeckoMetricsMapping.kt"] + metrics_files

--- a/tests/test_kotlin.py
+++ b/tests/test_kotlin.py
@@ -177,8 +177,10 @@ def test_gecko_datapoints(tmpdir):
     )
 
     metrics_files = [
-        "GfxContentCheckerboard.kt", "GfxInfoAdapter.kt", "PagePerf.kt",
-        "NonGeckoMetrics.kt"
+        "GfxContentCheckerboard.kt",
+        "GfxInfoAdapter.kt",
+        "PagePerf.kt",
+        "NonGeckoMetrics.kt",
     ]
     assert set(x.name for x in tmpdir.iterdir()) == set(
         ["GleanGeckoMetricsMapping.kt"] + metrics_files

--- a/tests/test_kotlin.py
+++ b/tests/test_kotlin.py
@@ -178,11 +178,11 @@ def test_gecko_datapoints(tmpdir):
 
     metrics_files = ["GfxContentCheckerboard.kt", "PagePerf.kt", "NonGeckoMetrics.kt"]
     assert set(x.name for x in tmpdir.iterdir()) == set(
-        ["GleanGeckoHistogramMapping.kt"] + metrics_files
+        ["GleanGeckoMetricsMapping.kt"] + metrics_files
     )
 
     # Make sure descriptions made it in
-    with open(tmpdir / "GleanGeckoHistogramMapping.kt", "r", encoding="utf-8") as fd:
+    with open(tmpdir / "GleanGeckoMetricsMapping.kt", "r", encoding="utf-8") as fd:
         content = fd.read()
         # Make sure we're adding the relevant Glean SDK import, once.
         assert content.count("import Bar.private.HistogramMetricBase") == 1


### PR DESCRIPTION
This changes the parser to support Gecko scalars in the Glean SDK. See the related android components PR mozilla-mobile/android-components#4344 .

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
