### PR TITLE
1573191: Remove metric types that aren't implemented in glean-core

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,10 @@ Unreleased
 
 * `yamllint` has been added to test the YAML files on CI.
 
+* ⚠ Metric types that don't yet have implementations in glean-core have been
+  removed. This includes `enumeration`, `rate`, `usage`, and `use_counter`, as
+  well as many labeled metrics that don't exist.
+
 1.9.5 (2019-10-22)
 ------------------
 

--- a/docs/metrics-yaml.rst
+++ b/docs/metrics-yaml.rst
@@ -40,13 +40,9 @@ Metric parameters
 
 .. metric_parameter:: version
 
-.. metric_parameter:: values
-
 .. metric_parameter:: time_unit
 
 .. metric_parameter:: labels
-
-.. metric_parameter:: denominator
 
 .. metric_parameter:: extra_keys
 

--- a/glean_parser/kotlin.py
+++ b/glean_parser/kotlin.py
@@ -205,7 +205,6 @@ def output_kotlin(objs, output_dir, options={}):
         "allowed_extra_keys",
         "bucket_count",
         "category",
-        "denominator",
         "disabled",
         "histogram_type",
         "include_client_id",
@@ -216,7 +215,6 @@ def output_kotlin(objs, output_dir, options={}):
         "range_min",
         "send_in_pings",
         "time_unit",
-        "values",
     ]
 
     namespace = options.get("namespace", "GleanMetrics")

--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -174,12 +174,6 @@ class StringList(Metric):
 
 
 @dataclass
-class Enumeration(Metric):
-    typename = "enumeration"
-    values: List[str] = field(default_factory=list)
-
-
-@dataclass
 class Counter(Metric):
     typename = "counter"
 
@@ -249,28 +243,6 @@ class CustomDistribution(Metric):
 @dataclass
 class Datetime(TimeBase):
     typename = "datetime"
-
-
-@dataclass
-class UseCounter(Metric):
-    typename = "use_counter"
-    denominator: str = ""
-
-    def __post_init__(self, *args):
-        super().__post_init__(*args)
-
-        if not self.denominator:
-            raise ValueError("denominator is required on all use_counter metrics")
-
-
-@dataclass
-class Usage(Metric):
-    typename = "usage"
-
-
-@dataclass
-class Rate(Metric):
-    typename = "rate"
 
 
 @dataclass

--- a/glean_parser/schemas/metrics.1-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.1-0-0.schema.yaml
@@ -73,9 +73,6 @@ definitions:
 
             - `string_list`: a list of Unicode strings.
 
-            - `enumeration`: a string with a fixed set of values. Additional
-              properties: `values`_.
-
             - `counter`: A numeric value that can only be incremented.
 
             - `quantity`: A numeric value that is set directly. Only allowed for
@@ -89,21 +86,6 @@ definitions:
 
             - `datetime`: A date/time value. Represented as an ISO datetime in
               UTC. Additional properties: `time_unit`_.
-
-            - `use_counter`: Records the value of one of more values in relation
-              to another value. Represented internally as a list of numerators
-              and denominator, all of which can be incremented separately.
-              Additional properties: `labels`_, `denominator`_.
-
-            - `usage`: Record whether a feature is used. This is functionally
-              equivalent to a boolean metric type, except the analysis and
-              visualization side may present it differently, knowing that it
-              indicates the usage of a feature.
-
-            - `rate`: Record the rate of an event over time. This is
-              functionally equivalent to a counter, except the analysis and
-              visualization will tie it to the duration of the ping to display
-              it as a rate over time.
 
             - `uuid`: Record a UUID v4.
 
@@ -121,17 +103,14 @@ definitions:
               of the metric to be stored at a given set of labels. The labeled
               metric types include:
 
-                `labeled_boolean`, `labeled_string`, `labeled_enumeration`,
-                `labeled_counter`, `labeled_timing_distribution`,
-                `labeled_datetime`, `labeled_use_counter`, `labeled_usage`,
-                `labeled_rate`.
+                `labeled_boolean`, `labeled_string`, `labeled_counter`.
+
         type: string
         enum:
           - event
           - boolean
           - string
           - string_list
-          - enumeration
           - counter
           - quantity
           - timespan
@@ -139,9 +118,6 @@ definitions:
           - custom_distribution
           - memory_distribution
           - datetime
-          - use_counter
-          - usage
-          - rate
           - uuid
           - labeled_boolean
           - labeled_string
@@ -266,16 +242,6 @@ definitions:
           The version of the metric. A monotonically increasing value. If not
           provided, defaults to 0.
 
-      values:
-        title: Supported values
-        description: |
-          A list of the supported enumeration values.
-
-          Valid when `type`_ is `enumeration`.
-        type: array
-        items:
-          type: string
-
       time_unit:
         title: Time unit
         description: |
@@ -334,15 +300,6 @@ definitions:
               $ref: "#/definitions/labeled_metric_id"
             maxItems: 16
           - type: "null"
-
-      denominator:
-        title: Denominator
-        description: |
-          The name of the denominator value for a use counter.
-
-          Valid when `type`_ is `use_counter`.
-        allOf:
-          - $ref: "#/definitions/snake_case"
 
       extra_keys:
         title: Extra keys

--- a/tests/data/core.yaml
+++ b/tests/data/core.yaml
@@ -154,12 +154,8 @@ environment:
     expires: 2100-01-01
 
   os:
-    type: enumeration
+    type: string
     lifetime: application
-    values:
-      - linux
-      - android
-      - ios
     description: The name of the operating system.
     bugs:
       - 1137353
@@ -203,11 +199,8 @@ environment:
     expires: 2100-01-01
 
   arch:
-    type: enumeration
+    type: string
     lifetime: application
-    values:
-      - arm
-      - x86
     description: The architecture of the device.
     bugs:
       - 1137353

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -210,17 +210,6 @@ def test_multiple_errors():
     assert len(errors) == 2
 
 
-def test_required_denominator():
-    """denominator is required on use_counter"""
-    contents = [{"category": {"metric": {"type": "use_counter"}}}]
-
-    contents = [util.add_required(x) for x in contents]
-    all_metrics = parser.parse_objects(contents)
-    errors = list(all_metrics)
-    assert len(errors) == 1
-    assert "denominator is required" in errors[0]
-
-
 def test_event_must_be_ping_lifetime():
     contents = [{"category": {"metric": {"type": "event", "lifetime": "user"}}}]
 


### PR DESCRIPTION
This is tech debt, but it will come in handy to have this cleaned-out for the Python bindings work over in glean-core.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
