### PR TITLE
Bug 1599764: Warn about expired metrics

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ Unreleased
 ----------
 
 * The `SUPERFLUOUS_NO_LINT` warning has been removed from the glinter. It likely did more harm than good, and makes it hard to make `metrics.yaml` files that pass across different versions of `glean_parser`.
+* Expired metrics will now produce a linter warning, `EXPIRED_METRIC`.
 
 1.28.3 (2020-07-28)
 -------------------

--- a/glean_parser/lint.py
+++ b/glean_parser/lint.py
@@ -235,6 +235,13 @@ def check_user_lifetime_expiration(
         )
 
 
+def check_expired_metric(
+    metric: metrics.Metric, parser_config: Dict[str, Any] = {}
+) -> LintGenerator:
+    if metric.is_expired():
+        yield ("Metric has expired. Please consider removing it.")
+
+
 # The checks that operate on an entire category of metrics:
 #    {NAME: (function, is_error)}
 CATEGORY_CHECKS: Dict[
@@ -255,6 +262,7 @@ INDIVIDUAL_CHECKS: Dict[
     "BASELINE_PING": (check_valid_in_baseline, CheckType.error),
     "MISSPELLED_PING": (check_misspelled_pings, CheckType.error),
     "USER_LIFETIME_EXPIRATION": (check_user_lifetime_expiration, CheckType.warning),
+    "EXPIRED": (check_expired_metric, CheckType.warning),
 }
 
 

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -240,3 +240,29 @@ def test_user_lifetime_expiration():
 
     assert len(nits) == 1
     assert set(["USER_LIFETIME_EXPIRATION"]) == set(v.check_name for v in nits)
+
+
+def test_expired_metric():
+    """Test that expiring 'user' lifetime metrics generate a warning."""
+    contents = [
+        {
+            "user_data": {
+                "counter": {
+                    "type": "counter",
+                    "lifetime": "ping",
+                    "expires": "1999-01-01",
+                },
+            }
+        }
+    ]
+
+    contents = [util.add_required(x) for x in contents]
+    all_metrics = parser.parse_objects(contents)
+
+    errs = list(all_metrics)
+    assert len(errs) == 0
+
+    nits = lint.lint_metrics(all_metrics.value)
+
+    assert len(nits) == 1
+    assert set(["EXPIRED"]) == set(v.check_name for v in nits)


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
