### PR TITLE
1585699 - Remove unsupported labeled metric types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,5 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+.vscode/

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,11 @@ History
 Unreleased
 ----------
 
+1.8.4 (2019-10-02)
+------------------
+
+* Removed unsupported labeled metric types.
+
 1.8.3 (2019-10-02)
 ------------------
 

--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -315,35 +315,5 @@ class LabeledString(Labeled, String):
 
 
 @dataclass
-class LabeledEnumeration(Labeled, Enumeration):
-    typename = "labeled_enumeration"
-
-
-@dataclass
 class LabeledCounter(Labeled, Counter):
     typename = "labeled_counter"
-
-
-@dataclass
-class LabeledTimingDistribution(Labeled, TimingDistribution):
-    typename = "labeled_timing_distribution"
-
-
-@dataclass
-class LabeledDatetime(Labeled, Datetime):
-    typename = "labeled_datetime"
-
-
-@dataclass
-class LabeledUseCounter(Labeled, UseCounter):
-    typename = "labeled_use_counter"
-
-
-@dataclass
-class LabeledUsage(Labeled, Usage):
-    typename = "labeled_usage"
-
-
-@dataclass
-class LabeledRate(Labeled, Rate):
-    typename = "labeled_rate"

--- a/glean_parser/schemas/metrics.1-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.1-0-0.schema.yaml
@@ -142,13 +142,7 @@ definitions:
           - uuid
           - labeled_boolean
           - labeled_string
-          - labeled_enumeration
           - labeled_counter
-          - labeled_timing_distribution
-          - labeled_datetime
-          - labeled_use_counter
-          - labeled_usage
-          - labeled_rate
 
       description:
         title: Description


### PR DESCRIPTION
This removes all but the labeled_boolean, labeled_counter, and labeled_string from the "labeled" types.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
