### PR TITLE
Fixes bugs in markdown reason support

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,10 @@ History
 Unreleased
 ----------
 
+* BUGFIX: Reason codes are displayed in markdown output for built-in pings as
+  well.
+* BUGFIX: Reason descriptions are indented correctly in markdown output.
+
 1.18.0 (2020-02-13)
 -------------------
 

--- a/glean_parser/markdown.py
+++ b/glean_parser/markdown.py
@@ -90,7 +90,7 @@ def ping_reasons(ping_name, custom_pings_cache):
     """
     Returns the reasons dictionary for the ping.
     """
-    if ping_name in pings.RESERVED_PING_NAMES or ping_name == "all-pings":
+    if ping_name == "all-pings":
         return {}
     elif ping_name in custom_pings_cache:
         return custom_pings_cache[ping_name].reasons

--- a/glean_parser/templates/markdown.jinja2
+++ b/glean_parser/templates/markdown.jinja2
@@ -32,7 +32,7 @@ This ping is sent if empty.
 {% if ping_name|ping_reasons %}
 Reasons this ping may be sent:
 {% for (reason, desc) in ping_name|ping_reasons|dictsort %}
-    - `{{ reason }}`: {{ desc }}
+    - `{{ reason }}`: {{ desc|indent(6, indentfirst=False) }}
 {% endfor %}
 
 {% endif %}


### PR DESCRIPTION
This fixes a couple of bugs introduced in #170.

- Even built-in pings should have their reason codes listed
- Properly indent the output so the markdown list is rendered correctly

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
