### PR TITLE
Produces a warning when 'user' lifetime metrics are set to expire

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,10 @@ History
 Unreleased
 ----------
 
+* `glean_parser` now produces a linter error when `user` lifetime metrics are
+  set to expire. See [bug 1604854](https://bugzilla.mozilla.org/show_bug.cgi?id=1604854)
+  for additional context.
+
 1.90.0 (2020-03-18)
 -------------------
 

--- a/glean_parser/lint.py
+++ b/glean_parser/lint.py
@@ -194,6 +194,17 @@ def check_misspelled_pings(
                 )
 
 
+def check_user_lifetime_expiration(
+    metric: metrics.Metric, parser_config: Dict[str, Any] = {}
+) -> LintGenerator:
+
+    if metric.lifetime == metrics.Lifetime.user and metric.expires != "never":
+        yield (
+            "Metrics with `user` lifetime cannot have an expiration date. "
+            "They live as long as the user profile does."
+        )
+
+
 CATEGORY_CHECKS = {
     "COMMON_PREFIX": check_common_prefix,
     "CATEGORY_GENERIC": check_category_generic,
@@ -205,6 +216,7 @@ INDIVIDUAL_CHECKS = {
     "BUG_NUMBER": check_bug_number,
     "BASELINE_PING": check_valid_in_baseline,
     "MISSPELLED_PING": check_misspelled_pings,
+    "USER_LIFETIME_EXPIRATION": check_user_lifetime_expiration,
 }  # type: Dict[str, Callable[[metrics.Metric, dict], LintGenerator]]
 
 


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
