### PR TITLE
1618873: Support external translators

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,8 @@ Unreleased
   * State wether the ping includes client id;
   * Add list of data review links;
   * Add list of related bugs links.
+* `glean_parser` now makes it easier to write external translation functions for
+  different language targets.
 
 1.18.3 (2020-02-24)
 -------------------

--- a/glean_parser/translate.py
+++ b/glean_parser/translate.py
@@ -24,59 +24,62 @@ from . import swift
 from . import util
 
 
-# Each outputter in the table has the following keys:
-# - "output_func": the main function of the outputter, the one which
-#   does the actual translation.
-# - "clear_output_dir": a flag to clear the target directory before moving there
-#   the generated files.
-# - "extensions": A list of glob patterns to clear in the directory.
-
-
 class Outputter:
     """
     Class to define an output format.
+
+    Each outputter in the table has the following member values:
+    - output_func: the main function of the outputter, the one which
+      does the actual translation.
+    - clear_patterns: A list of glob patterns to clear in the directory before
+      writing new results to it.
     """
 
     def __init__(
         self,
         output_func: Callable[[metrics.ObjectTree, Path, Dict[str, Any]], None],
-        clear_output_dir: bool,
-        extensions: List[str] = [],
+        clear_patterns: List[str] = [],
     ):
         self.output_func = output_func
-        self.clear_output_dir = clear_output_dir
-        self.extensions = extensions
+        self.clear_patterns = clear_patterns
 
 
 OUTPUTTERS = {
-    "kotlin": Outputter(kotlin.output_kotlin, True, ["*.kt"]),
-    "markdown": Outputter(markdown.output_markdown, False),
-    "swift": Outputter(swift.output_swift, True, ["*.swift"]),
+    "kotlin": Outputter(kotlin.output_kotlin, ["*.kt"]),
+    "markdown": Outputter(markdown.output_markdown),
+    "swift": Outputter(swift.output_swift, ["*.swift"]),
 }
 
 
-def translate(
+def translate_metrics(
     input_filepaths: Iterable[Path],
-    output_format: str,
     output_dir: Path,
+    translation_func: Callable[[metrics.ObjectTree, Path, Dict[str, Any]], None],
+    clear_patterns: List[str] = [],
     options: Dict[str, Any] = {},
     parser_config: Dict[str, Any] = {},
-) -> int:
+):
     """
-    Translate the files in `input_filepaths` to the given `output_format` and
-    put the results in `output_dir`.
+    Translate the files in `input_filepaths` by running the metrics through a
+    translation function and writing the results in `output_dir`.
 
     :param input_filepaths: list of paths to input metrics.yaml files
-    :param output_format: the name of the output formats
     :param output_dir: the path to the output directory
+    :param translation_func: the function that actually performs the translation.
+        It is passed the following arguments:
+            - metrics_objects: The tree of metrics as pings as returned by
+              `parser.parse_objects`.
+            - output_dir: The path to the output directory.
+            - options: A dictionary of output format-specific options.
+        Examples of translation functions are in `kotlin.py` and `swift.py`.
+    :param clear_patterns: a list of glob patterns of files to clear before
+        generating the output files. By default, no files will be cleared (i.e.
+        the directory should be left alone).
     :param options: dictionary of options. The available options are backend
-        format specific.
+        format specific. These are passed unchanged to `translation_func`.
     :param parser_config: A dictionary of options that change parsing behavior.
         See `parser.parse_metrics` for more info.
     """
-    if output_format not in OUTPUTTERS:
-        raise ValueError("Unknown output format '{}'".format(output_format))
-
     all_objects = parser.parse_objects(input_filepaths, parser_config)
 
     if util.report_validation_errors(all_objects):
@@ -96,17 +99,16 @@ def translate(
     # real directory, for transactional integrity.
     with tempfile.TemporaryDirectory() as tempdir:
         tempdir_path = Path(tempdir)
-        OUTPUTTERS[output_format].output_func(all_objects.value, tempdir_path, options)
+        translation_func(all_objects.value, tempdir_path, options)
 
-        if OUTPUTTERS[output_format].clear_output_dir:
-            if output_dir.is_file():
-                output_dir.unlink()
-            elif output_dir.is_dir():
-                for extensions in OUTPUTTERS[output_format].extensions:
-                    for filepath in output_dir.glob(extensions):
-                        filepath.unlink()
-                if len(list(output_dir.iterdir())):
-                    print("Extra contents found in '{}'.".format(output_dir))
+        if output_dir.is_file():
+            output_dir.unlink()
+        elif output_dir.is_dir() and len(clear_patterns):
+            for clear_pattern in clear_patterns:
+                for filepath in output_dir.glob(clear_pattern):
+                    filepath.unlink()
+            if len(list(output_dir.iterdir())):
+                print("Extra contents found in '{}'.".format(output_dir))
 
         # We can't use shutil.copytree alone if the directory already exists.
         # However, if it doesn't exist, make sure to create one otherwise
@@ -116,3 +118,37 @@ def translate(
             shutil.copy(str(filename), str(output_dir))
 
     return 0
+
+
+def translate(
+    input_filepaths: Iterable[Path],
+    output_format: str,
+    output_dir: Path,
+    options: Dict[str, Any] = {},
+    parser_config: Dict[str, Any] = {},
+):
+    """
+    Translate the files in `input_filepaths` to the given `output_format` and
+    put the results in `output_dir`.
+
+    :param input_filepaths: list of paths to input metrics.yaml files
+    :param output_format: the name of the output format
+    :param output_dir: the path to the output directory
+    :param options: dictionary of options. The available options are backend
+        format specific.
+    :param parser_config: A dictionary of options that change parsing behavior.
+        See `parser.parse_metrics` for more info.
+    """
+    format_desc = OUTPUTTERS.get(output_format, None)
+
+    if format_desc is None:
+        raise ValueError("Unknown output format '{}'".format(output_format))
+
+    return translate_metrics(
+        input_filepaths,
+        output_dir,
+        format_desc.output_func,
+        format_desc.clear_patterns,
+        options,
+        parser_config,
+    )

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -145,7 +145,7 @@ def test_external_translator(tmpdir):
         assert {"foo": "bar", "allow_reserved": True} == options
 
         for category in all_objects:
-            with open(tmpdir / category, "w") as fd:
+            with (tmpdir / category).open("w") as fd:
                 for metric in category:
                     fd.write("{}\n".format(metric))
 


### PR DESCRIPTION
This is just a minor refactor to create an entry point where another glean_parser-using-library can provide their own translation function.  It doesn't provide a *ton* of value over what could be done without this change except providing access to the transactional directory writing behavior.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
