### PR TITLE
Add support for HashSet and Dictionary in the C# template

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,8 @@ History
 Unreleased
 ----------
 
+* BUGFIX: Support HashSet and Dictionary in the C# generated code.
+
 1.28.2 (2020-07-28)
 -------------------
 

--- a/glean_parser/csharp.py
+++ b/glean_parser/csharp.py
@@ -24,8 +24,8 @@ def csharp_datatypes_filter(value: util.JSONType) -> str:
 
     Based on Python's JSONEncoder, but overrides:
       - lists to use `new string[] {}` (only strings)
-      - dicts to use mapOf (not currently supported)
-      - sets to use setOf (not currently supported)
+      - dicts to use `new Dictionary<string, string> { ...}` (string, string)
+      - sets to use `new HashSet<string>() {}` (only strings)
       - enums to use the like-named C# enum
     """
 
@@ -42,27 +42,29 @@ def csharp_datatypes_filter(value: util.JSONType) -> str:
                     first = False
                 yield "}"
             elif isinstance(value, dict):
-                yield "mapOf("
+                yield "new Dictionary<string, string> {"
                 first = True
                 for key, subvalue in value.items():
                     if not first:
                         yield ", "
+                    yield "{"
                     yield from self.iterencode(key)
-                    yield " to "
+                    yield ", "
                     yield from self.iterencode(subvalue)
+                    yield "}"
                     first = False
-                yield ")"
+                yield "}"
             elif isinstance(value, enum.Enum):
                 yield (value.__class__.__name__ + "." + util.Camelize(value.name))
             elif isinstance(value, set):
-                yield "setOf("
+                yield "new HashSet<string>() {"
                 first = True
                 for subvalue in sorted(list(value)):
                     if not first:
                         yield ", "
                     yield from self.iterencode(subvalue)
                     first = False
-                yield ")"
+                yield "}"
             else:
                 yield from super().iterencode(value)
 

--- a/glean_parser/templates/csharp.jinja2
+++ b/glean_parser/templates/csharp.jinja2
@@ -20,6 +20,7 @@ Jinja2 template is not. Please file bugs! #}
             ){% if lazy %});{% else %};{% endif %}{% endmacro %}
 
 using System;
+using System.Collections.Generic;
 using {{ glean_namespace }}.Private;
 
 {# The C# metrics design require the class name to have a 'Definition'

--- a/tests/test_csharp.py
+++ b/tests/test_csharp.py
@@ -86,7 +86,7 @@ def test_csharp_generator():
     assert cdf(["test", "\n"]) == r'new string[] {"test", "\n"}'
     assert (
         cdf(OrderedDict([("key", "value"), ("key2", "value2")]))
-        == r'mapOf("key" to "value", "key2" to "value2")'
+        == r'new Dictionary<string, string> {{"key", "value"}, {"key2", "value2"}}'
     )
     assert cdf(metrics.Lifetime.ping) == "Lifetime.Ping"
 


### PR DESCRIPTION
Without this events and static labels for labeled types would fail to compile.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
