### PR TITLE
Generate a lookup table for Gecko categorical histograms

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,8 @@ Unreleased
 
 * BUGFIX: Provides a helpful error message when `geckoview_datapoint` is used on an metric type that doesn't support GeckoView exfiltration.
 
+* Generate a lookup table for Gecko categorical histograms in `GleanGeckoMetricsMapping`.
+
 1.4.1 (2019-08-28)
 ------------------
 

--- a/glean_parser/kotlin.py
+++ b/glean_parser/kotlin.py
@@ -129,7 +129,7 @@ def output_gecko_lookup(objs, output_dir, options={}):
     #     ],
     #     ...
     #   },
-    #   "boolean": {}
+    #   "other-type": {}
     # }
     gecko_metrics = defaultdict(lambda: defaultdict(list))
 
@@ -144,10 +144,15 @@ def output_gecko_lookup(objs, output_dir, options={}):
             if not getattr(metric, "gecko_datapoint", False):
                 continue
 
-            # Put scalars in their own categories, histogram-like in "histograms".
-            type_category = (
-                "histograms" if metric.type not in SCALAR_LIKE_TYPES else metric.type
-            )
+            # Put scalars in their own categories, histogram-like in "histograms" and
+            # categorical histograms in "categoricals".
+            type_category = "histograms"
+            if metric.type in SCALAR_LIKE_TYPES:
+                type_category = metric.type
+            elif metric.type == "labeled_counter":
+                # Labeled counters with a 'gecko_datapoint' property
+                # are categorical histograms.
+                type_category = "categoricals"
 
             gecko_metrics[type_category][category_key].append(
                 {"gecko_datapoint": metric.gecko_datapoint, "name": metric.name}

--- a/glean_parser/schemas/metrics.1-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.1-0-0.schema.yaml
@@ -474,12 +474,13 @@ additionalProperties:
                   - quantity
                   - boolean
                   - string
+                  - labeled_counter
         then:
           properties:
             gecko_datapoint:
               description: |
                 `gecko_datapoint` is only allowed for `timing_distribution`, `custom_distribution`,
-                `memory_distribution`, `quantity`, `boolean` and `string`.
+                `memory_distribution`, `quantity`, `boolean`, `string` and `labeled_counter`.
               maxLength: 0
       -
         if:

--- a/glean_parser/templates/kotlin.geckoview.jinja2
+++ b/glean_parser/templates/kotlin.geckoview.jinja2
@@ -42,6 +42,27 @@ internal object GleanGeckoMetricsMapping {
     {% endif %}
     }
 
+    // Support exfiltration of Gecko categorical histograms from products using
+    // both the Glean SDK and GeckoView. See bug 1571740 for more context.
+    @Suppress("UNUSED_PARAMETER")
+    fun getCategoricalMetric(
+        geckoMetricName: String
+    ): LabeledMetricType<CounterMetricType>? {
+    {% if 'categoricals' in gecko_metrics %}
+        return when (geckoMetricName) {
+        {% for category in gecko_metrics['categoricals'].keys()|sort %}
+            // From {{ category|Camelize }}.kt
+            {% for metric in gecko_metrics['categoricals'][category] %}
+            "{{ metric.gecko_datapoint }}" -> {{ category|Camelize }}.{{ metric.name|camelize }}
+            {% endfor %}
+        {%- endfor %}
+            else -> null
+        }
+    {% else %}
+        return null
+    {% endif %}
+    }
+
     // Support exfiltration of Gecko boolean scalars from products using both the
     // Glean SDK and GeckoView. See bug 1579365 for more context.
     @Suppress("UNUSED_PARAMETER")

--- a/tests/data/gecko.yaml
+++ b/tests/data/gecko.yaml
@@ -31,6 +31,26 @@ page.perf:
       - CHANGE-ME@example.com
     expires: 2100-01-01
 
+  dom_script_preload:
+    type: labeled_counter
+    gecko_datapoint: DOM_SCRIPT_PRELOAD_RESULT
+    labels:
+      - used
+      - rejected_by_policy
+      - request_mismatch
+      - load_error
+      - not_used
+    lifetime: application
+    description: >
+      A sample categorical metric exported from Gecko.
+    bugs:
+      - 1571740
+    data_reviews:
+      - http://example.com/reviews
+    notification_emails:
+      - CHANGE-ME@example.com
+    expires: 2100-01-01
+
 gfx.content.checkerboard:
   duration:
     type: timing_distribution

--- a/tests/test_kotlin.py
+++ b/tests/test_kotlin.py
@@ -209,6 +209,18 @@ def test_gecko_datapoints(tmpdir):
 
         assert expected_func in content
 
+        expected_func = """    fun getCategoricalMetric(
+        geckoMetricName: String
+    ): LabeledMetricType<CounterMetricType>? {
+        return when (geckoMetricName) {
+            // From PagePerf.kt
+            "DOM_SCRIPT_PRELOAD_RESULT" -> PagePerf.domScriptPreload
+            else -> null
+        }
+    }"""
+
+        assert expected_func in content
+
         expected_func = """    fun getBooleanScalar(geckoMetricName: String): BooleanMetricType? {
         return when (geckoMetricName) {
             // From GfxInfoAdapter.kt


### PR DESCRIPTION
This adds a function to look up labeled counters that will represent Gecko [categorical histograms](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/collection/histograms.html#categorical).

**Notes**
Gecko categorical histograms are a special kind of linear histograms in which bins are associated to user-provided labels: the labels can be used to increment the counts in the bins. This Gecko type naturally maps to Glean SDK `labeled_counter` with static labels. The `GleanAdapter` in A-C's engine-gecko-* will need to know when an histogram accumulation is related to a categorical histogram: in that case, the adapter will need to find the corresponding Glean SDK generated metric and attempt an accumulation with that.

**Quirks**
Gecko will only send us the value of the accumulation: e.g. a value of `2` for a categorical means that the bin at *index 2* needs to be incremented of 1 unit. This means we might need to implement a new function in Glean SDK `LabeledMetricType` to accumulate to by the label's index. For example:

```kotlin
    operator fun get(labelIndex: Int): T? {
        val actualLabel = if (labels != null && labelIndex < labels.size) {
            labels.elementAt(labelIndex)
        } else {
            OTHER_LABEL
        }

        return this[actualLabel]
    }
```

@mdboom , thoughts?

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
