### PR TITLE
Be more specific about what the autodocs documents

### DIFF
--- a/glean_parser/templates/markdown.jinja2
+++ b/glean_parser/templates/markdown.jinja2
@@ -3,7 +3,7 @@
 Jinja2 template is not. Please file bugs! #}
 
 # Metrics
-This document enumerates the metrics collected by {{ project_title }}.
+This document enumerates the metrics collected by {{ project_title }} using the [Glean SDK](https://mozilla.github.io/glean/book/index.html).
 This project may depend on other projects which also collect metrics.
 This means you might have to go searching through the dependency tree to get a full picture of everything collected by this project.
 


### PR DESCRIPTION
This documentation might be misunderstood as enumerating _all_ the data being collected by this project. In e.g. Firefox Desktop there is (and will for the foreseeable future continue to be) quite a lot of other data being collected by other means, so we should be specific here.

No Changelog needed because it's a pedantic change to autodocs only.