### PR TITLE
Recommend https over git for cloning

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -32,7 +32,7 @@ You can either clone the public repository:
 
 .. code-block:: console
 
-    $ git clone git://github.com/mdboom/glean_parser
+    $ git clone https://github.com/mozilla/glean_parser.git
 
 Or download the `tarball`_:
 


### PR DESCRIPTION
TIL the `git` protocol is fundamentally insecure, so should probably not recommend it.  (I think this doc actually comes from a cookiecutter template -- that should probably be patched upstream, too).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
