### PR TITLE
Document pings that are sent if empty and document if no metrics…

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ Unreleased
 * The `translate` command will no longer clear extra files in the output directory.
 * BUGFIX: Ensure all newlines in comments are prefixed with comment markers
 * BUGFIX: Escape Swift keywords in variable names in generated code
+* Generate documentation for pings that are sent if empty
 
 1.12.0 (2019-11-27)
 -------------------

--- a/glean_parser/markdown.py
+++ b/glean_parser/markdown.py
@@ -79,6 +79,13 @@ def ping_docs(ping_name):
     return f"https://mozilla.github.io/glean/book/user/pings/{ping_name}.html"
 
 
+def if_empty(ping_name, custom_pings_cache={}):
+    return (
+        custom_pings_cache.get(ping_name)
+        and custom_pings_cache[ping_name].send_if_empty
+    )
+
+
 def output_markdown(objs, output_dir, options={}):
     """
     Given a tree of objects, output Markdown docs to `output_dir`.
@@ -116,6 +123,8 @@ def output_markdown(objs, output_dir, options={}):
             # the description
             if isinstance(obj, pings.Ping):
                 custom_pings_cache[obj.name] = obj
+                if obj.send_if_empty:
+                    metrics_by_pings[obj.name] = []
             elif obj.is_internal_metric():
                 # This is an internal Glean metric, and we don't
                 # want docs for it.
@@ -139,6 +148,7 @@ def output_markdown(objs, output_dir, options={}):
             ("extra_info", extra_info),
             ("metrics_docs", metrics_docs),
             ("ping_desc", lambda x: ping_desc(x, custom_pings_cache)),
+            ("ping_send_if_empty", lambda x: if_empty(x, custom_pings_cache)),
             ("ping_docs", ping_docs),
         ),
     )

--- a/glean_parser/templates/markdown.jinja2
+++ b/glean_parser/templates/markdown.jinja2
@@ -23,6 +23,10 @@ Sorry about that.
 See the Glean SDK documentation for the [`{{ ping_name }}` ping]({{ ping_name|ping_docs }}).
 {% endif %}
 {% endif %}
+{% if ping_name|ping_send_if_empty %}
+This ping is sent if empty.
+{% endif %}
+{% if metrics_by_pings[ping_name] %}
 The following metrics are added to the ping:
 
 | Name | Type | Description | Data reviews | Extras | Expiration |
@@ -43,6 +47,9 @@ The following metrics are added to the ping:
 {%- endif -%} |
 {{- metric.expires }} |
 {% endfor %}
+{% else %}
+This ping contains no metrics.
+{% endif %}
 
 {% endfor %}
 

--- a/tests/data/pings.yaml
+++ b/tests/data/pings.yaml
@@ -31,3 +31,15 @@ really_custom_ping:
     - http://nowhere.com/reviews
   notification_emails:
     - CHANGE-ME@test-only.com
+
+custom_ping_might_be_empty:
+  description:
+    This is another custom ping
+  include_client_id: true
+  send_if_empty: true
+  bugs:
+    - 1137353
+  data_reviews:
+    - http://nowhere.com/reviews
+  notification_emails:
+    - CHANGE-ME@test-only.com


### PR DESCRIPTION
e.g. it. might render this as:

```
## custom_ping_might_be_empty
This is another custom ping
This ping is sent if empty.
This ping contains no metrics.
```

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
