### PR TITLE
Bug 1652471: Unify the extra_args values in the generator

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,8 @@ Unreleased
 ----------
 
 * Add support for generating C# code.
+* BUGFIX: The memory unit is now correctly passed to the MemoryDistribution
+  metric type in Swift.
 
 1.24.0 (2020-06-30)
 -------------------

--- a/glean_parser/csharp.py
+++ b/glean_parser/csharp.py
@@ -127,25 +127,6 @@ def output_csharp(
         ),
     )
 
-    # The object parameters to pass to constructors
-    extra_args = [
-        "allowed_extra_keys",
-        "bucket_count",
-        "category",
-        "disabled",
-        "histogram_type",
-        "include_client_id",
-        "send_if_empty",
-        "lifetime",
-        "memory_unit",
-        "name",
-        "range_max",
-        "range_min",
-        "reason_codes",
-        "send_in_pings",
-        "time_unit",
-    ]
-
     namespace = options.get("namespace", "GleanMetrics")
     glean_namespace = options.get("glean_namespace", "Mozilla.Glean")
 
@@ -158,7 +139,7 @@ def output_csharp(
                 template.render(
                     category_name=category_key,
                     objs=category_val,
-                    extra_args=extra_args,
+                    extra_args=util.extra_args,
                     namespace=namespace,
                     glean_namespace=glean_namespace,
                 )

--- a/glean_parser/kotlin.py
+++ b/glean_parser/kotlin.py
@@ -222,25 +222,6 @@ def output_kotlin(
         ),
     )
 
-    # The object parameters to pass to constructors
-    extra_args = [
-        "allowed_extra_keys",
-        "bucket_count",
-        "category",
-        "disabled",
-        "histogram_type",
-        "include_client_id",
-        "send_if_empty",
-        "lifetime",
-        "memory_unit",
-        "name",
-        "range_max",
-        "range_min",
-        "reason_codes",
-        "send_in_pings",
-        "time_unit",
-    ]
-
     namespace = options.get("namespace", "GleanMetrics")
     glean_namespace = options.get("glean_namespace", "mozilla.components.service.glean")
 
@@ -261,7 +242,7 @@ def output_kotlin(
                     category_name=category_key,
                     objs=category_val,
                     obj_types=obj_types,
-                    extra_args=extra_args,
+                    extra_args=util.extra_args,
                     namespace=namespace,
                     has_labeled_metrics=has_labeled_metrics,
                     glean_namespace=glean_namespace,

--- a/glean_parser/swift.py
+++ b/glean_parser/swift.py
@@ -140,21 +140,6 @@ def output_swift(
         ),
     )
 
-    # The object parameters to pass to constructors.
-    # **CAUTION**: This list needs to be in the order the type constructor expects them.
-    # The `test_order_of_fields` test checks that the generated code is valid.
-    # **DO NOT CHANGE THE ORDER OR ADD NEW FIELDS IN THE MIDDLE**
-    extra_args = [
-        "category",
-        "name",
-        "send_in_pings",
-        "lifetime",
-        "disabled",
-        "time_unit",
-        "allowed_extra_keys",
-        "reason_codes",
-    ]
-
     namespace = options.get("namespace", "GleanMetrics")
     glean_namespace = options.get("glean_namespace", "Glean")
 
@@ -178,7 +163,7 @@ def output_swift(
         fd.write(
             template.render(
                 categories=categories,
-                extra_args=extra_args,
+                extra_args=util.extra_metric_args,
                 namespace=namespace,
                 glean_namespace=glean_namespace,
                 allow_reserved=options.get("allow_reserved", False),

--- a/glean_parser/util.py
+++ b/glean_parser/util.py
@@ -381,3 +381,40 @@ def report_validation_errors(all_objects):
         print("=" * 78, file=sys.stderr)
         print(error, file=sys.stderr)
     return found_error
+
+
+# Names of metric parameters to pass to constructors.
+# This includes only things that the language bindings care about, not things
+# that are metadata-only or are resolved into other parameters at parse time.
+# **CAUTION**: This list needs to be in the order the Swift type constructors
+# expects them. (The other language bindings don't care about the order). The
+# `test_order_of_fields` test checks that the generated code is valid.
+# **DO NOT CHANGE THE ORDER OR ADD NEW FIELDS IN THE MIDDLE**
+extra_metric_args = [
+    "category",
+    "name",
+    "send_in_pings",
+    "lifetime",
+    "disabled",
+    "time_unit",
+    "memory_unit",
+    "allowed_extra_keys",
+    "reason_codes",
+    "bucket_count",
+    "range_max",
+    "range_min",
+    "histogram_type",
+]
+
+
+# Names of ping parameters to pass to constructors.
+extra_ping_args = [
+    "include_client_id",
+    "send_if_empty",
+    "name",
+    "reason_codes",
+]
+
+
+# Names of parameters to pass to both metric and ping constructors.
+extra_args = list(set(extra_metric_args) | set(extra_ping_args))


### PR DESCRIPTION
This also detected a bug that `memory_unit` was missing from the Swift
generator.
Fortunately none of our iOS seem to be using MemoryDistribution yet.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
