### PR TITLE
Bug 1601270 Restrict ping names to be kebab-case

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,7 @@ Unreleased
 -------------------
 
 * glean_parser now supports Python versions 3.5, 3.6, 3.7 and 3.8.
+* Restrict new pings names to be kebab-case and change `all_pings` to `all-pings`
 
 1.13.0 (2019-12-04)
 -------------------

--- a/glean_parser/markdown.py
+++ b/glean_parser/markdown.py
@@ -44,7 +44,7 @@ def ping_desc(ping_name, custom_pings_cache={}):
             "This is a built-in ping that is assembled out of the "
             "box by the Glean SDK."
         )
-    elif ping_name == "all_pings":
+    elif ping_name == "all-pings":
         desc = "These metrics are sent in every ping."
     elif ping_name in custom_pings_cache:
         desc = custom_pings_cache[ping_name].description

--- a/glean_parser/parser.py
+++ b/glean_parser/parser.py
@@ -179,12 +179,12 @@ def _instantiate_metrics(all_objects, sources, content, filepath, config):
             else:
                 if (
                     not config.get("allow_reserved")
-                    and "all_pings" in metric_obj.send_in_pings
+                    and "all-pings" in metric_obj.send_in_pings
                 ):
                     yield util.format_error(
                         filepath,
                         "On instance {}.{}".format(category_key, metric_key),
-                        'Only internal metrics may specify "all_pings" '
+                        'Only internal metrics may specify "all-pings" '
                         'in "send_in_pings"',
                     )
                     metric_obj = None

--- a/glean_parser/schemas/metrics.1-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.1-0-0.schema.yaml
@@ -28,6 +28,13 @@ definitions:
     pattern: "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})*$"
     maxLength: 40
 
+  kebab_case:
+    type: string
+    # Bug 1601270; we allow 3 specific existing snake_cased ping names for now,
+    # but these special cases can be removed in 2020H2.
+    pattern: "^[a-z][a-z0-9-]{0,29}$\
+      |^deletion_request$|^bookmarks_sync$|^history_sync$"
+
   long_id:
     allOf:
       - $ref: "#/definitions/snake_case"
@@ -160,12 +167,12 @@ definitions:
           and the `metrics` ping for everything else. Most metrics don't need to
           specify this.
 
-          (There is an additional special value of `all_pings` for internal
+          (There is an additional special value of `all-pings` for internal
           Glean metrics only that is used to indicate that a metric may appear
           in any ping.)
         type: array
         items:
-          $ref: "#/definitions/snake_case"
+          $ref: "#/definitions/kebab_case"
         default:
           - default
 

--- a/glean_parser/schemas/metrics.1-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.1-0-0.schema.yaml
@@ -31,7 +31,8 @@ definitions:
   kebab_case:
     type: string
     # Bug 1601270; we allow 3 specific existing snake_cased ping names for now,
-    # but these special cases can be removed in 2020H2.
+    # but these special cases can be removed once the number of legacy clients
+    # sufficiently dwindles, likely in 2020H2.
     pattern: "^[a-z][a-z0-9-]{0,29}$\
       |^deletion_request$|^bookmarks_sync$|^history_sync$"
 

--- a/glean_parser/schemas/pings.1-0-0.schema.yaml
+++ b/glean_parser/schemas/pings.1-0-0.schema.yaml
@@ -10,7 +10,7 @@ description: |
 
   The top-level of the `pings.yaml` file has a key defining the name of each
   ping. The values contain metadata about that ping. Ping names must be
-  snake_case, though they may also have dots `.` to define subcategories.
+  kebab-case per https://docs.telemetry.mozilla.org/cookbooks/new_ping.html
 
 $id: moz://mozilla.org/schemas/glean/pings/1-0-0
 
@@ -19,16 +19,22 @@ definitions:
     type: string
     pattern: "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})*$"
     maxLength: 40
+  kebab_case:
+    type: string
+    # Bug 1601270; we allow 3 specific existing snake_cased ping names for now,
+    # but these special cases can be removed in 2020H2.
+    pattern: "^[a-z][a-z0-9-]{0,29}$\
+      |^deletion_request$|^bookmarks_sync$|^history_sync$"
 
 type: object
 
 propertyNames:
   allOf:
     - anyOf:
-        - $ref: "#/definitions/dotted_snake_case"
+        - $ref: "#/definitions/kebab_case"
         - enum: ['$schema']
     - not:
-        enum: ['all_pings']
+        enum: ['all-pings']
 
 properties:
   $schema:

--- a/glean_parser/schemas/pings.1-0-0.schema.yaml
+++ b/glean_parser/schemas/pings.1-0-0.schema.yaml
@@ -22,7 +22,8 @@ definitions:
   kebab_case:
     type: string
     # Bug 1601270; we allow 3 specific existing snake_cased ping names for now,
-    # but these special cases can be removed in 2020H2.
+    # but these special cases can be removed once the number of legacy clients
+    # sufficiently dwindles, likely in 2020H2.
     pattern: "^[a-z][a-z0-9-]{0,29}$\
       |^deletion_request$|^bookmarks_sync$|^history_sync$"
 

--- a/tests/data/pings.yaml
+++ b/tests/data/pings.yaml
@@ -4,7 +4,7 @@
 ---
 $schema: moz://mozilla.org/schemas/glean/pings/1-0-0
 
-custom_ping:
+custom-ping:
   description:
     This is a custom ping
   include_client_id: false
@@ -15,7 +15,7 @@ custom_ping:
   notification_emails:
     - CHANGE-ME@test-only.com
 
-really_custom_ping:
+really-custom-ping:
   description: >
     Lorem ipsum dolor sit amet, consectetur adipiscing elit,
     sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
@@ -32,7 +32,7 @@ really_custom_ping:
   notification_emails:
     - CHANGE-ME@test-only.com
 
-custom_ping_might_be_empty:
+custom-ping-might-be-empty:
   description:
     This is another custom ping
   include_client_id: true

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -94,8 +94,8 @@ def test_ping_desc():
     # If we have a custom ping cache, try look up the
     # description there.
     cache = {}
-    cache["cached_ping"] = pings.Ping(
-        name="cached_ping",
+    cache["cached-ping"] = pings.Ping(
+        name="cached-ping",
         description="the description for the custom ping\n with a surprise",
         bugs=["1234"],
         notification_emails=["email@example.com"],
@@ -104,7 +104,7 @@ def test_ping_desc():
     )
 
     assert (
-        markdown.ping_desc("cached_ping", cache)
+        markdown.ping_desc("cached-ping", cache)
         == "the description for the custom ping\n with a surprise"
     )
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -39,10 +39,10 @@ def test_parser():
                 assert isinstance(metric_val.labels, set)
 
     pings = all_metrics.value["pings"]
-    assert pings["custom_ping"].name == "custom_ping"
-    assert pings["custom_ping"].include_client_id is False
-    assert pings["really_custom_ping"].name == "really_custom_ping"
-    assert pings["really_custom_ping"].include_client_id is True
+    assert pings["custom-ping"].name == "custom-ping"
+    assert pings["custom-ping"].include_client_id is False
+    assert pings["really-custom-ping"].name == "really-custom-ping"
+    assert pings["really-custom-ping"].include_client_id is True
 
 
 def test_parser_invalid():
@@ -304,9 +304,9 @@ def test_geckoview_only_on_valid_metrics():
 
 
 def test_all_pings_reserved():
-    # send_in_pings: [all_pings] is only allowed for internal metrics
+    # send_in_pings: [all-pings] is only allowed for internal metrics
     contents = [
-        {"category": {"metric": {"type": "string", "send_in_pings": ["all_pings"]}}}
+        {"category": {"metric": {"type": "string", "send_in_pings": ["all-pings"]}}}
     ]
 
     contents = [util.add_required(x) for x in contents]
@@ -320,13 +320,13 @@ def test_all_pings_reserved():
     errors = list(all_metrics)
     assert len(errors) == 0
 
-    # A custom ping called "all_pings" is not allowed
-    contents = [{"all_pings": {"include_client_id": True}}]
+    # A custom ping called "all-pings" is not allowed
+    contents = [{"all-pings": {"include_client_id": True}}]
     contents = [util.add_required_ping(x) for x in contents]
     all_pings = parser.parse_objects(contents)
     errors = list(all_pings)
     assert len(errors) == 1
-    assert "is not allowed for 'all_pings'"
+    assert "is not allowed for 'all-pings'"
 
 
 def test_custom_distribution():

--- a/tests/test_pings.py
+++ b/tests/test_pings.py
@@ -37,7 +37,7 @@ def test_reserved_metrics_category():
     assert "reserved" in errors[0]
 
 
-def test_snake_case_ping_names():
+def test_camel_case_ping_name():
     content = {"camelCasePingName": {"include_client_id": True}}
 
     util.add_required_ping(content)
@@ -46,8 +46,25 @@ def test_snake_case_ping_names():
     assert "camelCasePingName" in errors[0]
 
 
+def test_snake_case_ping_name():
+    content = {"snake_case_ping_name": {"include_client_id": True}}
+
+    util.add_required_ping(content)
+    errors = list(parser.parse_objects([content]))
+    assert len(errors) == 1
+    assert "snake_case_ping_name" in errors[0]
+
+
+def test_legacy_snake_case_ping_name():
+    content = {"bookmarks_sync": {"include_client_id": True}}
+
+    util.add_required_ping(content)
+    errors = list(parser.parse_objects([content]))
+    assert len(errors) == 0
+
+
 def test_send_if_empty():
-    content = {"valid_ping": {"include_client_id": True, "send_if_empty": True}}
+    content = {"valid-ping": {"include_client_id": True, "send_if_empty": True}}
 
     util.add_required_ping(content)
     errors = list(parser.parse_objects([content]))


### PR DESCRIPTION
This supersedes #90 and #94, and adds special cases to
allow current legacy ping names with underscores to continue
to work.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
