### PR TITLE
Pass `memory_unit` to the MemoryDistributionMetricType in Kotlin

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,8 @@ History
 Unreleased
 ----------
 
+* BUGFIX: `memory_unit` is now passed to the Kotlin generator.
+
 1.8.0 (2019-09-26)
 ------------------
 

--- a/glean_parser/kotlin.py
+++ b/glean_parser/kotlin.py
@@ -210,6 +210,7 @@ def output_kotlin(objs, output_dir, options={}):
         "histogram_type",
         "include_client_id",
         "lifetime",
+        "memory_unit",
         "name",
         "range_max",
         "range_min",

--- a/glean_parser/parser.py
+++ b/glean_parser/parser.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 """
 Code for parsing metrics.yaml files.
 """

--- a/glean_parser/schemas/metrics.1-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.1-0-0.schema.yaml
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 $schema: http://json-schema.org/draft-07/schema#
 title: Metrics
 description: |

--- a/glean_parser/schemas/pings.1-0-0.schema.yaml
+++ b/glean_parser/schemas/pings.1-0-0.schema.yaml
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 $schema: http://json-schema.org/draft-07/schema#
 title: Pings
 description: |

--- a/tests/data/core.yaml
+++ b/tests/data/core.yaml
@@ -1,3 +1,6 @@
+# Any copyright is dedicated to the Public Domain.
+# https://creativecommons.org/publicdomain/zero/1.0/
+
 $schema: moz://mozilla.org/schemas/glean/metrics/1-0-0
 
 telemetry:

--- a/tests/data/duplicate_labeled.yaml
+++ b/tests/data/duplicate_labeled.yaml
@@ -1,3 +1,6 @@
+# Any copyright is dedicated to the Public Domain.
+# https://creativecommons.org/publicdomain/zero/1.0/
+
 $schema: moz://mozilla.org/schemas/glean/metrics/1-0-0
 
 category:

--- a/tests/data/duplicate_send_in_ping.yaml
+++ b/tests/data/duplicate_send_in_ping.yaml
@@ -1,3 +1,6 @@
+# Any copyright is dedicated to the Public Domain.
+# https://creativecommons.org/publicdomain/zero/1.0/
+
 $schema: moz://mozilla.org/schemas/glean/metrics/1-0-0
 
 telemetry:

--- a/tests/data/empty.yaml
+++ b/tests/data/empty.yaml
@@ -1,0 +1,2 @@
+# Any copyright is dedicated to the Public Domain.
+# https://creativecommons.org/publicdomain/zero/1.0/

--- a/tests/data/gecko.yaml
+++ b/tests/data/gecko.yaml
@@ -1,3 +1,6 @@
+# Any copyright is dedicated to the Public Domain.
+# https://creativecommons.org/publicdomain/zero/1.0/
+
 $schema: moz://mozilla.org/schemas/glean/metrics/1-0-0
 
 page.perf:

--- a/tests/data/invalid.yaml
+++ b/tests/data/invalid.yaml
@@ -1,1 +1,4 @@
+# Any copyright is dedicated to the Public Domain.
+# https://creativecommons.org/publicdomain/zero/1.0/
+
 !!! THIS ISN'T YAML !!!

--- a/tests/data/pings.yaml
+++ b/tests/data/pings.yaml
@@ -1,3 +1,6 @@
+# Any copyright is dedicated to the Public Domain.
+# https://creativecommons.org/publicdomain/zero/1.0/
+
 $schema: moz://mozilla.org/schemas/glean/pings/1-0-0
 
 custom_ping:

--- a/tests/data/schema-violation.yaml
+++ b/tests/data/schema-violation.yaml
@@ -1,3 +1,6 @@
+# Any copyright is dedicated to the Public Domain.
+# https://creativecommons.org/publicdomain/zero/1.0/
+
 $schema: moz://mozilla.org/schemas/glean/metrics/1-0-0
 gleantest.foo:
     a: b

--- a/tests/data/smaller.yaml
+++ b/tests/data/smaller.yaml
@@ -1,3 +1,6 @@
+# Any copyright is dedicated to the Public Domain.
+# https://creativecommons.org/publicdomain/zero/1.0/
+
 $schema: moz://mozilla.org/schemas/glean/metrics/1-0-0
 
 telemetry:


### PR DESCRIPTION
This additionally adds the missing license headers. Note that this fixes mozilla/glean#321.

I attempted to write a test for this, but it is a bit hard: unless we try to compile Kotlin code, how do we know that something is missing?

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
