### PR TITLE
1611111 - Restore the order of extra arguments in Swift code

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ Unreleased
 * Remove default schema URL from `validate_ping`
 * Make `schema` argument required for CLI
 * BUGFIX: Avoid default import in Swift code for Glean itself
+* BUGFIX: Restore order of fields in generated Swift code
 
 1.16.0 (2020-01-15)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ Unreleased
 
 * Remove default schema URL from `validate_ping`
 * Make `schema` argument required for CLI
+* BUGFIX: Avoid default import in Swift code for Glean itself
 
 1.16.0 (2020-01-15)
 -------------------

--- a/glean_parser/swift.py
+++ b/glean_parser/swift.py
@@ -121,16 +121,18 @@ def output_swift(objs, output_dir, options={}):
     )
 
     # The object parameters to pass to constructors.
-    # Need to be in the order the type constructor expects them.
+    # **CAUTION**: This list needs to be in the order the type constructor expects them.
+    # The `test_order_of_fields` test checks that the generated code is valid.
+    # **DO NOT CHANGE THE ORDER OR ADD NEW FIELDS IN THE MIDDLE**
     extra_args = [
-        "allowed_extra_keys",
         "category",
-        "disabled",
-        "lifetime",
         "name",
-        "reason_codes",
         "send_in_pings",
+        "lifetime",
+        "disabled",
         "time_unit",
+        "reason_codes",
+        "allowed_extra_keys",
     ]
 
     namespace = options.get("namespace", "GleanMetrics")

--- a/glean_parser/templates/swift.jinja2
+++ b/glean_parser/templates/swift.jinja2
@@ -15,7 +15,7 @@ Jinja2 template is not. Please file bugs! #}
         )
 {% endmacro %}
 
-{% if glean_namespace|length and glean_namespace != "Glean" %}
+{% if glean_namespace|length and glean_namespace is not equalto "Glean" %}
 import {{ glean_namespace }}
 
 {% endif %}


### PR DESCRIPTION
This fixes 2 small bugs (one is a drive-by fix).

Caution: mozilla/glean will still not compile with this, due to the reason code changes, that don't exist yet for Swift.