### PR TITLE
Use iso8601 library rather than backports-fromisoformat

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ is installed by `pip`.
 
 Additionally on Python 3.6 and 3.5:
 
-- backports-datetime-fromisoformat
+- iso8601
 
 And on Python 3.5:
 

--- a/glean_parser/__init__.py
+++ b/glean_parser/__init__.py
@@ -16,11 +16,3 @@ except DistributionNotFound:
 
 __author__ = """Michael Droettboom"""
 __email__ = "mdroettboom@mozilla.com"
-
-import sys
-
-# Import a backport of datetime.datetime.fromisoformat()
-if sys.version_info < (3, 7):
-    from backports.datetime_fromisoformat import MonkeyPatch
-
-    MonkeyPatch.patch_fromisoformat()

--- a/glean_parser/util.py
+++ b/glean_parser/util.py
@@ -21,6 +21,9 @@ import jsonschema
 from jsonschema import _utils
 import yaml
 
+if sys.version_info < (3, 7):
+    import iso8601
+
 
 TESTING_MODE = "pytest" in sys.modules
 
@@ -318,7 +321,10 @@ def is_expired(expires):
         return True
     else:
         try:
-            date = datetime.date.fromisoformat(expires)
+            if sys.version_info < (3, 7):
+                date = iso8601.parse_date(expires).date()
+            else:
+                date = datetime.date.fromisoformat(expires)
         except ValueError:
             raise ValueError(
                 (
@@ -335,7 +341,10 @@ def validate_expires(expires):
     """
     if expires in ("never", "expired"):
         return
-    datetime.date.fromisoformat(expires)
+    if sys.version_info < (3, 7):
+        iso8601.parse_date(expires)
+    else:
+        datetime.date.fromisoformat(expires)
 
 
 def report_validation_errors(all_objects):

--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,10 @@ with open("HISTORY.rst") as history_file:
 
 requirements = [
     "appdirs>=1.4.3",
-    "backports-datetime-fromisoformat==1.0.0",
     "Click>=7.0",
     "diskcache>=4.0.0",
     "inflection>=0.3.1",
+    "iso8601>=0.1.12",
     "Jinja2>=2.10.1",
     "jsonschema>=3.0.2",
     "pep487==1.0.1",


### PR DESCRIPTION
The reasons for this PR are a bit obscure.

We were using the `backports.datetime_fromisoformat` library to support parsing iso8601 dates on Python 3.6 and earlier (where such functionality is not in the standard library).  However, this library includes a C extension, so installing it on Windows requires a C compiler to be handy and installed correctly so Python can find it (which is not always the case, even if the user otherwise has their machine set up for C/C++ development).

This replaces that library with another one that is pure Python to avoid this issue.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
