### PR TITLE
Bug 1675771: Redirect linter output correctly

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,8 @@ History
 Unreleased
 ----------
 
+* BUGFIX: Linter output can now be redirected correctly (1675771).
+
 1.29.0 (2020-10-07)
 -------------------
 

--- a/glean_parser/lint.py
+++ b/glean_parser/lint.py
@@ -402,7 +402,7 @@ def lint_yaml_files(
     if len(nits):
         print("Sorry, Glean found some glinter nits:", file=file)
         for (path, p) in nits:
-            print(f"{path} ({p.line}:{p.column}) - {p.message}")
+            print(f"{path} ({p.line}:{p.column}) - {p.message}", file=file)
         print("", file=file)
         print("Please fix the above nits to continue.", file=file)
 


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
