### PR TITLE
Make labels from Labeled types sets again

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,8 @@ Unreleased
 
 * New lint: Warn for slight misspellings in ping names
 
+* BUGFIX: change Labeled types labels from lists to sets.
+
 1.9.4 (2019-10-16)
 ------------------
 

--- a/glean_parser/markdown.py
+++ b/glean_parser/markdown.py
@@ -25,8 +25,8 @@ def extra_info(obj):
         for key in obj.allowed_extra_keys:
             extra_info.append((key, obj.extra_keys[key]["description"]))
 
-    if isinstance(obj, metrics.Labeled) and obj.labels is not None:
-        for label in obj.labels:
+    if isinstance(obj, metrics.Labeled) and obj.ordered_labels is not None:
+        for label in obj.ordered_labels:
             extra_info.append((label, None))
 
     return extra_info

--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -303,8 +303,23 @@ class Uuid(Metric):
 
 @dataclass
 class Labeled(Metric):
-    labels: List[str] = None
     labeled = True
+    # Start the labels as a List to preserve the order from `metrics.yaml`
+    labels: List[str] = None
+
+    def __post_init__(self, *args):
+        ordered_labels = self.labels
+
+        # If any, turn the labels into a Set to properly inialize the Metric object.
+        # This is important because Kotlin code needs this labels as a Set
+        if self.labels is not None:
+            self.labels = set(ordered_labels)
+        super().__post_init__(*args)
+
+        # After initializing the Metric object, add the ordered_labels to it.
+        # If we do this step before calling the __post_init__ for the Metric class,
+        # the metric schema validation will fail
+        self.ordered_labels = ordered_labels
 
 
 @dataclass

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -35,7 +35,7 @@ def test_parser():
             assert isinstance(metric_val, metrics.Metric)
             assert isinstance(metric_val.lifetime, metrics.Lifetime)
             if getattr(metric_val, "labels", None) is not None:
-                assert isinstance(metric_val.labels, list)
+                assert isinstance(metric_val.labels, set)
 
     pings = all_metrics.value["pings"]
     assert pings["custom_ping"].name == "custom_ping"


### PR DESCRIPTION
These labels were recently changed to lists to ensure the labels
ordering from `metrics.yaml` was kept in the markdown generated
documentation. That had the unwanted effect of changing the type
of the labels in the Kotlin and Swift generated codes.

To fix this, a new property `ordered_labels` was added to the
Labeled types which is a list. Keeping the actual `labels` property
a set.

See discussion: https://github.com/mozilla-mobile/android-components/pull/4750#discussion_r336030971

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
