### PR TITLE
BUGFIX: Improve error message when gecko_datapoint is on non-Gecko metric type

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,8 @@ History
 Unreleased
 ----------
 
+* BUGFIX: Provides a helpful error message when `geckoview_datapoint` is used on an metric type that doesn't support GeckoView exfiltration.
+
 1.4.1 (2019-08-28)
 ------------------
 

--- a/glean_parser/schemas/metrics.1-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.1-0-0.schema.yaml
@@ -480,11 +480,11 @@ additionalProperties:
                   - boolean
                   - string
         then:
-          description: |
-            `gecko_datapoint` is only allowed for `timing_distribution`, `custom_distribution`,
-            `memory_distribution`, `quantity`, `boolean` and `string`.
           properties:
             gecko_datapoint:
+              description: |
+                `gecko_datapoint` is only allowed for `timing_distribution`, `custom_distribution`,
+                `memory_distribution`, `quantity`, `boolean` and `string`.
               maxLength: 0
       -
         if:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -289,6 +289,7 @@ def test_geckoview_only_on_valid_metrics():
     all_metrics = parser.parse_objects(contents)
     errs = list(all_metrics)
     assert len(errs) == 1
+    assert "is only allowed for" in str(errs[0])
 
 
 def test_all_pings_reserved():


### PR DESCRIPTION

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
