### PR TITLE
WIP: 1600257: Support Python 3.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,11 +29,6 @@ commands:
             - run:
                     name: test
                     command: make test
-            - run:
-                    name: make-docs
-                    command: |
-                        make docs
-                        touch docs/_build/html/.nojekyll
 
 jobs:
     build-35:
@@ -57,6 +52,11 @@ jobs:
             - persist_to_workspace:
                     root: docs/_build
                     paths: html
+            - run:
+                    name: make-docs
+                    command: |
+                        make docs
+                        touch docs/_build/html/.nojekyll
 
     build-38:
         docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 commands:
     test-python-version:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
             - image: circleci/python:3.7.5
         steps:
             - test-python-version
-            - persist-to-workspace:
+            - persist_to_workspace:
                     root: docs/_build
                     paths: html
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,49 +1,68 @@
 version: 2
 
-test-template: &test-template
-    steps:
-        - checkout
-        - run:
-                name: environment
-                command: |
-                    echo 'export PATH=.:$HOME/.local/bin:$PATH' >> $BASH_ENV
-        - run:
-                name: install
-                command: |
-                    pip install --progress-bar off --user -U -r requirements_dev.txt
-                    sudo apt update -q
-                    sudo apt upgrade -q
-                    sudo apt install openjdk-11-jdk-headless
-                    make install-kotlin-linters
-
-        - run:
-                name: lint
-                command: make lint
-        - run:
-                name: install
-                command: python setup.py install --user
-        - run:
-                name: test
-                command: make test
-        - run:
-                name: make-docs
-                command: |
-                    make docs
-                    touch docs/_build/html/.nojekyll
-        - persist-to-workspace:
-                root: docs/_build
-                paths: html
+commands:
+    test-python-version:
+        parameters:
+            requirements-file:
+                type: string
+                default: "requirements_dev.txt"
+        steps:
+            - checkout
+            - run:
+                    name: environment
+                    command: |
+                        echo 'export PATH=.:$HOME/.local/bin:$PATH' >> $BASH_ENV
+            - run:
+                    name: install
+                    command: |
+                        pip install --progress-bar off --user -U -r <<parameters.requirements-file>>
+                        sudo apt update -q
+                        sudo apt upgrade -q
+                        sudo apt install openjdk-11-jdk-headless
+                        make install-kotlin-linters
+            - run:
+                    name: lint
+                    command: make lint
+            - run:
+                    name: install
+                    command: python setup.py install --user
+            - run:
+                    name: test
+                    command: make test
+            - run:
+                    name: make-docs
+                    command: |
+                        make docs
+                        touch docs/_build/html/.nojekyll
+            - persist-to-workspace:
+                    root: docs/_build
+                    paths: html
 
 jobs:
+    build-35:
+        docker:
+            - image: circleci/python:3.5.9
+        steps:
+            - test-python-version:
+                    requirements-file: requirements_dev_py35.txt
+
+    build-36:
+        docker:
+            - image: circleci/python:3.6.9
+        steps:
+            - test-python-version
+
     build-37:
         docker:
             - image: circleci/python:3.7.5
-        <<: *test-template
+        steps:
+            - test-python-version
 
     build-38:
         docker:
             - image: circleci/python:3.8.0
-        <<: *test-template
+        steps:
+            - test-python-version
 
     docs-deploy:
         docker:
@@ -90,6 +109,14 @@ workflows:
     version: 2
     build:
         jobs:
+            - build-35:
+                    filters:
+                        tags:
+                            only: /.*/
+            - build-36:
+                    filters:
+                        tags:
+                            only: /.*/
             - build-37:
                     filters:
                         tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,14 +49,14 @@ jobs:
             - image: circleci/python:3.7.5
         steps:
             - test-python-version
-            - persist_to_workspace:
-                    root: docs/_build
-                    paths: html
             - run:
                     name: make-docs
                     command: |
                         make docs
                         touch docs/_build/html/.nojekyll
+            - persist_to_workspace:
+                    root: docs/_build
+                    paths: html
 
     build-38:
         docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,9 +34,6 @@ commands:
                     command: |
                         make docs
                         touch docs/_build/html/.nojekyll
-            - persist-to-workspace:
-                    root: docs/_build
-                    paths: html
 
 jobs:
     build-35:
@@ -57,6 +54,9 @@ jobs:
             - image: circleci/python:3.7.5
         steps:
             - test-python-version
+            - persist-to-workspace:
+                    root: docs/_build
+                    paths: html
 
     build-38:
         docker:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -87,6 +87,10 @@ Ready to contribute? Here's how to set up `glean_parser` for local development.
 
     $ pip install -r requirements_dev.txt
 
+   If using Python 3.5:
+
+    $ pip install -r requirements_dev_35.txt
+
    Optionally, if you want to ensure that the generated Kotlin code lints correctly, install a Java SDK, and then run::
 
      $ make install-kotlin-linters
@@ -113,7 +117,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 3.7.
+3. The pull request should work for Python 3.5, 3.6, 3.7 and 3.8 (The CI system will take care of testing all of these Python versions).
 4. The pull request should update the changelog in `HISTORY.rst`.
 
 Tips

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,8 @@ History
 Unreleased
 ----------
 
+* glean_parser now supports Python versions 3.5, 3.6, 3.7 and 3.8.
+
 1.13.0 (2019-12-04)
 -------------------
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,9 @@ clean-test: ## remove test and coverage artifacts
 
 lint: ## check style with flake8
 	python3 -m flake8 glean_parser tests
-	python3 -m black --check glean_parser tests
+	if [[ `python3 --version` =~ "Python 3\.[678]\..*" ]]; then \
+		python3 -m black --check glean_parser tests; \
+	fi
 	python3 -m yamllint glean_parser tests
 
 test: ## run tests quickly with the default Python

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ The full documentation is available `here <https://mozilla.github.io/glean_parse
 Requirements
 ------------
 
-- Python 3.7 (or later)
+- Python 3.5 (or later)
 
 The following library requirements are installed automatically when glean_parser
 is installed by `pip`.
@@ -30,6 +30,14 @@ is installed by `pip`.
 - Jinja2
 - jsonschema
 - PyYAML
+
+Additionally on Python 3.6 and 3.5:
+
+- backports-datetime-fromisoformat
+
+And on Python 3.5:
+
+- pep487
 
 Usage
 -----

--- a/glean_parser/__init__.py
+++ b/glean_parser/__init__.py
@@ -16,3 +16,11 @@ except DistributionNotFound:
 
 __author__ = """Michael Droettboom"""
 __email__ = "mdroettboom@mozilla.com"
+
+import sys
+
+# Import a backport of datetime.datetime.fromisoformat()
+if sys.version_info < (3, 7):
+    from backports.datetime_fromisoformat import MonkeyPatch
+
+    MonkeyPatch.patch_fromisoformat()

--- a/glean_parser/markdown.py
+++ b/glean_parser/markdown.py
@@ -76,7 +76,7 @@ def ping_docs(ping_name):
     if ping_name not in pings.RESERVED_PING_NAMES:
         return ""
 
-    return f"https://mozilla.github.io/glean/book/user/pings/{ping_name}.html"
+    return "https://mozilla.github.io/glean/book/user/pings/{}.html".format(ping_name)
 
 
 def if_empty(ping_name, custom_pings_cache={}):
@@ -156,7 +156,7 @@ def output_markdown(objs, output_dir, options={}):
     filename = "metrics.md"
     filepath = output_dir / filename
 
-    with open(filepath, "w", encoding="utf-8") as fd:
+    with filepath.open("w", encoding="utf-8") as fd:
         fd.write(template.render(metrics_by_pings=metrics_by_pings))
         # Jinja2 squashes the final newline, so we explicitly add it
         fd.write("\n")

--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -23,9 +23,6 @@ else:
     base_object = object
 
 
-_builtin_type = type
-
-
 class Lifetime(enum.Enum):
     ping = 0
     user = 1

--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -8,13 +8,22 @@
 Classes for each of the high-level metric types.
 """
 
-import dataclasses
-from dataclasses import dataclass, field, InitVar
 import enum
-from typing import Dict, List, Set, Union
+import sys
 
-from . import parser
 from . import util
+
+
+# Import a backport of PEP487 to support __init_subclass__
+if sys.version_info < (3, 6):
+    import pep487
+
+    base_object = pep487.PEP487Object
+else:
+    base_object = object
+
+
+_builtin_type = type
 
 
 class Lifetime(enum.Enum):
@@ -23,11 +32,70 @@ class Lifetime(enum.Enum):
     application = 2
 
 
-@dataclass
-class Metric:
+class Metric(base_object):
     glean_internal_metric_cat = "glean.internal.metrics"
     metric_types = {}
     default_store_names = ["metrics"]
+
+    def __init__(
+        self,
+        type,
+        category,
+        name,
+        bugs,
+        description,
+        notification_emails,
+        expires,
+        data_reviews=None,
+        version=0,
+        disabled=False,
+        lifetime="ping",
+        send_in_pings=None,
+        unit="",
+        gecko_datapoint="",
+        no_lint=None,
+        _config=None,
+        _validated=False,
+    ):
+        # Avoid cyclical import
+        from . import parser
+
+        self.type = type
+        self.category = category
+        self.name = name
+        self.bugs = bugs
+        self.description = description
+        self.notification_emails = notification_emails
+        self.expires = expires
+        if data_reviews is None:
+            data_reviews = []
+        self.data_reviews = data_reviews
+        self.version = version
+        self.disabled = disabled
+        self.lifetime = getattr(Lifetime, lifetime)
+        if send_in_pings is None:
+            send_in_pings = ["default"]
+        self.send_in_pings = send_in_pings
+        self.unit = unit
+        self.gecko_datapoint = gecko_datapoint
+        if no_lint is None:
+            no_lint = []
+        self.no_lint = no_lint
+
+        # _validated indicates whether this metric has already been jsonschema
+        # validated (but not any of the Python-level validation).
+        if not _validated:
+            data = {
+                "$schema": parser.METRICS_ID,
+                self.category: {self.name: self.serialize()},
+            }
+            for error in parser.validate(data):
+                raise ValueError(error)
+
+        # Metrics in the special category "glean.internal.metrics" need to have
+        # an empty category string when identifying the metrics in the ping.
+        if self.category == Metric.glean_internal_metric_cat:
+            self.category = ""
 
     def __init_subclass__(cls, **kwargs):
         # Create a mapping of all of the subclasses of this class
@@ -63,7 +131,7 @@ class Metric:
         """
         Serialize the metric back to JSON object model.
         """
-        d = dataclasses.asdict(self)
+        d = self.__dict__.copy()
         # Convert enum fields back to strings
         for key, val in d.items():
             if isinstance(val, enum.Enum):
@@ -84,66 +152,6 @@ class Metric:
             return self.name
         return ".".join((self.category, self.name))
 
-    def __post_init__(self, _config, _validated):
-        # Convert enum fields to Python enums
-        for f in dataclasses.fields(self):
-            if isinstance(f.type, type) and issubclass(f.type, enum.Enum):
-                setattr(self, f.name, getattr(f.type, getattr(self, f.name)))
-            if f.type == Set[str]:
-                value = getattr(self, f.name)
-                if isinstance(value, list):
-                    setattr(self, f.name, set(value))
-
-        self.validate_expires(self.expires)
-        if hasattr(self, "extra_keys"):
-            self.validate_extra_keys(self.extra_keys, _config)
-
-        # _validated indicates whether this metric has already been jsonschema
-        # validated (but not any of the Python-level validation).
-        if not _validated:
-            data = {
-                "$schema": parser.METRICS_ID,
-                self.category: {self.name: self.serialize()},
-            }
-            for error in parser.validate(data):
-                raise ValueError(error)
-
-        # Metrics in the special category "glean.internal.metrics" need to have
-        # an empty category string when identifying the metrics in the ping.
-        if self.category == Metric.glean_internal_metric_cat:
-            self.category = ""
-
-    type: str
-
-    # Metadata
-    category: str
-    name: str
-    bugs: List[Union[int, str]]
-    description: str
-    notification_emails: List[str]
-    expires: str
-    data_reviews: List[str] = field(default_factory=list)
-    version: int = 0
-    disabled: bool = False
-
-    # Ping-related properties
-    lifetime: Lifetime = "ping"
-    send_in_pings: List[str] = field(default_factory=lambda: ["default"])
-
-    unit: str = ""
-
-    # The following is a Gecko-specific property for using the Glean SDK
-    # with GeckoView metrics. See bug 1566356 for more context.
-    gecko_datapoint: str = ""
-
-    # Lint checks to disable for this metric.
-    no_lint: List[str] = field(default_factory=list)
-
-    # Implementation detail -- these are parameters to the constructor that
-    # aren't stored in the dataclass object.
-    _config: InitVar[dict] = {}
-    _validated: InitVar[bool] = False
-
     def is_disabled(self):
         return self.disabled or self.is_expired()
 
@@ -158,27 +166,22 @@ class Metric:
         return self.category in (Metric.glean_internal_metric_cat, "")
 
 
-@dataclass
 class Boolean(Metric):
     typename = "boolean"
 
 
-@dataclass
 class String(Metric):
     typename = "string"
 
 
-@dataclass
 class StringList(Metric):
     typename = "string_list"
 
 
-@dataclass
 class Counter(Metric):
     typename = "counter"
 
 
-@dataclass
 class Quantity(Metric):
     typename = "quantity"
 
@@ -193,17 +196,16 @@ class TimeUnit(enum.Enum):
     day = 6
 
 
-@dataclass
 class TimeBase(Metric):
-    time_unit: TimeUnit = "millisecond"
+    def __init__(self, *args, **kwargs):
+        self.time_unit = getattr(TimeUnit, kwargs.pop("time_unit", "millisecond"))
+        super().__init__(*args, **kwargs)
 
 
-@dataclass
 class Timespan(TimeBase):
     typename = "timespan"
 
 
-@dataclass
 class TimingDistribution(TimeBase):
     typename = "timing_distribution"
 
@@ -215,11 +217,12 @@ class MemoryUnit(enum.Enum):
     gigabyte = 3
 
 
-@dataclass
 class MemoryDistribution(Metric):
     typename = "memory_distribution"
 
-    memory_unit: MemoryUnit = "byte"
+    def __init__(self, *args, **kwargs):
+        self.memory_unit = getattr(MemoryUnit, kwargs.pop("memory_unit", "byte"))
+        super().__init__(*args, **kwargs)
 
 
 class HistogramType(enum.Enum):
@@ -227,30 +230,32 @@ class HistogramType(enum.Enum):
     exponential = 1
 
 
-@dataclass
 class CustomDistribution(Metric):
     typename = "custom_distribution"
 
-    range_min: int = 1
-    # The defaults must be provided here to work with Python's @dataclass,
-    # however, in practice, these parameters are required by the schema,
-    # so they will never be used.
-    range_max: int = -1
-    bucket_count: int = -1
-    histogram_type: HistogramType = HistogramType.exponential
+    def __init__(self, *args, **kwargs):
+        self.range_min = kwargs.pop("range_min", 1)
+        self.range_max = kwargs.pop("range_max")
+        self.bucket_count = kwargs.pop("bucket_count")
+        self.histogram_type = getattr(
+            HistogramType, kwargs.pop("histogram_type", "exponential")
+        )
+        super().__init__(*args, **kwargs)
 
 
-@dataclass
 class Datetime(TimeBase):
     typename = "datetime"
 
 
-@dataclass
 class Event(Metric):
     typename = "event"
+
     default_store_names = ["events"]
 
-    extra_keys: Dict[str, str] = field(default_factory=dict)
+    def __init__(self, *args, **kwargs):
+        self.extra_keys = kwargs.pop("extra_keys", {})
+        self.validate_extra_keys(self.extra_keys, kwargs.get("_config", {}))
+        super().__init__(*args, **kwargs)
 
     @property
     def allowed_extra_keys(self):
@@ -268,42 +273,40 @@ class Event(Metric):
             )
 
 
-@dataclass
 class Uuid(Metric):
     typename = "uuid"
 
 
-@dataclass
 class Labeled(Metric):
     labeled = True
-    # Start the labels as a List to preserve the order from `metrics.yaml`
-    labels: List[str] = None
 
-    def __post_init__(self, *args):
-        ordered_labels = self.labels
+    def __init__(self, *args, **kwargs):
+        labels = kwargs.pop("labels", None)
+        if labels is not None:
+            self.ordered_labels = labels
+            self.labels = set(labels)
+        else:
+            self.ordered_labels = None
+            self.labels = None
+        super().__init__(*args, **kwargs)
 
-        # If any, turn the labels into a Set to properly inialize the Metric object.
-        # This is important because Kotlin code needs this labels as a Set
-        if self.labels is not None:
-            self.labels = set(ordered_labels)
-        super().__post_init__(*args)
-
-        # After initializing the Metric object, add the ordered_labels to it.
-        # If we do this step before calling the __post_init__ for the Metric class,
-        # the metric schema validation will fail
-        self.ordered_labels = ordered_labels
+    def serialize(self):
+        """
+        Serialize the metric back to JSON object model.
+        """
+        d = super().serialize()
+        d["labels"] = self.ordered_labels
+        del d["ordered_labels"]
+        return d
 
 
-@dataclass
 class LabeledBoolean(Labeled, Boolean):
     typename = "labeled_boolean"
 
 
-@dataclass
 class LabeledString(Labeled, String):
     typename = "labeled_string"
 
 
-@dataclass
 class LabeledCounter(Labeled, Counter):
     typename = "labeled_counter"

--- a/glean_parser/swift.py
+++ b/glean_parser/swift.py
@@ -92,7 +92,7 @@ def variable_name(var):
     Returns a valid Swift variable name, escaping keywords if necessary.
     """
     if var in SWIFT_RESERVED_NAMES:
-        return f"`{var}`"
+        return "`" + var + "`"
     else:
         return var
 

--- a/glean_parser/swift.py
+++ b/glean_parser/swift.py
@@ -45,7 +45,7 @@ def swift_datatypes_filter(value):
                     first = False
                 yield "]"
             elif isinstance(value, enum.Enum):
-                yield (f".{util.camelize(value.name)}")
+                yield ("." + util.camelize(value.name))
             elif isinstance(value, set):
                 yield "["
                 first = True
@@ -69,10 +69,10 @@ def type_name(obj):
     """
     if isinstance(obj, metrics.Event):
         if len(obj.extra_keys):
-            enumeration = f"{util.Camelize(obj.name)}Keys"
+            enumeration = util.Camelize(obj.name) + "Keys"
         else:
             enumeration = "NoExtraKeys"
-        return f"EventMetricType<{enumeration}>"
+        return "EventMetricType<{}>".format(enumeration)
     return class_name(obj.type)
 
 
@@ -84,7 +84,7 @@ def class_name(obj_type):
         return "Ping"
     if obj_type.startswith("labeled_"):
         obj_type = obj_type[8:]
-    return f"{util.Camelize(obj_type)}MetricType"
+    return util.Camelize(obj_type) + "MetricType"
 
 
 def variable_name(var):
@@ -144,7 +144,7 @@ def output_swift(objs, output_dir, options={}):
             getattr(metric, "labeled", False) for metric in category_val.values()
         )
 
-        with open(filepath, "w", encoding="utf-8") as fd:
+        with filepath.open("w", encoding="utf-8") as fd:
             fd.write(
                 template.render(
                     category_name=category_key,

--- a/glean_parser/translate.py
+++ b/glean_parser/translate.py
@@ -85,7 +85,7 @@ def translate(input_filepaths, output_format, output_dir, options={}, parser_con
                     for filepath in output_dir.glob(extensions):
                         filepath.unlink()
                 if len(list(output_dir.iterdir())):
-                    print(f"Extra contents found in '{output_dir}'.")
+                    print("Extra contents found in '{}'.".format(output_dir))
 
         # We can't use shutil.copytree alone if the directory already exists.
         # However, if it doesn't exist, make sure to create one otherwise

--- a/glean_parser/translate.py
+++ b/glean_parser/translate.py
@@ -56,7 +56,7 @@ def translate(input_filepaths, output_format, output_dir, options={}, parser_con
         See `parser.parse_metrics` for more info.
     """
     if output_format not in OUTPUTTERS:
-        raise ValueError(f"Unknown output format '{output_format}'")
+        raise ValueError("Unknown output format '{}'".format(output_format))
 
     all_objects = parser.parse_objects(input_filepaths, parser_config)
 
@@ -90,8 +90,8 @@ def translate(input_filepaths, output_format, output_dir, options={}, parser_con
         # We can't use shutil.copytree alone if the directory already exists.
         # However, if it doesn't exist, make sure to create one otherwise
         # shutil.copy will fail.
-        os.makedirs(output_dir, exist_ok=True)
+        os.makedirs(str(output_dir), exist_ok=True)
         for filename in tempdir_path.glob("*"):
-            shutil.copy(filename, output_dir)
+            shutil.copy(str(filename), str(output_dir))
 
     return 0

--- a/requirements_dev_py35.txt
+++ b/requirements_dev_py35.txt
@@ -1,0 +1,11 @@
+coverage==4.5.2
+flake8==3.7.8
+m2r==0.2.1
+pip
+pytest-runner==4.4
+pytest==4.3.0
+Sphinx==1.8.4
+twine==1.13.0
+watchdog==0.9.0
+wheel
+yamllint==1.18.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bdist_wheel]
-universal = 1
+python_tag = py3
 
 [flake8]
 exclude = docs

--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,9 @@ requirements = [
     'inflection>=0.3.1',
     'Jinja2>=2.10.1',
     'jsonschema>=3.0.2',
-    'pep487==1.0.1'
+    'pep487==1.0.1',
     'PyYAML>=3.13',
-    'yamllint>=1.18.0'
+    'yamllint>=1.18.0',
 ]
 
 setup_requirements = ['pytest-runner', 'setuptools-scm']

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,9 @@ import sys
 from setuptools import setup, find_packages
 
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 5):
     print(
-        "glean_parser requires at least Python 3.7",
+        "glean_parser requires at least Python 3.5",
         file=sys.stderr
     )
     sys.exit(1)
@@ -27,13 +27,15 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 requirements = [
+    'appdirs>=1.4.3',
+    'backports-datetime-fromisoformat==1.0.0',
     'Click>=7.0',
-    'PyYAML>=3.13',
-    'jsonschema>=3.0.2',
+    'diskcache>=4.0.0',
     'inflection>=0.3.1',
     'Jinja2>=2.10.1',
-    'diskcache>=4.0.0',
-    'appdirs>=1.4.3',
+    'jsonschema>=3.0.2',
+    'pep487==1.0.1'
+    'PyYAML>=3.13',
     'yamllint>=1.18.0'
 ]
 
@@ -49,7 +51,10 @@ setup(
         'Intended Audience :: Developers',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     description="Parser tools for Mozilla's Glean telemetry",
     entry_points={

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,7 +42,7 @@ def test_translate(tmpdir):
         ],
     )
     assert result.exit_code == 0
-    assert set(os.listdir(tmpdir)) == set(
+    assert set(os.listdir(str(tmpdir))) == set(
         [
             "CorePing.kt",
             "Telemetry.kt",
@@ -51,9 +51,9 @@ def test_translate(tmpdir):
             "GleanInternalMetrics.kt",
         ]
     )
-    for filename in os.listdir(tmpdir):
-        path = tmpdir / filename
-        with open(path) as fd:
+    for filename in os.listdir(str(tmpdir)):
+        path = Path(str(tmpdir)) / filename
+        with path.open() as fd:
             content = fd.read()
         assert "package Foo" in content
 
@@ -73,7 +73,7 @@ def test_translate_errors(tmpdir):
         ],
     )
     assert result.exit_code == 1
-    assert len(os.listdir(tmpdir)) == 0
+    assert len(os.listdir(str(tmpdir))) == 0
 
 
 def test_translate_invalid_format(tmpdir):

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -16,7 +16,7 @@ ROOT = Path(__file__).parent
 
 def test_parser(tmpdir):
     """Test translating metrics to Markdown files."""
-    tmpdir = Path(tmpdir)
+    tmpdir = Path(str(tmpdir))
 
     translate.translate(
         ROOT / "data" / "core.yaml",
@@ -29,7 +29,7 @@ def test_parser(tmpdir):
     assert set(x.name for x in tmpdir.iterdir()) == set(["metrics.md"])
 
     # Make sure descriptions made it in
-    with open(tmpdir / "metrics.md", "r", encoding="utf-8") as fd:
+    with (tmpdir / "metrics.md").open("r", encoding="utf-8") as fd:
         content = fd.read()
         assert "is assembled out of the box by the Glean SDK." in content
         # Make sure the table structure is in place
@@ -63,7 +63,7 @@ def test_extra_info_generator():
         notification_emails=["nobody@example.com"],
         description="description...",
         expires="never",
-        labels={"label"},
+        labels=["label"],
     )
 
     assert markdown.extra_info(labeled) == [("label", None)]

--- a/tests/test_pings.py
+++ b/tests/test_pings.py
@@ -34,7 +34,7 @@ def test_reserved_metrics_category():
     util.add_required(content)
     errors = list(parser.parse_objects(content))
     assert len(errors) == 1
-    assert "reserved as a category name" in errors[0]
+    assert "reserved" in errors[0]
 
 
 def test_snake_case_ping_names():

--- a/tests/test_swift.py
+++ b/tests/test_swift.py
@@ -3,6 +3,7 @@
 # Any copyright is dedicated to the Public Domain.
 # http://creativecommons.org/publicdomain/zero/1.0/
 
+from collections import OrderedDict
 from pathlib import Path
 import shutil
 import subprocess
@@ -18,7 +19,7 @@ ROOT = Path(__file__).parent
 
 def test_parser(tmpdir):
     """Test translating metrics to Swift files."""
-    tmpdir = Path(tmpdir)
+    tmpdir = Path(str(tmpdir))
 
     translate.translate(
         ROOT / "data" / "core.yaml", "swift", tmpdir, {}, {"allow_reserved": True}
@@ -35,15 +36,15 @@ def test_parser(tmpdir):
     )
 
     # Make sure descriptions made it in
-    with open(tmpdir / "CorePing.swift", "r", encoding="utf-8") as fd:
+    with (tmpdir / "CorePing.swift").open("r", encoding="utf-8") as fd:
         content = fd.read()
         assert "True if the user has set Firefox as the default browser." in content
 
-    with open(tmpdir / "Telemetry.swift", "r", encoding="utf-8") as fd:
+    with (tmpdir / "Telemetry.swift").open("r", encoding="utf-8") as fd:
         content = fd.read()
         assert "جمع 搜集" in content
 
-    with open(tmpdir / "GleanInternalMetrics.swift", "r", encoding="utf-8") as fd:
+    with (tmpdir / "GleanInternalMetrics.swift").open("r", encoding="utf-8") as fd:
         content = fd.read()
         assert 'category: ""' in content
 
@@ -66,7 +67,8 @@ def test_swift_generator():
     assert kdf("\n") == r'"\n"'
     assert kdf([42, "\n"]) == r'[42, "\n"]'
     assert (
-        kdf({"key": "value", "key2": "value2"}) == r'["key": "value", "key2": "value2"]'
+        kdf(OrderedDict([("key", "value"), ("key2", "value2")]))
+        == r'["key": "value", "key2": "value2"]'
     )
     assert kdf(metrics.Lifetime.ping) == ".ping"
 

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -120,10 +120,10 @@ def test_translate_send_in_pings(tmpdir):
 
 
 def test_translate_dont_remove_extra_files(tmpdir):
-    output = Path(tmpdir) / "foo"
+    output = Path(str(tmpdir)) / "foo"
     output.mkdir()
 
-    with open(output / "extra.txt", "w") as fd:
+    with (output / "extra.txt").open("w") as fd:
         fd.write("\n")
 
     translate.translate(

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -25,7 +25,7 @@ def test_translate_unknown_format():
 
 
 def test_translate_missing_directory(tmpdir):
-    output = Path(tmpdir) / "foo"
+    output = Path(str(tmpdir)) / "foo"
 
     translate.translate(
         ROOT / "data" / "core.yaml",
@@ -38,7 +38,7 @@ def test_translate_missing_directory(tmpdir):
 
 
 def test_translate_remove_obsolete_kotlin_files(tmpdir):
-    output = Path(tmpdir) / "foo"
+    output = Path(str(tmpdir)) / "foo"
 
     translate.translate(
         ROOT / "data" / "core.yaml",
@@ -55,7 +55,7 @@ def test_translate_remove_obsolete_kotlin_files(tmpdir):
 
 
 def test_translate_retains_existing_markdown_files(tmpdir):
-    output = Path(tmpdir) / "foo"
+    output = Path(str(tmpdir)) / "foo"
 
     translate.translate(
         ROOT / "data" / "core.yaml",
@@ -66,7 +66,7 @@ def test_translate_retains_existing_markdown_files(tmpdir):
 
     # Move the file to a different location, translate always writes to
     # metrics.md.
-    shutil.move(output / "metrics.md", output / "old.md")
+    shutil.move(str(output / "metrics.md"), str(output / "old.md"))
 
     assert len(list(output.iterdir())) == 1
 


### PR DESCRIPTION
This PR makes me :cry:

Basically, the changes are:
- Don't use `dataclasses`.  Most of the type checking it provided for us was redundant anyway, since we validate using the JSON schema before getting there anyway.
- `pathlib.Path` didn't play well with the rest of the `stdlib` in Python 3.5, so we need to do more explicit casting to strings.
- `datetime.datetime.fromisoformat()` is new in 3.7, so this uses a backport library
- `__init_subclass__` is new in 3.6, so we use the `pep487` backport library for that
- f-strings are new in 3.6, so we have to go back to `str.format()` :nauseated_face: 
- Dictionaries have a stable ordering in 3.7, so here we have to use `OrderedDict` in a number of places to make the tests pass consistently.

And, of course, this also adds CI for Python 3.5 and 3.6.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
