### PR TITLE
Specify maximum version of Jinja2 (backported from v1.17.3)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,12 @@ History
 Unreleased
 ----------
 
+1.15.6 (2020-02-06)
+-------------------
+
+* BUGFIX: The version of Jinja2 now specifies < 3.0, since that version no
+  longer supports Python 3.5 (backported from 1.17.3).
+
 1.15.5 (2019-12-19)
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ requirements = [
     "diskcache>=4.0.0",
     "inflection>=0.3.1",
     "iso8601>=0.1.12",
-    "Jinja2>=2.10.1",
+    "Jinja2>=2.10.1,<3.0",
     "jsonschema>=3.0.2",
     "pep487==1.0.1",
     "PyYAML>=3.13",


### PR DESCRIPTION
I created a branch `release-v1.15` based on the `v1.15.5` tag.

This PR is against that branch, backporting the single-line fix from v1.17.3.
Once this lands and is tagged I'm going to merge the changelog changes into master as well in a follow-up PR.
