### PR TITLE
1622909: Fix encoding when reading in files on 32-bit Windows

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,7 @@ Unreleased
   * Add list of related bugs links.
 * `glean_parser` now makes it easier to write external translation functions for
   different language targets.
+* BUGFIX: glean_parser now works on 32-bit Windows.
 
 1.18.3 (2020-02-24)
 -------------------

--- a/docs/metrics-yaml.rst
+++ b/docs/metrics-yaml.rst
@@ -17,6 +17,8 @@ Within each category, the individual metrics are defined. The key is the name of
 the metric (``snake_case`` with a maximum of 30 characters), and each value is
 an object with the following parameters described below.
 
+``metrics.yaml`` files must be encoded in UTF-8.
+
 Metric parameters
 -----------------
 

--- a/glean_parser/lint.py
+++ b/glean_parser/lint.py
@@ -297,7 +297,7 @@ def lint_yaml_files(input_filepaths: Iterable[Path], file=sys.stderr) -> List:
     for path in input_filepaths:
         # yamllint needs both the file content and the path.
         file_content = None
-        with path.open("r") as fd:
+        with path.open("r", encoding="utf-8") as fd:
             file_content = fd.read()
 
         problems = linter.run(file_content, YamlLintConfig("extends: default"), path)

--- a/glean_parser/util.py
+++ b/glean_parser/util.py
@@ -123,10 +123,10 @@ def load_yaml_or_json(path: Path, ordered_dict: bool = False):
         return {}
 
     if path.suffix == ".json":
-        with path.open("r") as fd:
+        with path.open("r", encoding="utf-8") as fd:
             return json.load(fd)
     elif path.suffix in (".yml", ".yaml", ".yamlx"):
-        with path.open("r") as fd:
+        with path.open("r", encoding="utf-8") as fd:
             if ordered_dict:
                 return ordered_yaml_load(fd)
             else:

--- a/glean_parser/validate_ping.py
+++ b/glean_parser/validate_ping.py
@@ -68,7 +68,7 @@ def validate_ping(ins, outs=None, schema_url=None):
         outs = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
 
     if isinstance(ins, (str, bytes, Path)):
-        with open(ins, "r") as fd:
+        with open(ins, "r", encoding="utf-8") as fd:
             return _validate_ping(fd, outs, schema_url=schema_url)
     else:
         return _validate_ping(ins, outs, schema_url=schema_url)

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,10 @@ if sys.version_info < (3, 5):
     sys.exit(1)
 
 
-with open("README.rst") as readme_file:
+with open("README.rst", encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
-with open("HISTORY.rst") as history_file:
+with open("HISTORY.rst", encoding="utf-8") as history_file:
     history = history_file.read()
 
 requirements = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@
 
 import os
 from pathlib import Path
+import re
 
 from click.testing import CliRunner
 
@@ -53,7 +54,7 @@ def test_translate(tmpdir):
     )
     for filename in os.listdir(str(tmpdir)):
         path = Path(str(tmpdir)) / filename
-        with path.open() as fd:
+        with path.open(encoding="utf-8") as fd:
             content = fd.read()
         assert "package Foo" in content
 
@@ -84,4 +85,4 @@ def test_translate_invalid_format(tmpdir):
         ["translate", str(ROOT / "data" / "core.yaml"), "-o", str(tmpdir), "-f", "foo"],
     )
     assert result.exit_code == 2
-    assert 'Invalid value for "--format"' in result.output
+    assert re.search("Invalid value for ['\"]--format['\"]", result.output)


### PR DESCRIPTION
On 32-bit Windows with the upstream python.org interpreter, the default encoding for loading files is locale-dependent (and is cp1252 in en_US, for example). This breaks when trying to load a `.yaml` file in UTF-8.

This fixes things by always treating files as `UTF-8`.  This is strictly not 100% YAML-compliant, which says YAML can be in UTF-8 or UTF-16 if a BOM is present.  However, the `yamllint` library doesn't provide a way to automatically determine the encoding -- it requires that its input as already decoded.  In practice, I don't think this is much of an issue: UTF-8 is the most sane choice in 2020 and we can just document that requirement.

For JSON files, the JSON standard *requires* it to be UTF-8 anyway, so we are now simply correct there.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
