### PR TITLE
Break the CI build if any of the dependencies require a C compiler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,13 @@ commands:
                     command: make lint
             - run:
                     name: install
-                    command: python setup.py install --user
+                    # Set CC to something that isn't a working compiler so we
+                    # can detect if any of the dependencies require a compiler
+                    # to be installed. We can't count on a working compiler
+                    # being available to pip on all of the platforms we need to
+                    # support, so we need to make sure the dependencies are all
+                    # pure Python or provide pre-built wheels.
+                    command: CC=broken_compiler python setup.py install --user
             - run:
                     name: test
                     command: make test


### PR DESCRIPTION
This should prevent against future errors like #148 where we inadvertently added a dependency that requires a C compiler at install time.  We can't count on a working C compiler to be available every where that glean_parser is used, so we should detect when we use a dependency like that and break the build.

(NOTE: I expect this PR to fail the first time as a way of testing it, and then will come back and remove the "bad" dependency to make it pass.)

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
