### PR TITLE
Bug 1664889: Display glean_parser version when there is an error

### DIFF
--- a/glean_parser/__main__.py
+++ b/glean_parser/__main__.py
@@ -131,5 +131,18 @@ main.add_command(check)
 main.add_command(glinter)
 
 
+def main_wrapper(args=None):
+    """
+    A simple wrapper around click's `main` to display the glean_parser version
+    when there is an error.
+    """
+    try:
+        main(args=args)
+    except SystemExit as e:
+        if e.code != 0:
+            print(f"ERROR running glean_parser v{glean_parser.__version__}")
+        raise
+
+
 if __name__ == "__main__":
-    sys.exit(main())  # pragma: no cover
+    main_wrapper()  # pragma: no cover

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     description="Parser tools for Mozilla's Glean telemetry",
     entry_points={
         "console_scripts": [
-            "glean_parser=glean_parser.__main__:main",
+            "glean_parser=glean_parser.__main__:main_wrapper",
         ],
     },
     install_requires=requirements,


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
