### PR TITLE
Bug 1631078: More fine-grained version control

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,8 @@ History
 Unreleased
 ----------
 
+* Dependencies that depend on the version of Python being used are now specified using the `Declaring platform specific dependencies syntax in setuptools <https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-platform-specific-dependencies>`__. This means that more recent versions of dependencies are likely to be installed on Python 3.6 and later, and unnecessary backport libraries won't be installed on more recent Python versions.
+
 1.12.1 (2020-04-21)
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -27,19 +27,20 @@ requirements = [
     "appdirs>=1.4",
     "Click>=7",
     "diskcache>=4",
-    "iso8601>=0.1.10",
+    "iso8601>=0.1.10; python_version<='3.6'",
     # Jinja2 3.0.0 will drop Python 3.5 support.
-    "Jinja2>=2.10.1,<3.0",
+    "Jinja2>=2.10.1,<3.0; python_version=='3.5'",
+    "Jinja2>=2.10.1; python_version>'3.5'",
     "jsonschema>=3.0.2",
     # 'markupsafe' is required by Jinja2. From version 2.0.0 on
     # py3.5 support is dropped.
-    "markupsafe>=1.1,<2.0.0",
-    "pep487>=1.0.1",
+    "markupsafe>=1.1,<2.0.0; python_version=='3.5'",
+    "pep487>=1.0.1; python_version=='3.5'",
     "PyYAML>=3.13",
     "yamllint>=1.18.0",
     # 'zipp' is required by jsonschema->importlib_metadata,
     # it drops py3.5 in newer versions.
-    "zipp>=0.5,<2.0",
+    "zipp>=0.5,<2.0; python_version=='3.5'",
 ]
 
 setup_requirements = ["pytest-runner", "setuptools-scm"]


### PR DESCRIPTION
This is a follow-on to #184 to improve the dependency specifications even further using a syntax that was rather hard to find: https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-platform-specific-dependencies

This means we can specify the maximum version of packages *only* for when it matters (on Python 3.5), and specify the backport compatibility libraries to *only* be required when needed on older versions of Python.

This should also help with making glean_parser dependencies more broadly compatible with more environments that it may be installed into, because more recent versions of things will be considered "compatible with glean_parser" on more recent versions of Python.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
