### PR TITLE
Bug 1640997: Use time_unit to control min and max range

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,8 @@ History
 Unreleased
 ----------
 
+* Support for using `timing_distribution`'s `time_unit` parameter to control the range of acceptable values is documented. The default unit for this use case is `nanosecond` to avoid creating a breaking change.  See [bug 1630997](https://bugzilla.mozilla.org/show_bug.cgi?id=1630997) for more information.
+
 1.20.2 (2020-04-24)
 -------------------
 

--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -219,6 +219,10 @@ class Timespan(TimeBase):  # type: ignore
 class TimingDistribution(TimeBase):  # type: ignore
     typename = "timing_distribution"
 
+    def __init__(self, *args, **kwargs):
+        self.time_unit = getattr(TimeUnit, kwargs.pop("time_unit", "nanosecond"))
+        Metric.__init__(self, *args, **kwargs)
+
 
 class MemoryUnit(enum.Enum):
     byte = 0

--- a/glean_parser/schemas/metrics.1-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.1-0-0.schema.yaml
@@ -256,12 +256,21 @@ definitions:
       time_unit:
         title: Time unit
         description: |
-          Specifies the unit that the metric will be stored and displayed in. If
-          not provided, it defaults to milliseconds. Time values are sent to the
-          backend as integers, so `time_unit`_ determines the maximum resolution
-          at which timespans are recorded. Times are always truncated, not
-          rounded, to the nearest time unit. For example, a measurement of 25 ns
-          will be returned as 0 ms if `time_unit` is `"millisecond"`.
+          For timespans and datetimes, specifies the unit that the metric will
+          be stored and displayed in. If not provided, it defaults to
+          "millisecond". Time values are sent to the backend as integers, so
+          `time_unit`_ determines the maximum resolution at which timespans are
+          recorded. Times are always truncated, not rounded, to the nearest time
+          unit. For example, a measurement of 25 ns will be returned as 0 ms if
+          `time_unit` is `"millisecond"`.
+
+          For timing distributions, times are always recorded and sent in
+          nanoseconds, but `time_unit` controls the minimum and maximum values.
+          If not provided, it defaults to "nanosecond".
+
+          - nanosecond: 1ns <= x <= 10 minutes
+          - microsecond: 1μs <= x <= ~6.94 days
+          - millisecond: 1ms <= x <= ~19 years
 
           Valid when `type`_ is `timespan`, `timing_distribution` or `datetime`.
         enum:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -303,6 +303,21 @@ def test_geckoview_only_on_valid_metrics():
     assert "is only allowed for" in str(errs[0])
 
 
+def test_timing_distribution_unit_default():
+    contents = [{"category1": {"metric1": {"type": "timing_distribution"}}}]
+    contents = [util.add_required(x) for x in contents]
+
+    print(contents)
+    all_metrics = parser.parse_objects(contents)
+    errs = list(all_metrics)
+    assert len(errs) == 0
+    print(all_metrics.value)
+    assert (
+        all_metrics.value["category1"]["metric1"].time_unit
+        == metrics.TimeUnit.nanosecond
+    )
+
+
 def test_all_pings_reserved():
     # send_in_pings: [all-pings] is only allowed for internal metrics
     contents = [

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -307,11 +307,9 @@ def test_timing_distribution_unit_default():
     contents = [{"category1": {"metric1": {"type": "timing_distribution"}}}]
     contents = [util.add_required(x) for x in contents]
 
-    print(contents)
     all_metrics = parser.parse_objects(contents)
     errs = list(all_metrics)
     assert len(errs) == 0
-    print(all_metrics.value)
     assert (
         all_metrics.value["category1"]["metric1"].time_unit
         == metrics.TimeUnit.nanosecond


### PR DESCRIPTION
Part of mozilla/glean#850

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
