### PR TITLE
Have the metrics names in Java match their names in Kotlin

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,9 @@ History
 Unreleased
 ----------
 
+* **Breaking Change (Java API)** Have the metrics names in Java match the names in Kotlin.
+  See [Bug 1588060](https://bugzilla.mozilla.org/show_bug.cgi?id=1588060).
+
 1.17.3 (2020-02-05)
 -------------------
 

--- a/glean_parser/templates/kotlin.jinja2
+++ b/glean_parser/templates/kotlin.jinja2
@@ -10,6 +10,7 @@ Jinja2 template is not. Please file bugs! #}
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 {% macro obj_declaration(obj, suffix='', access='', lazy=False) %}
+@get:JvmName("{{ obj.name|camelize }}{{ suffix }}")
 {{ access }}val {{ obj.name|camelize }}{{ suffix }}: {{ obj|type_name }}{% if lazy %} by lazy { {%- else %} ={% endif %}
 
         {{ obj|type_name }}(


### PR DESCRIPTION
Related to [Bug 1588060](https://bugzilla.mozilla.org/show_bug.cgi?id=1588060).

When this lands and glean is updated, it should also include tests for the Java API in https://github.com/mozilla/glean/blob/master/glean-core/android/src/test/java/mozilla/telemetry/glean/GleanFromJavaTest.java.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
