### PR TITLE
Bug 1666192 - Ensure kotlin arguments are deterministically ordered

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,7 @@ Unreleased
 -------------------
 
 * Fix deploy step to update pip before deploying to pypi.
+* BUGFIX: Ensure Kotlin arguments are deterministically ordered
 
 1.28.4 (2020-09-14)
 -------------------

--- a/glean_parser/util.py
+++ b/glean_parser/util.py
@@ -434,5 +434,7 @@ extra_ping_args = [
 ]
 
 
-# Names of parameters to pass to both metric and ping constructors.
-extra_args = list(set(extra_metric_args) | set(extra_ping_args))
+# Names of parameters to pass to both metric and ping constructors (no duplicates).
+extra_args = extra_metric_args + [
+    v for v in extra_ping_args if v not in extra_metric_args
+]

--- a/tests/test_kotlin.py
+++ b/tests/test_kotlin.py
@@ -353,3 +353,28 @@ def test_event_extra_keys_in_correct_order(tmpdir):
         content = " ".join(content.split())
         assert "exampleKeys { alice, bob, charlie }" in content
         assert 'allowedExtraKeys = listOf("alice", "bob", "charlie")' in content
+
+
+def test_arguments_are_generated_in_deterministic_order(tmpdir):
+    """
+    Assert that arguments on generated code are always on the same order.
+
+    https://bugzilla.mozilla.org/show_bug.cgi?id=1666192
+    """
+
+    tmpdir = Path(str(tmpdir))
+
+    translate.translate(
+        ROOT / "data" / "event_key_ordering.yaml",
+        "kotlin",
+        tmpdir,
+        {"namespace": "Foo"},
+    )
+
+    assert set(x.name for x in tmpdir.iterdir()) == set(["Event.kt"])
+
+    with (tmpdir / "Event.kt").open("r", encoding="utf-8") as fd:
+        content = fd.read()
+        content = " ".join(content.split())
+        expected = 'EventMetricType<exampleKeys> by lazy { EventMetricType<exampleKeys>( category = "event", name = "example", sendInPings = listOf("events"), lifetime = Lifetime.Ping, disabled = false, allowedExtraKeys = listOf("alice", "bob", "charlie") ) } }'  # noqa
+        assert expected in content

--- a/tests/test_kotlin.py
+++ b/tests/test_kotlin.py
@@ -357,7 +357,7 @@ def test_event_extra_keys_in_correct_order(tmpdir):
 
 def test_arguments_are_generated_in_deterministic_order(tmpdir):
     """
-    Assert that arguments on generated code are always on the same order.
+    Assert that arguments on generated code are always in the same order.
 
     https://bugzilla.mozilla.org/show_bug.cgi?id=1666192
     """


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
