### PR TITLE
Bug 1650787 - Support JWE metric types

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,8 @@ History
 Unreleased
 ----------
 
+* Add support for JWE metric types.
+
 1.25.0 (2020-07-17)
 -------------------
 

--- a/glean_parser/markdown.py
+++ b/glean_parser/markdown.py
@@ -33,6 +33,9 @@ def extra_info(obj: Union[metrics.Metric, pings.Ping]) -> List[Tuple[str, str]]:
         for label in obj.ordered_labels:
             extra_info.append((label, None))
 
+    if isinstance(obj, metrics.Jwe):
+        extra_info.append(("decrypted_name", obj.decrypted_name))
+
     return extra_info
 
 

--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -286,6 +286,14 @@ class Uuid(Metric):
     typename = "uuid"
 
 
+class Jwe(Metric):
+    typename = "jwe"
+
+    def __init__(self, *args, **kwargs):
+        self.decrypted_name = kwargs.pop("decrypted_name")
+        super().__init__(*args, **kwargs)
+
+
 class Labeled(Metric):
     labeled = True
 

--- a/glean_parser/schemas/metrics.1-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.1-0-0.schema.yaml
@@ -97,6 +97,8 @@ definitions:
 
             - `uuid`: Record a UUID v4.
 
+            - `jwe`: Record a JWE value.
+
             - `memory_distribution`: A histogram for recording memory usage
               values. Additional properties: `memory_unit`.
 
@@ -127,6 +129,7 @@ definitions:
           - memory_distribution
           - datetime
           - uuid
+          - jwe
           - labeled_boolean
           - labeled_string
           - labeled_counter
@@ -412,6 +415,16 @@ definitions:
         items:
           type: string
 
+      decrypted_name:
+        title: Decrypted name
+        description: |
+          Name of the column where to persist the decrypted value
+          stored in the JWE after processing.
+
+          Required when `type`_ is `jwe`.
+        type: string
+        pattern: "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})*$"
+
     required:
       - type
       - bugs
@@ -529,3 +542,13 @@ additionalProperties:
             - unit
           description: |
             `quantity` is missing required parameter `unit`.
+      -
+        if:
+          properties:
+            type:
+              const: jwe
+        then:
+          required:
+            - decrypted_name
+          description: |
+            `jwe` is missing required parameter `decrypted_name`.

--- a/glean_parser/schemas/metrics.1-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.1-0-0.schema.yaml
@@ -97,7 +97,7 @@ definitions:
 
             - `uuid`: Record a UUID v4.
 
-            - `jwe`: Record a JWE value.
+            - `jwe`: Record a [JWE](https://tools.ietf.org/html/rfc7516) value.
 
             - `memory_distribution`: A histogram for recording memory usage
               values. Additional properties: `memory_unit`.


### PR DESCRIPTION
* Create JweMetric objects from Swift, Kotlin and C#;
* Display JWE metrics in markdown with `decrypted_name` as an extra.