### PR TITLE
Bug 1700991 - Remove support for the JWE metric type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Raise limit on number of statically-defined lables to 100. ([bug 1702263](https://bugzilla.mozilla.org/show_bug.cgi?id=1702263))
 - BUGFIX: Version 2.0.0 of the schema now allows the "special" `glean_.*` ping names for Glean-internal use again.
+- Remove support for JWE metric types.
 
 ## 2.5.0 (2021-02-23)
 

--- a/glean_parser/markdown.py
+++ b/glean_parser/markdown.py
@@ -34,9 +34,6 @@ def extra_info(obj: Union[metrics.Metric, pings.Ping]) -> List[Tuple[str, str]]:
         for label in obj.ordered_labels:
             extra_info.append((label, None))
 
-    if isinstance(obj, metrics.Jwe):
-        extra_info.append(("decrypted_name", obj.decrypted_name))
-
     if isinstance(obj, metrics.Quantity):
         extra_info.append(("unit", obj.unit))
 

--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -325,8 +325,10 @@ class Jwe(Metric):
     typename = "jwe"
 
     def __init__(self, *args, **kwargs):
-        self.decrypted_name = kwargs.pop("decrypted_name")
-        super().__init__(*args, **kwargs)
+        raise ValueError(
+            "JWE support was removed. "
+            "If you require this send an email to glean-team@mozilla.com."
+        )
 
 
 class Labeled(Metric):

--- a/glean_parser/schemas/metrics.2-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.2-0-0.schema.yaml
@@ -94,8 +94,6 @@ definitions:
 
             - `uuid`: Record a UUID v4.
 
-            - `jwe`: Record a [JWE](https://tools.ietf.org/html/rfc7516) value.
-
             - `memory_distribution`: A histogram for recording memory usage
               values. Additional properties: `memory_unit`.
 
@@ -422,16 +420,6 @@ definitions:
         items:
           type: string
 
-      decrypted_name:
-        title: Decrypted name
-        description: |
-          Name of the column where to persist the decrypted value
-          stored in the JWE after processing.
-
-          Required when `type`_ is `jwe`.
-        type: string
-        pattern: "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})*$"
-
       data_sensitivity:
         title: The level of data sensitivity
         description: |
@@ -625,9 +613,10 @@ additionalProperties:
               const: jwe
         then:
           required:
-            - decrypted_name
+            - jwe_support_was_removed
           description: |
-            `jwe` is missing required parameter `decrypted_name`.
+            JWE support was removed.
+            If you require this send an email to glean-team@mozilla.com.
       - if:
           not:
             properties:

--- a/tests/data/jwe.yaml
+++ b/tests/data/jwe.yaml
@@ -1,0 +1,19 @@
+# Any copyright is dedicated to the Public Domain.
+# https://creativecommons.org/publicdomain/zero/1.0/
+
+---
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+
+crypto:
+  secret:
+    type: jwe
+    lifetime: ping
+    description: |
+      A secret token.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1700991
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1700991
+    notification_emails:
+      - CHANGE-ME@example.com
+    expires: never

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -87,3 +87,21 @@ def test_translate_invalid_format(tmpdir):
     )
     assert result.exit_code == 2
     assert re.search("Invalid value for ['\"]--format['\"]", result.output)
+
+
+def test_reject_jwe(tmpdir):
+    """Test that the JWE type is rejected"""
+    runner = CliRunner()
+    result = runner.invoke(
+        __main__.main,
+        [
+            "translate",
+            str(ROOT / "data" / "jwe.yaml"),
+            "-o",
+            str(tmpdir),
+            "-f",
+            "kotlin",
+        ],
+    )
+    assert result.exit_code == 1
+    assert len(os.listdir(str(tmpdir))) == 0

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -186,3 +186,18 @@ def test_no_unit():
     )
 
     assert not hasattr(event, "unit")
+
+
+def test_jwe_is_rejected():
+    with pytest.raises(ValueError):
+        metrics.Jwe(
+            type="jwe",
+            category="category",
+            name="metric",
+            bugs=["http://bugzilla.mozilla.com/12345"],
+            notification_emails=["nobody@example.com"],
+            description="description...",
+            expires="never",
+            extra_keys={"glean.internal": {"description": "foo"}},
+            _config={"allow_reserved": True},
+        )


### PR DESCRIPTION
I _think_ modifying the schema here is fine. I did that to provide an explicit error message. Does anyone else depend on this schema directly?

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
