### PR TITLE
Bug 1658349 - Allow using the quantity metric type outside of Gecko

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ Unreleased
 * The `SUPERFLUOUS_NO_LINT` warning has been removed from the glinter. It likely did more harm than good, and makes it hard to make `metrics.yaml` files that pass across different versions of `glean_parser`.
 * Expired metrics will now produce a linter warning, `EXPIRED_METRIC`.
 * Expiry dates that are more than 730 days (~2 years) in the future will produce a linter warning, `EXPIRATION_DATE_TOO_FAR`.
+* Allow using the Quantity metric type outside of Gecko.
 
 1.28.3 (2020-07-28)
 -------------------

--- a/glean_parser/markdown.py
+++ b/glean_parser/markdown.py
@@ -36,6 +36,9 @@ def extra_info(obj: Union[metrics.Metric, pings.Ping]) -> List[Tuple[str, str]]:
     if isinstance(obj, metrics.Jwe):
         extra_info.append(("decrypted_name", obj.decrypted_name))
 
+    if isinstance(obj, metrics.Quantity):
+        extra_info.append(("unit", obj.unit))
+
     return extra_info
 
 

--- a/glean_parser/schemas/metrics.1-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.1-0-0.schema.yaml
@@ -83,8 +83,7 @@ definitions:
 
             - `counter`: A numeric value that can only be incremented.
 
-            - `quantity`: A numeric value that is set directly. Only allowed for
-              metrics coming from GeckoView.
+            - `quantity`: A numeric value that is set directly.
 
             - `timespan`: Represents a time interval. Additional properties:
               `time_unit`.
@@ -548,12 +547,11 @@ additionalProperties:
             type:
               enum:
                 - custom_distribution
-                - quantity
         then:
           required:
             - gecko_datapoint
           description: |
-            `custom_distribution` and `quantity` is only allowed for Gecko
+            `custom_distribution` is only allowed for Gecko
             metrics.
       -
         if:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -575,11 +575,10 @@ def test_quantity():
     contents = [util.add_required(x) for x in contents]
     all_metrics = parser.parse_objects(contents)
     errors = list(all_metrics)
-    assert len(errors) == 2
+    assert len(errors) == 1
     assert any(
         "`quantity` is missing required parameter `unit`" in err for err in errors
     )
-    assert any("is only allowed for Gecko" in err for err in errors)
 
     # Test that quantity works
     contents = [

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -569,7 +569,7 @@ def test_memory_distribution():
 
 
 def test_quantity():
-    # Test that we get an error for a missing unit and gecko_datapoint
+    # Test that we get an error for a missing unit
     contents = [{"category": {"metric": {"type": "quantity"}}}]
 
     contents = [util.add_required(x) for x in contents]


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
