### PR TITLE
Add the imports for supporting Custom and Memory distributions

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,8 @@ History
 Unreleased
 ----------
 
+* BUGFIX: add `HistogramType` and `MemoryUnit` imports in Kotlin generated code.
+
 1.8.4 (2019-10-02)
 ------------------
 

--- a/glean_parser/templates/kotlin.jinja2
+++ b/glean_parser/templates/kotlin.jinja2
@@ -22,7 +22,9 @@ Jinja2 template is not. Please file bugs! #}
 @file:Suppress("PackageNaming")
 package {{ namespace }}
 
+import {{ glean_namespace }}.private.HistogramType // ktlint-disable import-ordering no-unused-imports
 import {{ glean_namespace }}.private.Lifetime // ktlint-disable import-ordering no-unused-imports
+import {{ glean_namespace }}.private.MemoryUnit // ktlint-disable import-ordering no-unused-imports
 import {{ glean_namespace }}.private.NoExtraKeys // ktlint-disable import-ordering no-unused-imports
 import {{ glean_namespace }}.private.TimeUnit // ktlint-disable import-ordering no-unused-imports
 {% for obj_type in obj_types %}


### PR DESCRIPTION
This was reported by :jnicol while working on the GeckoView integration. Both types are used to specify the properties of the generated Custom and Memory distributions instances.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
