### PR TITLE
Add project title to the markdown template

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,9 @@ History
 Unreleased
 ----------
 
+* Add project title to markdown template.
+* Remove "Sorry about that" from markdown template.
+
 1.15.2 (2019-12-12)
 -------------------
 

--- a/glean_parser/markdown.py
+++ b/glean_parser/markdown.py
@@ -96,8 +96,8 @@ def output_markdown(objs, output_dir, options={}):
     :param objects: A tree of objects (metrics and pings) as returned from
     `parser.parse_objects`.
     :param output_dir: Path to an output directory to write to.
-    :param options: options dictionary. No option currently supported, stays for
-    signature compatibility with the other outputters.
+    :param options: options dictionary, with the following optional key:
+        - `project_title`: The projects title.
     """
 
     # Build a dictionary that associates pings with their metrics.
@@ -142,6 +142,8 @@ def output_markdown(objs, output_dir, options={}):
             metrics_by_pings[ping_name], key=lambda x: x.identifier()
         )
 
+    project_title = options.get("project_title", "this project")
+
     template = util.get_jinja2_template(
         "markdown.jinja2",
         filters=(
@@ -157,6 +159,11 @@ def output_markdown(objs, output_dir, options={}):
     filepath = output_dir / filename
 
     with filepath.open("w", encoding="utf-8") as fd:
-        fd.write(template.render(metrics_by_pings=metrics_by_pings))
+        fd.write(
+            template.render(
+                metrics_by_pings=metrics_by_pings,
+                project_title=project_title
+            )
+        )
         # Jinja2 squashes the final newline, so we explicitly add it
         fd.write("\n")

--- a/glean_parser/templates/markdown.jinja2
+++ b/glean_parser/templates/markdown.jinja2
@@ -6,7 +6,6 @@ Jinja2 template is not. Please file bugs! #}
 This document enumerates the metrics collected by this project.
 This project may depend on other projects which also collect metrics.
 This means you might have to go searching through the dependency tree to get a full picture of everything collected by this project.
-Sorry about that.
 
 # Pings
 

--- a/glean_parser/templates/markdown.jinja2
+++ b/glean_parser/templates/markdown.jinja2
@@ -3,7 +3,7 @@
 Jinja2 template is not. Please file bugs! #}
 
 # Metrics
-This document enumerates the metrics collected by this project.
+This document enumerates the metrics collected by {{ project_title }}.
 This project may depend on other projects which also collect metrics.
 This means you might have to go searching through the dependency tree to get a full picture of everything collected by this project.
 


### PR DESCRIPTION
Fixes [Bug 1578347](https://bugzilla.mozilla.org/show_bug.cgi?id=1578347)

...and as a bonus fixes [Bug 1586730](https://bugzilla.mozilla.org/show_bug.cgi?id=1586730), about removing "Sorry about that" from the markdown template. I just remembered that bug and it was easy enough to remove that line. I can revert that commit if this is a problem :)

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
