### PR TITLE
Reorder the values of the `Lifetime` enum

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ Unreleased
 * `glinter` messages have been improved with more details and to be more
   actionable.
 * A maximum of 10 `extra_keys` is now enforced for `event` metric types.
+* BUGFIX: the `Lifetime` enum values now match the values of the implementation in mozilla/glean. 
 
 1.20.4 (2020-05-07)
 -------------------

--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -26,10 +26,13 @@ else:
     base_object = object
 
 
+# Important: if the values are ever changing here, make sure
+# to also fix mozilla/glean. Otherwise language bindings may
+# break there.
 class Lifetime(enum.Enum):
     ping = 0
-    user = 1
-    application = 2
+    application = 1
+    user = 2
 
 
 class Metric(base_object):  # type: ignore


### PR DESCRIPTION
The value of `user` and `application` were not matching the ones in mozilla/glean used for the Python bindings, causing all the metrics with "lifetime: application" to be sent as "lifetime: user".

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
