### PR TITLE
Drop 'inflection' and make transitive dependencies versions explicit

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,10 @@ History
 Unreleased
 ----------
 
+* Dropped the 'inflection' dependency.
+* Constrained the 'zipp' and 'MarkupSafe' transitive dependencies to versions that
+  support Python 3.5.
+
 1.18.2 (2020-02-14)
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,6 @@ is installed by `pip`.
 - appdirs
 - Click
 - diskcache
-- inflection
 - Jinja2
 - jsonschema
 - PyYAML

--- a/glean_parser/util.py
+++ b/glean_parser/util.py
@@ -15,7 +15,6 @@ import urllib.request
 
 import appdirs
 import diskcache
-import inflection
 import jinja2
 import jsonschema
 from jsonschema import _utils
@@ -136,6 +135,24 @@ def ensure_list(value):
     return value
 
 
+def to_camel_case(input, capitalize_first_letter):
+    """
+    Convert the value to camelCase.
+
+    This additionally replaces any '.' with '_'. The first letter is capitalized
+    depending on `capitalize_first_letter`.
+    """
+    sanitized_input = input.replace(".", "_").replace("-", "_")
+    # Filter out any empty token. This could happen due to leading '_' or
+    # consecutive '__'.
+    tokens = [s.capitalize() for s in sanitized_input.split("_") if len(s) != 0]
+    # If we're not meant to capitalize the first letter, then lowercase it.
+    if not capitalize_first_letter:
+        tokens[0] = tokens[0].lower()
+    # Finally join the tokens and capitalize.
+    return ''.join(tokens)
+
+
 def camelize(value):
     """
     Convert the value to camelCase (with a lower case first letter).
@@ -143,7 +160,7 @@ def camelize(value):
     This is a thin wrapper around inflection.camelize that handles dots in
     addition to underscores.
     """
-    return inflection.camelize(value.replace(".", "_").replace("-", "_"), False)
+    return to_camel_case(value, False)
 
 
 def Camelize(value):
@@ -153,7 +170,7 @@ def Camelize(value):
     This is a thin wrapper around inflection.camelize that handles dots in
     addition to underscores.
     """
-    return inflection.camelize(value.replace(".", "_").replace("-", "_"), True)
+    return to_camel_case(value, True)
 
 
 @functools.lru_cache()

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ requirements = [
     "appdirs>=1.4.3",
     "Click>=7.0",
     "diskcache>=4.0.0",
-    "inflection>=0.3.1",
     "iso8601>=0.1.12",
     "Jinja2>=2.10.1,<3.0",
     "jsonschema>=3.0.2",

--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,15 @@ requirements = [
     "iso8601>=0.1.12",
     "Jinja2>=2.10.1,<3.0",
     "jsonschema>=3.0.2",
+    # 'markupsafe' is required by Jinja2. From version 2.0.0 on
+    # py3.5 support is dropped.
+    "markupsafe>=1.1,<2.0.0",
     "pep487==1.0.1",
     "PyYAML>=3.13",
     "yamllint>=1.18.0",
+    # 'zipp' is required by jsonschema->importlib_metadata,
+    # it drops py3.5 in newer versions.
+    "zipp>=0.5,<2.0",
 ]
 
 setup_requirements = ["pytest-runner", "setuptools-scm"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+# Any copyright is dedicated to the Public Domain.
+# http://creativecommons.org/publicdomain/zero/1.0/
+
+from glean_parser.util import to_camel_case
+
+
+def test_camel_case_first_lowercase():
+    assert "testMe" == to_camel_case("test_me", False)
+
+
+def test_camel_case_first_uppercase():
+    assert "TestMe" == to_camel_case("test_me", True)
+
+
+def test_camel_case_empty_tokens():
+    assert "testMe" == to_camel_case("__test____me", False)
+
+
+def test_camel_case_dots_sanitized():
+    assert "testMeYeah" == to_camel_case("__test..me.yeah", False)
+
+
+def test_camel_case_numbers():
+    assert "g33kS4n1t1z3d" == to_camel_case("g33k_s4n1t1z3d", False)
+
+
+def test_camel_case_expected():
+    assert "easyOne" == to_camel_case("easy_one", False)
+    assert "moreInvolved1" == to_camel_case("more_involved_1", False)


### PR DESCRIPTION
This is required in order to integrate in mozilla-central, [see this bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1602773).

Given :ahal comment on the bug, I checked about downgrading pyYAML to 3.11. However 3.13 contains [fixes for python 3.7](https://github.com/yaml/pyyaml/blob/2f463cf5b0e98a52bc20e348d1e69761bf263b86/CHANGES#L83), which we need to support. I'll attempt to update pyyaml in m-c.


### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
