### PR TITLE
Bug 1693323 - Leverage glean_namespace to specify glean environment in JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Leverage the `glean_namespace` to provide correct import when building for Javascript.
+
 ## 2.2.0 (2021-02-11)
 
 - The Kotlin generator now generates static build information that can be passed

--- a/glean_parser/javascript.py
+++ b/glean_parser/javascript.py
@@ -67,16 +67,16 @@ def output_javascript(
 
         - `namespace`: The identifier of the global variable to assign to.
                        This will only have and effect for Qt and static web sites.
-                       Default is `GleanAssets`.
-        - `glean_namespace`: The identifier of the global variable Glean is assigned.
-                             Default is `Glean`.
+                       Default is `gleanAssets`.
+        - `glean_namespace`: Which version of the `@mozilla/glean` to import,
+                             options are `webext` or `qt`. Default is `webext`.
     """
 
     if options is None:
         options = {}
 
     namespace = options.get("namespace", "gleanAssets")
-    glean_namespace = options.get("glean_namespace", "Glean")
+    glean_namespace = options.get("glean_namespace", "webext")
 
     template = util.get_jinja2_template(
         "javascript.jinja2",

--- a/glean_parser/javascript.py
+++ b/glean_parser/javascript.py
@@ -68,7 +68,7 @@ def output_javascript(
         - `namespace`: The identifier of the global variable to assign to.
                        This will only have and effect for Qt and static web sites.
                        Default is `gleanAssets`.
-        - `glean_namespace`: Which version of the `@mozilla/glean` to import,
+        - `glean_namespace`: Which version of the `@mozilla/glean` package to import,
                              options are `webext` or `qt`. Default is `webext`.
     """
 

--- a/glean_parser/templates/javascript.jinja2
+++ b/glean_parser/templates/javascript.jinja2
@@ -25,11 +25,11 @@ var {{ category_name|camelize }};
 (function (root, factory) {
     if (typeof define === "function" && define.amd) {
         // AMD. Register as an anonymous module.
-        define(["{{ glean_namespace }}"], factory);
+        define(["@mozilla/glean/{{ glean_namespace }}"], factory);
     } else if (typeof module === "object" && module.exports) {
         // Node. Does not work with strict CommonJS, but
         // only CommonJS-like environments that support module.exports, like Node.
-        module.exports = factory(require("glean"));
+        module.exports = factory(require("@mozilla/glean/{{ glean_namespace }}"));
     } else if (typeof root === "undefined") {
         // In Qt/QML environments we can't change the global object from Javascript.
         // We will simply assing to a global variable in this case.


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `HISTORY.rst` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly

Have also tested this in the sample Glean.js webextension and it worked. This time I tested with the published @mozilla/glean package.

Sample generated file for reference:

```js
/* eslint-disable */

/* This Source Code Form is subject to the terms of the Mozilla Public
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */

"use strict";

// AUTOGENERATED BY glean_parser.  DO NOT EDIT.

// Global variable to use when in Qt/QML environments,
// where do not have access to the global object (i.e. window);
var pings;

// Universal Module Definition (UMD) template based on:
// https://github.com/umdjs/umd/blob/master/templates/returnExports.js
(function (root, factory) {
    if (typeof define === "function" && define.amd) {
        // AMD. Register as an anonymous module.
        define(["@mozilla/glean/webext"], factory);
    } else if (typeof module === "object" && module.exports) {
        // Node. Does not work with strict CommonJS, but
        // only CommonJS-like environments that support module.exports, like Node.
        module.exports = factory(require("@mozilla/glean/webext"));
    } else if (typeof root === "undefined") {
        // In Qt/QML environments we can't change the global object from Javascript.
        // We will simply assing to a global variable in this case.
        pings = factory(webext.Glean);
    } else {
        // Browser globals (root is window)
        if (!root["gleanAssets"]) {
            root["gleanAssets"] = {};
        }
        root["gleanAssets"]["pings"] = factory(root.webext);
    }
})(typeof self !== "undefined" ? self : this, function(Glean) {
    return {
        /**
        * A custom ping to help showcase Glean.js
        * It is sent everytime the user clicks the "Submit ping" button
        * on this sample extension popup.
        *
        * Generated from `custom`.
        */
        custom: new Glean._private.PingType({
            includeClientId: true,
            sendIfEmpty: false,
            name: "custom",
            reasonCodes: [],
        }, ),
    };
});
```
