### PR TITLE
Bug 1635754 - Explicitly test that underscores in ping names are disallowed

### DIFF
--- a/tests/data/invalid-ping-names.yaml
+++ b/tests/data/invalid-ping-names.yaml
@@ -1,0 +1,23 @@
+# Any copyright is dedicated to the Public Domain.
+# https://creativecommons.org/publicdomain/zero/1.0/
+
+---
+$schema: moz://mozilla.org/schemas/glean/metrics/1-0-0
+
+telemetry:
+  client_id:
+    type: uuid
+    lifetime: user
+    description: >
+      A UUID identifying a profile and allowing user-oriented
+      Correlation of data.
+      Some Unicode: جمع 搜集
+    bugs:
+      - https://bugzilla.mozilla.org/1137353
+    data_reviews:
+      - http://example.com/reviews
+    notification_emails:
+      - CHANGE-ME@example.com
+    send_in_pings:
+      - invalid_ping_name
+    expires: 2100-01-01

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -503,3 +503,11 @@ def test_do_not_disable_expired():
 
     metrics = all_metrics.value
     assert metrics["category"]["metric"].disabled is False
+
+
+def test_send_in_pings_restrictions():
+    """Test that invalid ping names are disallowed in `send_in_pings`."""
+    all_metrics = parser.parse_objects(ROOT / "data" / "invalid-ping-names.yaml")
+    errors = list(all_metrics)
+    assert len(errors) == 1
+    assert "'invalid_ping_name' does not match" in errors[0]

--- a/tests/test_swift.py
+++ b/tests/test_swift.py
@@ -53,7 +53,7 @@ def test_parser(tmpdir):
     # Only run this test if swiftc is on the path.
     if shutil.which("swiftc"):
         for filepath in tmpdir.glob("*.swift"):
-            subprocess.check_call(["swiftc", "-dump-parse", filepath])
+            subprocess.check_call(["swiftc", "-parse", filepath])
 
     # Lint check on the generated files.
     # Only run this test if swiftlint is on the path.


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
