### PR TITLE
Bug 1589635: Treat linter warnings as errors in translate command.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,8 @@ History
 Unreleased
 ----------
 
-* `glean_parser` now produces a linter error when `user` lifetime metrics are
+* **Breaking change:** glinter errors found during the `translate` command will now return an error code. glinter warnings will be displayed, but not return an error code.
+* `glean_parser` now produces a linter warning when `user` lifetime metrics are
   set to expire. See [bug 1604854](https://bugzilla.mozilla.org/show_bug.cgi?id=1604854)
   for additional context.
 

--- a/glean_parser/lint.py
+++ b/glean_parser/lint.py
@@ -205,24 +205,43 @@ def check_user_lifetime_expiration(
         )
 
 
+# The checks that operate on an entire category of metrics:
+#    {NAME: (function, is_error)}
 CATEGORY_CHECKS = {
-    "COMMON_PREFIX": check_common_prefix,
-    "CATEGORY_GENERIC": check_category_generic,
-}  # type: Dict[str, Callable[[str, Iterable[metrics.Metric]], LintGenerator]]
+    "COMMON_PREFIX": (check_common_prefix, True),
+    "CATEGORY_GENERIC": (check_category_generic, True),
+}  # noqa type: Dict[str, Tuple[Callable[[str, Iterable[metrics.Metric]], LintGenerator], bool]]
 
 
+# The checks that operate on individual metrics:
+#     {NAME: (function, is_error)}
 INDIVIDUAL_CHECKS = {
-    "UNIT_IN_NAME": check_unit_in_name,
-    "BUG_NUMBER": check_bug_number,
-    "BASELINE_PING": check_valid_in_baseline,
-    "MISSPELLED_PING": check_misspelled_pings,
-    "USER_LIFETIME_EXPIRATION": check_user_lifetime_expiration,
-}  # type: Dict[str, Callable[[metrics.Metric, dict], LintGenerator]]
+    "UNIT_IN_NAME": (check_unit_in_name, True),
+    "BUG_NUMBER": (check_bug_number, True),
+    "BASELINE_PING": (check_valid_in_baseline, True),
+    "MISSPELLED_PING": (check_misspelled_pings, True),
+    "USER_LIFETIME_EXPIRATION": (check_user_lifetime_expiration, False),
+}  # type: Dict[str, Tuple[Callable[[metrics.Metric, dict], LintGenerator], bool]]
+
+
+class GlinterNit:
+    def __init__(self, check_name: str, name: str, msg: str, is_error: bool):
+        self.check_name = check_name
+        self.name = name
+        self.msg = msg
+        self.is_error = is_error
+
+    def format(self):
+        if self.is_error:
+            nit_type = "ERROR"
+        else:
+            nit_type = "WARNING"
+        return "{}: {}: {}: {}".format(nit_type, self.check_name, self.name, self.msg)
 
 
 def lint_metrics(
     objs: metrics.ObjectTree, parser_config: Dict[str, Any] = {}, file=sys.stderr
-) -> List[Tuple[str, str, str]]:
+) -> List[GlinterNit]:
     """
     Performs glinter checks on a set of metrics objects.
 
@@ -230,7 +249,7 @@ def lint_metrics(
     :param file: The stream to write errors to.
     :returns: List of nits.
     """
-    nits = []  # type: List[Tuple[str, str, str]]
+    nits = []  # type: List[GlinterNit]
     for (category_name, category) in sorted(list(objs.items())):
         if category_name == "pings":
             continue
@@ -242,23 +261,28 @@ def lint_metrics(
             if isinstance(metric, metrics.Metric)
         )
 
-        for (cat_check_name, cat_check_func) in CATEGORY_CHECKS.items():
+        for (cat_check_name, (cat_check_func, is_error)) in CATEGORY_CHECKS.items():
             if any(
                 cat_check_name in metric.no_lint for metric in category_metrics.values()
             ):
                 continue
             nits.extend(
-                (cat_check_name, category_name, msg)
+                GlinterNit(cat_check_name, category_name, msg, is_error)
                 for msg in cat_check_func(category_name, category_metrics.values())
             )
 
         for (metric_name, metric) in sorted(list(category_metrics.items())):
-            for (check_name, check_func) in INDIVIDUAL_CHECKS.items():
+            for (check_name, (check_func, is_error)) in INDIVIDUAL_CHECKS.items():
                 new_nits = list(check_func(metric, parser_config))
                 if len(new_nits):
                     if check_name not in metric.no_lint:
                         nits.extend(
-                            (check_name, ".".join([metric.category, metric.name]), msg)
+                            GlinterNit(
+                                check_name,
+                                ".".join([metric.category, metric.name]),
+                                msg,
+                                is_error,
+                            )
                             for msg in new_nits
                         )
                 else:
@@ -267,20 +291,21 @@ def lint_metrics(
                         and check_name in metric.no_lint
                     ):
                         nits.append(
-                            (
+                            GlinterNit(
                                 "SUPERFLUOUS_NO_LINT",
                                 ".".join([metric.category, metric.name]),
                                 (
                                     "Superfluous no_lint entry '{}'. "
                                     "Please remove it."
                                 ).format(check_name),
+                                False,
                             )
                         )
 
     if len(nits):
         print("Sorry, Glean found some glinter nits:", file=file)
-        for check_name, name, msg in nits:
-            print("{}: {}: {}".format(check_name, name, msg), file=file)
+        for nit in nits:
+            print(nit.format(), file=file)
         print("", file=file)
         print("Please fix the above nits to continue.", file=file)
         print(
@@ -345,8 +370,9 @@ def glinter(
     if util.report_validation_errors(objs):
         return 1
 
-    if lint_metrics(objs.value, parser_config=parser_config, file=file):
+    nits = lint_metrics(objs.value, parser_config=parser_config, file=file)
+    if any(nit.is_error for nit in nits):
         return 1
-
-    print("✨ Your metrics are Glean! ✨", file=file)
+    if len(nits) == 0:
+        print("✨ Your metrics are Glean! ✨", file=file)
     return 0

--- a/glean_parser/translate.py
+++ b/glean_parser/translate.py
@@ -11,7 +11,6 @@ High-level interface for translating `metrics.yaml` into other formats.
 from pathlib import Path
 import os
 import shutil
-import sys
 import tempfile
 from typing import Any, Callable, Dict, Iterable, List
 
@@ -84,16 +83,15 @@ def translate_metrics(
     :param parser_config: A dictionary of options that change parsing behavior.
         See `parser.parse_metrics` for more info.
     """
+    input_filepaths = util.ensure_list(input_filepaths)
+
+    if lint.glinter(input_filepaths, parser_config):
+        return 1
+
     all_objects = parser.parse_objects(input_filepaths, parser_config)
 
     if util.report_validation_errors(all_objects):
         return 1
-
-    if lint.lint_metrics(all_objects.value, parser_config):
-        print(
-            "NOTE: These warnings will become errors in a future release of Glean.",
-            file=sys.stderr,
-        )
 
     # allow_reserved is also relevant to the translators, so copy it there
     if parser_config.get("allow_reserved"):

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -3,11 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-import io
 from pathlib import Path
-
-
-import yaml
 
 
 from glean_parser import lint

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -281,6 +281,6 @@ def test_warnings():
 
     nits = lint.lint_metrics(all_metrics.value)
 
-    assert not any(x.is_error for x in nits)
+    assert not any(x.check_type == lint.CheckType.error for x in nits)
     assert len(nits) == 1
     assert nits[0].check_name == "SUPERFLUOUS_NO_LINT"


### PR DESCRIPTION
Also breaks out the concept of glinter warnings and errors so we can
add checks that don't break the build in the future.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
