### PR TITLE
bug 1685406 - Add telemetry_mirror optional field to metrics schema

### DIFF
--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -57,6 +57,7 @@ class Metric:
         no_lint: Optional[List[str]] = None,
         data_sensitivity: Optional[List[str]] = None,
         defined_in: Optional[Dict] = None,
+        telemetry_mirror: Optional[str] = None,
         _config: Dict[str, Any] = None,
         _validated: bool = False,
     ):
@@ -90,6 +91,8 @@ class Metric:
                 getattr(DataSensitivity, x) for x in data_sensitivity
             ]
         self.defined_in = defined_in
+        if telemetry_mirror is not None:
+            self.telemetry_mirror = telemetry_mirror
 
         # _validated indicates whether this metric has already been jsonschema
         # validated (but not any of the Python-level validation).

--- a/glean_parser/schemas/metrics.2-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.2-0-0.schema.yaml
@@ -467,6 +467,18 @@ definitions:
         minLength: 1
         uniqueItems: true
 
+      telemetry_mirror:
+        title: Which probe in Telemetry to mirror this metric's value to.
+        description: |
+          The C++ enum form of the Scalar, Event, or Histogram to which we
+          should mirror values.
+          Use is limited to Firefox Desktop only.
+          Has no effect when used with non-FOG outputters.
+          See FOG's documentation on mirroring for details -
+          https://firefox-source-docs.mozilla.org/toolkit/components/glean/mirroring.html
+        type: string
+        minLength: 6
+
     required:
       - type
       - bugs

--- a/tests/data/telemetry_mirror.yaml
+++ b/tests/data/telemetry_mirror.yaml
@@ -1,0 +1,20 @@
+# Any copyright is dedicated to the Public Domain.
+# https://creativecommons.org/publicdomain/zero/1.0/
+
+---
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+
+telemetry.mirrored:
+  parses_fine:
+    type: string
+    lifetime: application
+    description: >
+      Test metric to ensure telemetry_mirror properties parse.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1685406
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1685406#c1
+    notification_emails:
+      - CHANGE-ME@example.com
+    expires: never
+    telemetry_mirror: telemetry.test.string_kind

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -628,3 +628,22 @@ def test_historical_versions():
 
     errors = list(all_metrics)
     assert len(errors) == 1
+
+
+def test_telemetry_mirror():
+    """
+    Ensure that telemetry_mirror makes it into the parsed metric definition.
+    """
+
+    all_metrics = parser.parse_objects(
+        [ROOT / "data" / "telemetry_mirror.yaml"],
+        config={"allow_reserved": False},
+    )
+
+    errs = list(all_metrics)
+    assert len(errs) == 0
+
+    assert (
+        all_metrics.value["telemetry.mirrored"]["parses_fine"].telemetry_mirror
+        == "telemetry.test.string_kind"
+    )


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x ] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
