### PR TITLE
Fix pytest warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,3 @@ exclude = docs
 
 [aliases]
 test = pytest
-
-[tool:pytest]
-collect_ignore = ['setup.py']


### PR DESCRIPTION
We are using a deprecated configuration parameter to pytest that is no longer necessary.

This fixes the following warning:

```
site-packages/_pytest/config/__init__.py:1233: PytestConfigWarning: Unknown config option: collect_ignore

    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
