### PR TITLE
Update deploy instructions to mention using GitHub releases

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -133,18 +133,29 @@ Deploying
 
 A reminder for the maintainers on how to deploy.
 
+Get a clean master branch with all of the changes from `upstream`::
+
+  $ git checkout master
+  $ git fetch upstream
+  $ git rebase upstream/master
+
 - Update the header with the new version and date in HISTORY.rst.
 
 - (By using the setuptools-scm package, there is no need to update the version anywhere else).
 
 - Make sure all your changes are committed.
 
-Then run (assuming the main fork is in a git remote called `upstream`)::
+- Push the changes upstream::
 
-$ git checkout master
-$ git fetch upstream
-$ git rebase upstream/master
-$ git tag vX.X.X
-$ git push upstream master --tags
+  $ git push upstream master
 
-The continuous integration system will then deploy to PyPI if tests pass.
+- Wait for [continuous integration to
+  pass](https://circleci.com/gh/mozilla/glean/tree/master) on master.
+
+- Make the release on GitHub using [this link](https://github.com/mozilla/glean_parser/releases/new)
+
+- Enter the new version in the form `vX.Y.Z`.
+
+- Copy and paste the relevant part of the `HISTORY.rst` file into the description.
+
+The continuous integration system will then automatically deploy to PyPI.


### PR DESCRIPTION
Maybe some day we'll want to pull over the detailed gitflow instructions from glean itself, but this at least does the minimal changes to mention using GitHub releases.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
