### PR TITLE
Bug 1631078: Loosen minimum versions of dependencies and test them in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ commands:
                         # otherwise its dependencies might install newer versions of
                         # glean_parser's dependencies.
                         python3 -m venv .rb
-                        .rb/bin/pip install --progress-bar off requirements-builder
+                        .rb/bin/pip install requirements-builder
                         .rb/bin/requirements-builder --level=min setup.py > min_requirements.txt
 
                         pip install --progress-bar off --user -U -r min_requirements.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,13 @@ commands:
                     command: |
                         # Use requirements-builder to determine the minimum versions of
                         # all requirements and test those
-                        pip install --progress-bar off requirements-builder
-                        requirements-builder --level=min setup.py > min_requirements.txt
+                        # We install requirements-builder itself into its own venv, since
+                        # otherwise its dependencies might install newer versions of
+                        # glean_parser's dependencies.
+                        python3 -m venv .rb
+                        .rb/bin/pip install --progress-bar off requirements-builder
+                        .rb/bin/requirements-builder --level=min setup.py > min_requirements.txt
+
                         pip install --progress-bar off --user -U -r min_requirements.txt
 
     test-python-version:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,31 @@
 version: 2.1
 
 commands:
-    test-python-version:
-        parameters:
-            requirements-file:
-                type: string
-                default: "requirements_dev.txt"
+    test-start:
         steps:
             - checkout
             - run:
                     name: environment
                     command: |
                         echo 'export PATH=.:$HOME/.local/bin:$PATH' >> $BASH_ENV
+
+    test-min-requirements:
+        steps:
+            - run:
+                    name: install minimum requirements
+                    command: |
+                        # Use requirements-builder to determine the minimum versions of
+                        # all requirements and test those
+                        pip install --progress-bar off requirements-builder
+                        requirements-builder --level=min setup.py > min_requirements.txt
+                        pip install --progress-bar off --user -U -r min_requirements.txt
+
+    test-python-version:
+        parameters:
+            requirements-file:
+                type: string
+                default: "requirements_dev.txt"
+        steps:
             - run:
                     name: install
                     command: |
@@ -41,6 +55,16 @@ jobs:
         docker:
             - image: circleci/python:3.5.9
         steps:
+            - test-start
+            - test-python-version:
+                    requirements-file: requirements_dev_py35.txt
+
+    build-35-min:
+        docker:
+            - image: circleci/python:3.5.9
+        steps:
+            - test-start
+            - test-min-requirements
             - test-python-version:
                     requirements-file: requirements_dev_py35.txt
 
@@ -48,12 +72,14 @@ jobs:
         docker:
             - image: circleci/python:3.6.9
         steps:
+            - test-start
             - test-python-version
 
     build-37:
         docker:
             - image: circleci/python:3.7.5
         steps:
+            - test-start
             - test-python-version
             - run:
                     name: make-docs
@@ -68,6 +94,15 @@ jobs:
         docker:
             - image: circleci/python:3.8.0
         steps:
+            - test-start
+            - test-python-version
+
+    build-38-min:
+        docker:
+            - image: circleci/python:3.8.0
+        steps:
+            - test-start
+            - test-min-requirements
             - test-python-version
 
     docs-deploy:
@@ -119,6 +154,10 @@ workflows:
                     filters:
                         tags:
                             only: /.*/
+            - build-35-min:
+                    filters:
+                        tags:
+                            only: /.*/
             - build-36:
                     filters:
                         tags:
@@ -128,6 +167,10 @@ workflows:
                         tags:
                             only: /.*/
             - build-38:
+                    filters:
+                        tags:
+                            only: /.*/
+            - build-38-min:
                     filters:
                         tags:
                             only: /.*/

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,8 @@ History
 Unreleased
 ----------
 
+* The minimum version of the runtime dependencies has been lowered to increase compatibility with other tools.  These minimum versions are now tested in CI, in addition to testing the latest versions of the dependencies that was already happening in CI.
+
 1.20.0 (2020-04-15)
 -------------------
 

--- a/glean_parser/util.py
+++ b/glean_parser/util.py
@@ -253,6 +253,10 @@ def fetch_remote_url(url: str, cache: bool = True):
     Fetches the contents from an HTTP url or local file path, and optionally
     caches it to disk.
     """
+    # Include the Python version in the cache key, since caches aren't
+    # sharable across Python versions.
+    key = (url, str(sys.version_info))
+
     is_http = url.startswith("http")
 
     if not is_http:
@@ -263,8 +267,8 @@ def fetch_remote_url(url: str, cache: bool = True):
     if cache:
         cache_dir = appdirs.user_cache_dir("glean_parser", "mozilla")
         with diskcache.Cache(cache_dir) as dc:
-            if url in dc:
-                return dc[url]
+            if key in dc:
+                return dc[key]
 
     contents = urllib.request.urlopen(url).read()  # type: ignore
 
@@ -276,7 +280,7 @@ def fetch_remote_url(url: str, cache: bool = True):
 
     if cache:
         with diskcache.Cache(cache_dir) as dc:
-            dc[url] = contents
+            dc[key] = contents
 
     return contents
 

--- a/setup.py
+++ b/setup.py
@@ -24,16 +24,16 @@ with open("HISTORY.rst", encoding="utf-8") as history_file:
     history = history_file.read()
 
 requirements = [
-    "appdirs>=1.4.3",
-    "Click>=7.0",
-    "diskcache>=4.0.0",
-    "iso8601>=0.1.12",
+    "appdirs>=1.4",
+    "Click>=7",
+    "diskcache>=4",
+    "iso8601>=0.1.10",
     "Jinja2>=2.10.1,<3.0",
     "jsonschema>=3.0.2",
     # 'markupsafe' is required by Jinja2. From version 2.0.0 on
     # py3.5 support is dropped.
     "markupsafe>=1.1,<2.0.0",
-    "pep487==1.0.1",
+    "pep487>=1.0.1",
     "PyYAML>=3.13",
     "yamllint>=1.18.0",
     # 'zipp' is required by jsonschema->importlib_metadata,

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ requirements = [
     "Click>=7",
     "diskcache>=4",
     "iso8601>=0.1.10",
+    # Jinja2 3.0.0 will drop Python 3.5 support.
     "Jinja2>=2.10.1,<3.0",
     "jsonschema>=3.0.2",
     # 'markupsafe' is required by Jinja2. From version 2.0.0 on


### PR DESCRIPTION
This lowers the minimum versions of dependencies as far as we can without breaking our unit tests.  Then it adds this to CI to make sure we don't start using newer APIs accidentally without updating the minimum versions.  (The third-party "requirements-builder" tool is used to help with this process).

This is a prerequisite to doing the same thing in Glean SDK.

This shouldn't have any bearing on the vendoring in m-c.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
