### PR TITLE
Add support for labels to the Markdown template

### DIFF
--- a/glean_parser/markdown.py
+++ b/glean_parser/markdown.py
@@ -25,6 +25,10 @@ def extra_info(obj):
         for key in obj.allowed_extra_keys:
             extra_info.append((key, obj.extra_keys[key]["description"]))
 
+    if isinstance(obj, metrics.Labeled) and obj.labels is not None:
+        for label in obj.labels:
+            extra_info.append((label, None))
+
     return extra_info
 
 

--- a/glean_parser/templates/markdown.jinja2
+++ b/glean_parser/templates/markdown.jinja2
@@ -37,7 +37,7 @@ The following metrics are added to the ping:
 {%- if metric|extra_info -%}
 <ul>
 {%- for property, desc in metric|extra_info %}
-<li>{{ property }}: {{ desc|replace("\n", " ") }}</li>
+<li>{{ property }}{%- if desc is not none -%}: {{ desc|replace("\n", " ") }}{%- endif -%}</li>
 {%- endfor -%}
 </ul>
 {%- endif -%} |

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -55,7 +55,20 @@ def test_extra_info_generator():
 
     assert markdown.extra_info(event) == [("my_extra", "an extra")]
 
-    # We don't currently support extra info for types other than events.
+    labeled = metrics.LabeledCounter(
+        type="labeled_counter",
+        category="category",
+        name="metric",
+        bugs=[42],
+        notification_emails=["nobody@example.com"],
+        description="description...",
+        expires="never",
+        labels={"label"},
+    )
+
+    assert markdown.extra_info(labeled) == [("label", None)]
+
+    # We currently support extra info only for events and labeled types.
     other = metrics.Timespan(
         type="timespan",
         category="category",


### PR DESCRIPTION
This fixes  [Bug 1578345](https://bugzilla.mozilla.org/show_bug.cgi?id=1578345).

I am not very sure about the solution, because it looks kind of fragile. But I thought it was best to send this in and discuss with some code on the table.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly

