### PR TITLE
Run detekt over generated Kotlin code in unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,9 @@ jobs:
             - run:
                     name: install dependencies
                     command: |
-                        pip install --user -U -r requirements_dev.txt
-                        sudo apt update
-                        sudo apt upgrade
+                        pip install --progress-bar off --user -U -r requirements_dev.txt
+                        sudo apt update -q
+                        sudo apt upgrade -q
                         sudo apt install openjdk-8-jdk-headless
                         make install-kotlin-linters
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,14 +10,13 @@ jobs:
                     command: |
                         echo 'export PATH=.:$HOME/.local/bin:$PATH' >> $BASH_ENV
             - run:
-                    name: install
+                    name: install dependencies
                     command: |
                         pip install --user -U -r requirements_dev.txt
                         sudo apt update
                         sudo apt upgrade
                         sudo apt install openjdk-8-jdk-headless
-                        curl -sSLO https://github.com/shyiko/ktlint/releases/download/0.29.0/ktlint && chmod a+x ktlint
-
+                        make install-kotlin-linters
             - run:
                     name: lint
                     command: make lint

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ ENV/
 .mypy_cache/
 
 .vscode/
+
+detekt/
+ktlint/

--- a/.gitignore
+++ b/.gitignore
@@ -106,5 +106,5 @@ ENV/
 
 .vscode/
 
-detekt/
-ktlint/
+detekt*.jar
+ktlint

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -81,14 +81,21 @@ Ready to contribute? Here's how to set up `glean_parser` for local development.
 
    Now you can make your changes locally.
 
-5. When you're done making changes, check that your changes pass linting through flake8 and black.
-   Also make sure that all tests are passing, including testing all Python versions with tox::
+5. To test your changes to `glean_parser`:
 
-    $ make lint
-    $ python setup.py test or py.test
-    $ tox
+   Install the testing dependencies::
 
-   To get flake8 and tox, just pip install them into your virtualenv.
+     $ pip install flake8 py.test black
+
+   Optionally, if you want to ensure that the generated Kotlin code lints correctly, install a Java SDK, and then run::
+
+     $ make install-kotlin-linters
+
+   Then make sure that all lints and tests are passing::
+
+     $ make lint
+     $ python setup.py test or py.test
+     $ tox
 
 6. Commit your changes and push your branch to GitHub::
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,9 @@ History
 Unreleased
 ----------
 
+* The Kotlin linter `detekt` is now run during CI, and for local
+  testing if installed.
+
 1.9.5 (2019-10-22)
 ------------------
 

--- a/Makefile
+++ b/Makefile
@@ -72,15 +72,6 @@ install: clean ## install the package to the active Python's site-packages
 	python setup.py install
 
 install-kotlin-linters: ## install ktlint and detekt for linting Kotlin output
-	mkdir ktlint
-	( \
-	    cd ktlint && \
-		curl -sSLO https://github.com/shyiko/ktlint/releases/download/0.29.0/ktlint && \
-		chmod a+x ktlint \
-	)
-	git clone https://github.com/arturbosch/detekt
-	( \
-	    cd detekt && \
-		git checkout 1.1.1 && \
-		./gradlew build detekt-cli:shadowJar \
-	)
+	curl -sSLO https://github.com/shyiko/ktlint/releases/download/0.29.0/ktlint
+	chmod a+x ktlint
+	curl -sSL --output "detekt-cli-1.1.1-all.jar" https://bintray.com/arturbosch/code-analysis/download_file?file_path=io%2Fgitlab%2Farturbosch%2Fdetekt%2Fdetekt-cli%2F1.1.1%2Fdetekt-cli-1.1.1-all.jar

--- a/Makefile
+++ b/Makefile
@@ -82,5 +82,5 @@ install-kotlin-linters: ## install ktlint and detekt for linting Kotlin output
 	( \
 	    cd detekt && \
 		git checkout 1.1.1 && \
-		./gradlew build shadowJar \
+		./gradlew build detekt-cli:shadowJar \
 	)

--- a/Makefile
+++ b/Makefile
@@ -70,3 +70,14 @@ dist: clean ## builds source and wheel package
 
 install: clean ## install the package to the active Python's site-packages
 	python setup.py install
+
+install-kotlin-linters: ## install ktlint and detekt for linting Kotlin output
+	mkdir ktlint
+	cd ktlint
+	curl -sSLO https://github.com/shyiko/ktlint/releases/download/0.29.0/ktlint && chmod a+x ktlint
+	cd ..
+	git clone https://github.com/arturbosch/detekt
+	cd detekt
+	git checkout 1.1.1 # Must match DETEKT_VERSION in tests/test_kotlin.py
+	./gradlew build shadowJar
+	cd ..

--- a/Makefile
+++ b/Makefile
@@ -73,11 +73,14 @@ install: clean ## install the package to the active Python's site-packages
 
 install-kotlin-linters: ## install ktlint and detekt for linting Kotlin output
 	mkdir ktlint
-	cd ktlint
-	curl -sSLO https://github.com/shyiko/ktlint/releases/download/0.29.0/ktlint && chmod a+x ktlint
-	cd ..
+	( \
+	    cd ktlint && \
+		curl -sSLO https://github.com/shyiko/ktlint/releases/download/0.29.0/ktlint && \
+		chmod a+x ktlint \
+	)
 	git clone https://github.com/arturbosch/detekt
-	cd detekt
-	git checkout 1.1.1 # Must match DETEKT_VERSION in tests/test_kotlin.py
-	./gradlew build shadowJar
-	cd ..
+	( \
+	    cd detekt && \
+		git checkout 1.1.1 && \
+		./gradlew build shadowJar \
+	)

--- a/glean_parser/templates/kotlin.geckoview.jinja2
+++ b/glean_parser/templates/kotlin.geckoview.jinja2
@@ -10,7 +10,7 @@ Jinja2 template is not. Please file bugs! #}
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-@file:Suppress("PackageNaming")
+@file:Suppress("PackageNaming", "MaxLineLength")
 package {{ namespace }}
 
 import {{ glean_namespace }}.private.BooleanMetricType // ktlint-disable import-ordering no-unused-imports

--- a/glean_parser/templates/kotlin.jinja2
+++ b/glean_parser/templates/kotlin.jinja2
@@ -19,7 +19,7 @@ Jinja2 template is not. Please file bugs! #}
         )
 {% if lazy %}    }{% endif %}{% endmacro %}
 
-@file:Suppress("PackageNaming")
+@file:Suppress("PackageNaming", "MaxLineLength")
 package {{ namespace }}
 
 import {{ glean_namespace }}.private.HistogramType // ktlint-disable import-ordering no-unused-imports
@@ -37,6 +37,7 @@ import {{ glean_namespace }}.private.LabeledMetricType // ktlint-disable import-
 internal object {{ category_name|Camelize }} {
 {% for obj in objs.values() %}
     {% if obj.extra_keys|length %}
+    @Suppress("ClassNaming", "EnumNaming")
     enum class {{ obj.name|camelize }}Keys {
     {% for key in obj.allowed_extra_keys %}
         {{ key|camelize }}{{ "," if not loop.last }}

--- a/tests/detekt.yml
+++ b/tests/detekt.yml
@@ -1,0 +1,2 @@
+build:
+  maxIssues: 0

--- a/tests/test_kotlin.py
+++ b/tests/test_kotlin.py
@@ -3,6 +3,7 @@
 # Any copyright is dedicated to the Public Domain.
 # http://creativecommons.org/publicdomain/zero/1.0/
 
+import os
 from pathlib import Path
 import subprocess
 
@@ -22,7 +23,9 @@ DETEKT_VERSION = "1.1.1"
 
 def run_detekt(files):
     detekt_exec = ROOT.parent / f"detekt-cli-{DETEKT_VERSION}-all.jar"
-    if detekt_exec.is_file():
+    # We want to make sure this runs on CI, but it's not required
+    # for local development
+    if detekt_exec.is_file() or "CI" in os.environ:
         subprocess.check_call(
             [
                 "java",
@@ -39,7 +42,9 @@ def run_detekt(files):
 
 def run_ktlint(files):
     ktlint_exec = ROOT.parent / "ktlint"
-    if ktlint_exec.is_file():
+    # We want to make sure this runs on CI, but it's not required
+    # for local development
+    if ktlint_exec.is_file() or "CI" in os.environ:
         subprocess.check_call([ktlint_exec] + files)
 
 

--- a/tests/test_kotlin.py
+++ b/tests/test_kotlin.py
@@ -23,10 +23,6 @@ DETEKT_VERSION = "1.1.1"
 def run_detekt(files):
     detekt_exec = (
         ROOT.parent
-        / "detekt"
-        / "detekt-cli"
-        / "build"
-        / "libs"
         / f"detekt-cli-{DETEKT_VERSION}-all.jar"
     )
     if detekt_exec.is_file():
@@ -45,7 +41,7 @@ def run_detekt(files):
 
 
 def run_ktlint(files):
-    ktlint_exec = ROOT.parent / "ktlint" / "ktlint"
+    ktlint_exec = ROOT.parent / "ktlint"
     if ktlint_exec.is_file():
         subprocess.check_call([ktlint_exec] + files)
 

--- a/tests/test_kotlin.py
+++ b/tests/test_kotlin.py
@@ -21,10 +21,7 @@ DETEKT_VERSION = "1.1.1"
 
 
 def run_detekt(files):
-    detekt_exec = (
-        ROOT.parent
-        / f"detekt-cli-{DETEKT_VERSION}-all.jar"
-    )
+    detekt_exec = ROOT.parent / f"detekt-cli-{DETEKT_VERSION}-all.jar"
     if detekt_exec.is_file():
         subprocess.check_call(
             [


### PR DESCRIPTION
This sets the stage for, but doesn't really fix [1590080](https://bugzilla.mozilla.org/show_bug.cgi?id=1590080).  This just adds `detekt` to the checks performed on the generated Kotlin code in CI, and adds the necessary supressions to make them pass.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
