### PR TITLE
Update ping schema url

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,8 @@ History
 Unreleased
 ----------
 
+* Updated ping schema URL
+
 1.16.0 (2020-01-15)
 -------------------
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ clean-build: ## remove build artifacts
 	rm -fr dist/
 	rm -fr .eggs/
 	find . -name '*.egg-info' -exec rm -fr {} +
-	find . -name '*.egg' -exec rm -f {} +
+	find . -name '*.egg' -exec rm -fr {} +
 
 clean-pyc: ## remove Python file artifacts
 	find . -name '*.pyc' -exec rm -f {} +

--- a/glean_parser/__main__.py
+++ b/glean_parser/__main__.py
@@ -74,7 +74,7 @@ def translate(input, format, output, option, allow_reserved):
     "--schema",
     "-s",
     type=str,
-    default=validate_ping.PING_SCHEMA_DEFAULT_URL,
+    default=validate_ping.GLEAN_PING_SCHEMA_URL,
     nargs=1,
     required=False,
     help=("HTTP url or file path to Glean ping schema. If remote, will cache to disk."),

--- a/glean_parser/validate_ping.py
+++ b/glean_parser/validate_ping.py
@@ -26,7 +26,7 @@ SCHEMAS_DIR = ROOT_DIR / "schemas"
 GLEAN_PING_SCHEMA_GIT_HASH = "a56043b"
 GLEAN_PING_SCHEMA_URL = (
     "https://raw.githubusercontent.com/mozilla-services/"
-    "mozilla-pipeline-schemas/%s/schemas/glean/glean/"
+    "mozilla-pipeline-schemas/{}/schemas/glean/glean/"
     "glean.1.schema.json"
 ).format(GLEAN_PING_SCHEMA_GIT_HASH)
 

--- a/glean_parser/validate_ping.py
+++ b/glean_parser/validate_ping.py
@@ -26,9 +26,9 @@ SCHEMAS_DIR = ROOT_DIR / "schemas"
 GLEAN_PING_SCHEMA_GIT_HASH = "a56043b"
 GLEAN_PING_SCHEMA_URL = (
     "https://raw.githubusercontent.com/mozilla-services/"
-    f"mozilla-pipeline-schemas/{GLEAN_PING_SCHEMA_GIT_HASH}/"
-    "schemas/glean/glean/glean.1.schema.json"
-)
+    "mozilla-pipeline-schemas/%s/schemas/glean/glean/"
+    "glean.1.schema.json"
+).format(GLEAN_PING_SCHEMA_GIT_HASH)
 
 
 @functools.lru_cache(maxsize=1)

--- a/glean_parser/validate_ping.py
+++ b/glean_parser/validate_ping.py
@@ -23,17 +23,18 @@ ROOT_DIR = Path(__file__).parent
 SCHEMAS_DIR = ROOT_DIR / "schemas"
 
 
-PING_SCHEMA_DEFAULT_URL = (
+GLEAN_PING_SCHEMA_GIT_HASH = "a56043b"
+GLEAN_PING_SCHEMA_URL = (
     "https://raw.githubusercontent.com/mozilla-services/"
-    "mozilla-pipeline-schemas/dev/schemas/glean/baseline/"
-    "baseline.1.schema.json"
+    f"mozilla-pipeline-schemas/{GLEAN_PING_SCHEMA_GIT_HASH}/"
+    "schemas/glean/glean/glean.1.schema.json"
 )
 
 
 @functools.lru_cache(maxsize=1)
 def _get_ping_schema(schema_url):
     contents = util.fetch_remote_url(
-        schema_url, cache=(schema_url != PING_SCHEMA_DEFAULT_URL)
+        schema_url, cache=(schema_url != GLEAN_PING_SCHEMA_URL)
     )
     return json.loads(contents)
 
@@ -59,7 +60,7 @@ def _validate_ping(ins, outs, schema_url):
     return has_error
 
 
-def validate_ping(ins, outs=None, schema_url=PING_SCHEMA_DEFAULT_URL):
+def validate_ping(ins, outs=None, schema_url=GLEAN_PING_SCHEMA_URL):
     """
     Validates the contents of a Glean ping.
 


### PR DESCRIPTION
I have updated the schema and changed it to look exactly like it does in glean-core (see: https://github.com/mozilla/glean/blob/master/glean-core/android/build.gradle#L26-L27).

This is one case where it would be useful to have shared global vars between the projects. That is not urgent of course, I have closed [a bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1551694) related to this last year because the changes were too much work and not much gain, but still, just to keep it in mind :)

Ah, also did a small change to the Makefile. A bunch of my tests failed when I updated the schema, turns out it was not related to that, but to the fact that the project was not building because it couldn't get past the `clean` phase 🤦‍♀️

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
