### PR TITLE
Swift: Generate "import Glean" based on allow_reserved flag

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,9 @@ History
 Unreleased
 ----------
 
+* BUGFIX: Generated Swift code now includes `import Glean`, unless generating
+  for a Glean-internal build.
+
 1.17.0 (2020-02-03)
 -------------------
 

--- a/glean_parser/swift.py
+++ b/glean_parser/swift.py
@@ -112,6 +112,9 @@ def output_swift(objs, output_dir, options={}):
     `parser.parse_objects`.
     :param output_dir: Path to an output directory to write to.
     :param options: options dictionary, with the following optional keys:
+        - namespace: The namespace to generate metrics in
+        - glean_namespace: The namespace to import Glean from
+        - allow_reserved: When True, this is a Glean-internal build
     """
     template = util.get_jinja2_template(
         "swift.jinja2",
@@ -164,6 +167,7 @@ def output_swift(objs, output_dir, options={}):
                     glean_namespace=glean_namespace,
                     has_labeled_metrics=has_labeled_metrics,
                     is_ping_type=len(custom_pings) > 0,
+                    allow_reserved=options.get("allow_reserved", False)
                 )
             )
             # Jinja2 squashes the final newline, so we explicitly add it

--- a/glean_parser/templates/swift.jinja2
+++ b/glean_parser/templates/swift.jinja2
@@ -15,7 +15,7 @@ Jinja2 template is not. Please file bugs! #}
         )
 {% endmacro %}
 
-{% if glean_namespace|length and glean_namespace is not equalto "Glean" %}
+{% if not allow_reserved %}
 import {{ glean_namespace }}
 
 {% endif %}

--- a/glean_parser/translate.py
+++ b/glean_parser/translate.py
@@ -69,6 +69,10 @@ def translate(input_filepaths, output_format, output_dir, options={}, parser_con
             file=sys.stderr,
         )
 
+    # allow_reserved is also relevant to the translators, so copy it there
+    if parser_config.get("allow_reserved"):
+        options["allow_reserved"] = True
+
     # Write everything out to a temporary directory, and then move it to the
     # real directory, for transactional integrity.
     with tempfile.TemporaryDirectory() as tempdir:

--- a/tests/test_swift.py
+++ b/tests/test_swift.py
@@ -167,3 +167,33 @@ def test_order_of_fields(tmpdir):
     # We only check the limited list of always available fields.
     size = len(expected_fields)
     assert expected_fields == first_metric_fields[:size]
+
+
+def test_no_import_glean(tmpdir):
+    tmpdir = Path(str(tmpdir))
+
+    translate.translate(
+        ROOT / "data" / "core.yaml", "swift", tmpdir, {}, {"allow_reserved": True}
+    )
+
+    # Make sure descriptions made it in
+    fd = (tmpdir / "CorePing.swift").open("r", encoding="utf-8")
+    content = fd.read()
+    fd.close()
+
+    assert "import Glean" not in content
+
+
+def test_import_glean(tmpdir):
+    tmpdir = Path(str(tmpdir))
+
+    translate.translate(
+        ROOT / "data" / "smaller.yaml", "swift", tmpdir, {}, {}
+    )
+
+    # Make sure descriptions made it in
+    fd = (tmpdir / "Telemetry.swift").open("r", encoding="utf-8")
+    content = fd.read()
+    fd.close()
+
+    assert "import Glean" in content


### PR DESCRIPTION
Prior to this, it was never generating "import Glean", which broke builds of
third-party Glean-using products.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
