### PR TITLE
Ignore lower-camelcase class name and enum variants in linter

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,8 @@ History
 Unreleased
 ----------
 
+*  Ignore lower-camelcase class name and enum variants in linter
+
 1.9.4 (2019-10-16)
 ------------------
 

--- a/glean_parser/templates/kotlin.jinja2
+++ b/glean_parser/templates/kotlin.jinja2
@@ -37,6 +37,7 @@ import {{ glean_namespace }}.private.LabeledMetricType // ktlint-disable import-
 internal object {{ category_name|Camelize }} {
 {% for obj in objs.values() %}
     {% if obj.extra_keys|length %}
+    @Suppress("ClassNaming", "EnumNaming")
     enum class {{ obj.name|camelize }}Keys {
     {% for key in obj.allowed_extra_keys %}
         {{ key|camelize }}{{ "," if not loop.last }}


### PR DESCRIPTION
**DO NOT MERGE UNTIL [BUG 1590080](https://bugzilla.mozilla.org/show_bug.cgi?id=1590080) REACHED A CONCLUSION**


This might be a short-term fix until we decide that `ClickKeys` and
`Open` are better than `clickKeys` and `open`, but we will need to fix
these things in Fenix when upgrading.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
