### PR TITLE
Bump the metric name limit to 30 characters

### DIFF
--- a/glean_parser/schemas/metrics.1-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.1-0-0.schema.yaml
@@ -33,15 +33,10 @@ definitions:
       - $ref: "#/definitions/snake_case"
       - maxLength: 30
 
-  very_short_id:
-    allOf:
-      - $ref: "#/definitions/snake_case"
-      - maxLength: 20
-
   labeled_metric_id:
     type: string
     pattern: "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$"
-    maxLength: 61
+    maxLength: 71 # Note: this should be category + metric + 1
 
   metric:
     description: |
@@ -453,7 +448,7 @@ additionalProperties:
   type: object
   propertyNames:
     anyOf:
-      - $ref: "#/definitions/very_short_id"
+      - $ref: "#/definitions/short_id"
   additionalProperties:
     allOf:
       - $ref: "#/definitions/metric"

--- a/tests/data/schema-violation.yaml
+++ b/tests/data/schema-violation.yaml
@@ -14,3 +14,19 @@ gleantest.lifetime:
         notification_emails: ['nobody@example.com']
         expires: never
         data_reviews: ['http://example.com']
+gleantest.with.way.too.long.category.name:
+    test_event_inv_lt:
+        description: A test metric
+        type: boolean
+        bugs: [1580707]
+        notification_emails: ['nobody@example.com']
+        expires: never
+        data_reviews: ['http://example.com']
+gleantest.short.category:
+    very_long_metric_name_this_is_too_long_s_well:
+        description: A test metric
+        type: boolean
+        bugs: [1580707]
+        notification_emails: ['nobody@example.com']
+        expires: never
+        data_reviews: ['http://example.com']

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -110,6 +110,27 @@ def test_parser_schema_violation():
 
             See https://mozilla.github.io/glean_parser/metrics-yaml.html
         """,
+        """
+        ```
+        gleantest.with.way.too.long.category.name
+        ...
+        ```
+
+        'gleantest.with.way.too.long.category.name' is not valid under any of
+        the given schemas
+        'gleantest.with.way.too.long.category.name' is too long
+        'gleantest.with.way.too.long.category.name' is not one of
+        ['$schema']
+        """,
+        """
+        ```
+        gleantest.short.category:very_long_metric_name_this_is_too_long_s_well
+        ```
+
+        'very_long_metric_name_this_is_too_long_s_well' is not valid under any
+        of the given schemas
+        'very_long_metric_name_this_is_too_long_s_well' is too long
+        """,
     ]
 
     expected_errors = set(


### PR DESCRIPTION
This additionally adds test coverage and bumps the maximum label size to 71 characters
(max category len + max name len + 1).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
