### PR TITLE
Warn for slight misspellings in ping names.

### DIFF
--- a/glean_parser/lint.py
+++ b/glean_parser/lint.py
@@ -26,9 +26,7 @@ def _hamming_distance(str1, str2):
 
     diffs = 0
     if len(str1) < len(str2):
-        tmp = str1
-        str1 = str2
-        str2 = tmp
+        str1, str2 = str2, str1
     len_dist = len(str1) - len(str2)
     str2 += " "*len_dist
 

--- a/glean_parser/lint.py
+++ b/glean_parser/lint.py
@@ -18,6 +18,26 @@ def _split_words(name):
     return re.split("[._]", name)
 
 
+def _hamming_distance(str1, str2):
+    """
+    Count the # of differences between strings str1 and str2,
+    padding the shorter one with whitespace
+    """
+
+    diffs = 0
+    if len(str1) < len(str2):
+        tmp = str1
+        str1 = str2
+        str2 = tmp
+    len_dist = len(str1) - len(str2)
+    str2 += " "*len_dist
+
+    for ch1, ch2 in zip(str1, str2):
+        if ch1 != ch2:
+            diffs += 1
+    return diffs
+
+
 def check_common_prefix(category_name, metrics):
     """
     Check if all metrics begin with a common prefix.
@@ -140,6 +160,16 @@ def check_valid_in_baseline(metric, parser_config={}):
         )
 
 
+def check_misspelled_pings(metric, parser_config={}):
+    builtin_pings = ["metrics", "events"]
+
+    for ping in metric.send_in_pings:
+        for builtin in builtin_pings:
+            distance = _hamming_distance(ping, builtin)
+            if distance == 1:
+                yield (f"Ping '{ping}' seems misspelled. Did you mean '{builtin}'?")
+
+
 CATEGORY_CHECKS = {
     "COMMON_PREFIX": check_common_prefix,
     "CATEGORY_GENERIC": check_category_generic,
@@ -150,6 +180,7 @@ INDIVIDUAL_CHECKS = {
     "UNIT_IN_NAME": check_unit_in_name,
     "BUG_NUMBER": check_bug_number,
     "BASELINE_PING": check_valid_in_baseline,
+    "MISSPELLED_PING": check_misspelled_pings,
 }
 
 

--- a/glean_parser/lint.py
+++ b/glean_parser/lint.py
@@ -28,7 +28,7 @@ def _hamming_distance(str1, str2):
     if len(str1) < len(str2):
         str1, str2 = str2, str1
     len_dist = len(str1) - len(str2)
-    str2 += " "*len_dist
+    str2 += " " * len_dist
 
     for ch1, ch2 in zip(str1, str2):
         if ch1 != ch2:

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -196,3 +196,25 @@ def test_baseline_restriction():
 
     assert len(nits) == 2
     assert set(["BASELINE_PING"]) == set(v[0] for v in nits)
+
+
+def test_misspelling_pings():
+    contents = [
+        {
+            "user_data": {
+                "counter": {"type": "counter", "send_in_pings": ["metric"]},
+                "string": {"type": "string", "send_in_pings": ["event"]},
+                "string2": {"type": "string", "send_in_pings": ["metrics", "events"]},
+            }
+        }
+    ]
+    contents = [util.add_required(x) for x in contents]
+    all_metrics = parser.parse_objects(contents)
+
+    errs = list(all_metrics)
+    assert len(errs) == 0
+
+    nits = lint.lint_metrics(all_metrics.value)
+
+    assert len(nits) == 2
+    assert set(["MISSPELLED_PING"]) == set(v[0] for v in nits)


### PR DESCRIPTION
This only handles builtin pings (and doesn't do baseline, because we actually don't want more metrics in there).