### PR TITLE
Remove `--use-feature=2020-resolver` flag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ commands:
                         .rb/bin/pip install requirements-builder
                         .rb/bin/requirements-builder --level=min setup.py > min_requirements.txt
 
-                        pip install --use-feature=2020-resolver --progress-bar off --user -U -r min_requirements.txt
+                        pip install --progress-bar off --user -U -r min_requirements.txt
 
     test-python-version:
         parameters:
@@ -38,7 +38,7 @@ commands:
             - run:
                     name: install
                     command: |
-                        pip install --use-feature=2020-resolver --progress-bar off --user -U -r <<parameters.requirements-file>>
+                        pip install --progress-bar off --user -U -r <<parameters.requirements-file>>
                         sudo apt update -q
                         sudo apt upgrade -q
                         sudo apt install openjdk-11-jdk-headless
@@ -149,7 +149,7 @@ jobs:
             - run:
                     name: install
                     command: |
-                        pip install --use-feature=2020-resolver --user -U -r requirements_dev.txt
+                        pip install --user -U -r requirements_dev.txt
             - run:
                     name: deploy
                     # Requires that the TWINE_USERNAME and TWINE_PASSWORD environment


### PR DESCRIPTION
Addresses this message:

```
WARNING: --use-feature=2020-resolver no longer has any effect, since it is now
the default dependency resolver in pip. This will become an error in pip 21.0.
```

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
