### PR TITLE
Do not check `is_internal_metric` for Pings

### DIFF
--- a/glean_parser/markdown.py
+++ b/glean_parser/markdown.py
@@ -110,12 +110,15 @@ def output_markdown(objs, output_dir, options={}):
         for obj in category_val.values():
             # Filter out custom pings. We will need them for extracting
             # the description
-            if obj.is_internal_metric():
-                continue
-            elif isinstance(obj, pings.Ping):
+            if isinstance(obj, pings.Ping):
                 custom_pings_cache[obj.name] = obj
+            elif obj.is_internal_metric():
+                # This is an internal Glean metric, and we don't
+                # want docs for it.
+                continue
             else:
-                # If we get here, obj is definitely a metric
+                # If we get here, obj is definitely a metric we want
+                # docs for.
                 for ping_name in obj.send_in_pings:
                     metrics_by_pings[ping_name].append(obj)
 


### PR DESCRIPTION
This fixes a bustage introduced by #118: ` AttributeError: 'Ping' object has no attribute 'is_internal_metric'`

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
