### PR TITLE
Fix @JvmName annotation on private members

### DIFF
--- a/glean_parser/templates/kotlin.jinja2
+++ b/glean_parser/templates/kotlin.jinja2
@@ -10,7 +10,9 @@ Jinja2 template is not. Please file bugs! #}
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 {% macro obj_declaration(obj, suffix='', access='', lazy=False) %}
+{% if (access != "private ") -%}
 @get:JvmName("{{ obj.name|camelize }}{{ suffix }}")
+{% endif -%}
 {{ access }}val {{ obj.name|camelize }}{{ suffix }}: {{ obj|type_name }}{% if lazy %} by lazy { {%- else %} ={% endif %}
 
         {{ obj|type_name }}(


### PR DESCRIPTION
This fixes a bug introduced in #165, where @JvmName isn't allowed on private
members, and results in this compiler error:

w: glean-core/android/build/generated/source/glean/debug/kotlin/GleanError.kt: (97, 5): An accessor will not be generated for 'invalidOverflowLabel', so the annotation wil
l not be written to the class file

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
