### PR TITLE
Bug 1693486 - Generate new event API construct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Generate new event API construct ([#321](https://github.com/mozilla/glean_parser/pull/321))
+
 ## 3.2.0 (2021-04-28)
 
 - Add option to add extra introductory text to generated markdown ([#298](https://github.com/mozilla/glean_parser/pull/298))

--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -299,12 +299,29 @@ class Event(Metric):
     def __init__(self, *args, **kwargs):
         self.extra_keys = kwargs.pop("extra_keys", {})
         self.validate_extra_keys(self.extra_keys, kwargs.get("_config", {}))
+        if self.has_extra_types:
+            self._generate_enums = [("allowed_extra_keys_with_types", "Extra")]
         super().__init__(*args, **kwargs)
 
     @property
     def allowed_extra_keys(self):
         # Sort keys so that output is deterministic
         return sorted(list(self.extra_keys.keys()))
+
+    @property
+    def allowed_extra_keys_with_types(self):
+        # Sort keys so that output is deterministic
+        return sorted(
+            [(k, v["type"]) for (k, v) in self.extra_keys.items()], key=lambda x: x[0]
+        )
+
+    @property
+    def has_extra_types(self):
+        """
+        If any extra key has a `type` specified,
+        we generate the new struct/object-based API.
+        """
+        return any("type" in x for x in self.extra_keys.values())
 
     @staticmethod
     def validate_extra_keys(extra_keys: Dict[str, str], config: Dict[str, Any]) -> None:

--- a/glean_parser/schemas/metrics.2-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.2-0-0.schema.yaml
@@ -348,6 +348,12 @@ definitions:
           properties:
             description:
               type: string
+            type:
+              type: string
+              enum:
+                - string
+                - boolean
+                - quantity
           required:
             - description
         maxProperties: 10

--- a/glean_parser/swift.py
+++ b/glean_parser/swift.py
@@ -85,6 +85,21 @@ def type_name(obj: Union[metrics.Metric, pings.Ping]) -> str:
     return class_name(obj.type)
 
 
+def extra_type_name(typ: str) -> str:
+    """
+    Returns the corresponding Kotlin type for event's extra key types.
+    """
+
+    if typ == "boolean":
+        return "Bool"
+    elif typ == "string":
+        return "String"
+    elif typ == "quantity":
+        return "Int32"
+    else:
+        return "UNSUPPORTED"
+
+
 def class_name(obj_type: str) -> str:
     """
     Returns the Swift class name for a given metric or ping type.
@@ -140,6 +155,7 @@ def output_swift(
             ("type_name", type_name),
             ("class_name", class_name),
             ("variable_name", variable_name),
+            ("extra_type_name", extra_type_name),
         ),
     )
 

--- a/glean_parser/templates/kotlin.jinja2
+++ b/glean_parser/templates/kotlin.jinja2
@@ -9,18 +9,49 @@ Jinja2 template is not. Please file bugs! #}
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-{% macro obj_declaration(obj, suffix='', access='', lazy=False) %}
+{%- macro obj_declaration(obj, suffix='', access='', lazy=False) -%}
 {% if (access != "private ") -%}
 @get:JvmName("{{ obj.name|camelize }}{{ suffix }}")
 {% endif -%}
 {{ access }}val {{ obj.name|camelize }}{{ suffix }}: {{ obj|type_name }}{% if lazy %} by lazy { {%- else %} ={% endif %} // generated from {{ obj.identifier() }}
+    {{ obj|type_name }}(
+        {% for arg_name in extra_args if obj[arg_name] is defined %}
+        {{ arg_name|camelize }} = {{ obj[arg_name]|kotlin }}{{ "," if not loop.last }}
+        {% endfor %}
+    )
+{% if lazy %}}{% endif %}
+{%- endmacro -%}
 
-        {{ obj|type_name }}(
-            {% for arg_name in extra_args if obj[arg_name] is defined %}
-            {{ arg_name|camelize }} = {{ obj[arg_name]|kotlin }}{{ "," if not loop.last }}
-            {% endfor %}
-        )
-{% if lazy %}    }{% endif %}{% endmacro %}
+{%- macro enum_decl(obj, name, suffix) -%}
+@Suppress("ClassNaming", "EnumNaming")
+enum class {{ obj.name|camelize }}{{ suffix }} {
+{% for key in obj|attr(name) %}
+    {{ key|camelize }}{{ "," if not loop.last }}
+{% endfor %}
+}
+{%- endmacro %}
+
+{%- macro struct_decl(obj, name, suffix) -%}
+@Suppress("ClassNaming", "EnumNaming")
+data class {{ obj.name|Camelize }}{{ suffix }}(
+{% for item, typ in obj|attr(name) %}
+    val {{ item|camelize }}: {{typ|extra_type_name}}? = null{{ "," if not loop.last }}
+{% endfor %}
+): EventExtras {
+  override fun toFfiExtra(): Pair<IntArray, StringArray> {
+    var keys = mutableListOf<Int>()
+    var values = mutableListOf<String>()
+
+    {% for item in obj|attr(name) %}
+    this.{{ item[0]|camelize }}?.let {
+      keys.add({{loop.index-1}})
+      values.add(it.toString())
+    }
+    {% endfor %}
+    return Pair(IntArray(keys.size, { keys[it] }), StringArray(values.toTypedArray(), "utf-8"))
+  }
+}
+{%- endmacro -%}
 
 /* ktlint-disable no-blank-line-before-rbrace */
 @file:Suppress("PackageNaming", "MaxLineLength")
@@ -44,19 +75,18 @@ internal object {{ category_name|Camelize }} {
     {% if obj|attr("_generate_enums") %}
     {% for name, suffix in obj["_generate_enums"] %}
     {% if obj|attr(name)|length %}
-    @Suppress("ClassNaming", "EnumNaming")
-    enum class {{ obj.name|camelize }}{{ suffix }} {
-    {% for key in obj|attr(name) %}
-        {{ key|camelize }}{{ "," if not loop.last }}
-    {% endfor %}
-    }
+    {% if obj.has_extra_types %}
+    {{ struct_decl(obj, name, suffix)|indent }}
+    {% else %}
+    {{ enum_decl(obj, name, suffix)|indent }}
+    {% endif %}
     {% endif %}
     {% endfor %}
     {% endif %}
 {% endfor %}
 {% for obj in objs.values() %}
     {% if obj.labeled %}
-    {{ obj_declaration(obj, 'Label', 'private ') }}
+    {{ obj_declaration(obj, 'Label', 'private ') | indent }}
     /**
      * {{ obj.description|wordwrap() | replace('\n', '\n        * ') }}
      */
@@ -75,7 +105,7 @@ internal object {{ category_name|Camelize }} {
     /**
      * {{ obj.description|wordwrap() | replace('\n', '\n     * ') }}
      */
-    {{ obj_declaration(obj, lazy=obj.type != 'ping') }}
+    {{ obj_declaration(obj, lazy=obj.type != 'ping') | indent }}
     {% endif %}
 {%- endfor %}
 }

--- a/glean_parser/templates/swift.jinja2
+++ b/glean_parser/templates/swift.jinja2
@@ -9,10 +9,44 @@ Jinja2 template is not. Please file bugs! #}
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 {% macro obj_declaration(obj, suffix='', access='') %}
 {{ access }}static let {{ obj.name|camelize|variable_name }}{{ suffix }} = {{ obj|type_name }}( // generated from {{ obj.identifier() }}
-            {% for arg_name in extra_args if obj[arg_name] is defined %}
-            {{ arg_name|camelize }}: {{ obj[arg_name]|swift }}{{ "," if not loop.last }}
+        {% for arg_name in extra_args if obj[arg_name] is defined %}
+        {{ arg_name|camelize }}: {{ obj[arg_name]|swift }}{{ "," if not loop.last }}
+        {% endfor %}
+    )
+{% endmacro %}
+
+{% macro enum_decl(obj, name, suffix) %}
+enum {{ obj.name|Camelize }}{{ suffix }}: Int32, ExtraKeys {
+        {% for key in obj|attr(name) %}
+        case {{ key|camelize|variable_name }} = {{ loop.index-1 }}
+        {% endfor %}
+
+        public func index() -> Int {
+            return self.rawValue
+        }
+    }
+{% endmacro %}
+
+{% macro struct_decl(obj, name, suffix) %}
+struct {{ obj.name|Camelize }}{{ suffix }}: EventExtras {
+        {% for item, typ in obj|attr(name) %}
+        val {{ item|camelize|variable_name }}: {{typ|extra_type_name}}?
+        {% endfor %}
+
+        func toFfiExtra() -> ([Int32], [String]) {
+            var keys = [Int32]()
+            var values = [String]()
+
+            {% for item in obj|attr(name) %}
+            if let {{ item[0]|camelize }} = self.{{item[0]|camelize}} {
+                keys.append({{ loop.index - 1 }})
+                values.append(String(val))
+            }
             {% endfor %}
-        )
+
+            return (keys, values)
+        }
+    }
 {% endmacro %}
 
 {% if not allow_reserved %}
@@ -36,7 +70,7 @@ extension {{ namespace }} {
 
         {% for obj in category.objs.values() %}
         {% if obj|attr("_generate_enums") %}
-        {% for name, suffix in obj["_generate_enums"] %}
+        {% for name, suffix, typ in obj["_generate_enums"] %}
         {% if obj|attr(name)|length %}
         enum {{ obj.name|Camelize }}{{ suffix }}: Int, ReasonCodes {
             {% for key in obj|attr(name) %}
@@ -68,23 +102,18 @@ extension {{ namespace }} {
         {% if obj|attr("_generate_enums") %}
         {% for name, suffix in obj["_generate_enums"] %}
         {% if obj|attr(name)|length %}
-        enum {{ obj.name|Camelize }}{{ suffix }}: Int32, ExtraKeys {
-        {% for key in obj|attr(name) %}
-            case {{ key|camelize|variable_name }} = {{ loop.index-1 }}
-        {% endfor %}
-
-            public func index() -> Int32 {
-                return self.rawValue
-            }
-        }
-
+        {% if obj.has_extra_types %}
+        {{ struct_decl(obj, name, suffix)|indent }}
+        {% else %}
+        {{ enum_decl(obj, name, suffix)|indent }}
+        {% endif %}
         {% endif %}
         {% endfor %}
         {% endif %}
     {% endfor %}
     {% for obj in category.objs.values() %}
         {% if obj.labeled %}
-        {{ obj_declaration(obj, 'Label', 'private ') }}
+        {{ obj_declaration(obj, 'Label', 'private ') | indent }}
         /// {{ obj.description|wordwrap() | replace('\n', '\n        /// ') }}
         static let {{ obj.name|camelize|variable_name }} = try! LabeledMetricType<{{ obj|type_name }}>( // generated from {{ obj.identifier() }}
             category: {{ obj.category|swift }},
@@ -98,7 +127,7 @@ extension {{ namespace }} {
 
         {% else %}
         /// {{ obj.description|wordwrap() | replace('\n', '\n        /// ') }}
-        {{ obj_declaration(obj) }}
+        {{ obj_declaration(obj) | indent }}
         {% endif %}
     {% endfor %}
     }

--- a/tests/data/events_with_types.yaml
+++ b/tests/data/events_with_types.yaml
@@ -1,0 +1,45 @@
+# Any copyright is dedicated to the Public Domain.
+# https://creativecommons.org/publicdomain/zero/1.0/
+
+---
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+
+core:
+  event_example:
+    type: event
+    description: >
+      Just testing events
+    bugs:
+      - https://bugzilla.mozilla.org/1123456789
+    data_reviews:
+      - http://example.com/reviews
+    notification_emails:
+      - CHANGE-ME@example.com
+    extra_keys:
+      key1:
+        description: "This is key one"
+      key2:
+        description: "This is key two"
+    expires: never
+
+  preference_toggled:
+    type: event
+    description: |
+      Just testing events
+    bugs:
+      - https://bugzilla.mozilla.org/1123456789
+    data_reviews:
+      - http://example.com/reviews
+    notification_emails:
+      - CHANGE-ME@example.com
+    extra_keys:
+      preference:
+        type: string
+        description: "This is key one"
+      enabled:
+        type: boolean
+        description: "This is key two"
+      swapped:
+        type: quantity
+        description: "This is key three"
+    expires: never

--- a/tests/test_swift.py
+++ b/tests/test_swift.py
@@ -211,3 +211,30 @@ def test_event_extra_keys_in_correct_order(tmpdir):
             "{ case alice = 0 case bob = 1 case charlie = 2" in content
         )
         assert 'allowedExtraKeys: ["alice", "bob", "charlie"]' in content
+
+
+def test_event_extra_keys_with_types(tmpdir):
+    """
+    Assert that the extra keys with types appear with their corresponding types.
+    """
+
+    tmpdir = Path(str(tmpdir))
+
+    translate.translate(
+        ROOT / "data" / "events_with_types.yaml",
+        "swift",
+        tmpdir,
+        {"namespace": "Foo"},
+    )
+
+    assert set(x.name for x in tmpdir.iterdir()) == set(["Metrics.swift"])
+
+    with (tmpdir / "Metrics.swift").open("r", encoding="utf-8") as fd:
+        content = fd.read()
+        content = " ".join(content.split())
+        assert (
+            "struct PreferenceToggledExtra: EventExtras "
+            "{ val enabled: Bool? val preference: String? "
+            "val swapped: Int32?" in content
+        )
+        assert 'allowedExtraKeys: ["enabled", "preference", "swapped"]' in content


### PR DESCRIPTION
When a metric of `type: event` includes any `type` annotation in its
extra keys list, the new object/struct-based API will be used.

Only three types are supported right now:

* string
* boolean
* quantity (an integer)

This is only implemented for Kotlin & Swift.
Python will need this in the Glean Python code base.
Glean.js will need its own implementation first.

FOG will need to implement something similar for its Rust, C++ and
JavaScript API.

---

Needs to land so that Glean can use it here: https://github.com/mozilla/glean/pull/1603