### PR TITLE
Bug 1713084 - For Kotlin only generate `GleanBuildInfo.kt` when explicitly requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add missing import for Kotlin code ([#339](https://github.com/mozilla/glean_parser/pull/341))
 - Use a plain Kotlin type in the generated interface implementation ([#339](https://github.com/mozilla/glean_parser/pull/341))
 - Generate additional generics for event metrics ([#339](https://github.com/mozilla/glean_parser/pull/341))
+- For Kotlin skip generating `GleanBuildInfo.kt` when requested (with `with_buildinfo=false`) ([#341](https://github.com/mozilla/glean_parser/pull/341))
 
 ## 3.3.2 (2021-05-18)
 

--- a/glean_parser/kotlin.py
+++ b/glean_parser/kotlin.py
@@ -244,6 +244,9 @@ def output_kotlin(
         - `glean_namespace`: The package namespace of the glean library itself.
           This is where glean objects will be imported from in the generated
           code.
+        - `with_buildinfo`: If "true" a `GleanBuildInfo.kt` file is generated.
+          Otherwise generation of that file is skipped.
+          Defaults to "true".
     """
     if options is None:
         options = {}
@@ -251,23 +254,25 @@ def output_kotlin(
     namespace = options.get("namespace", "GleanMetrics")
     glean_namespace = options.get("glean_namespace", "mozilla.components.service.glean")
     namespace_package = namespace[: namespace.rfind(".")]
+    with_buildinfo = options.get("with_buildinfo", "true").lower() == "true"
 
     # Write out the special "build info" object
     template = util.get_jinja2_template(
         "kotlin.buildinfo.jinja2",
     )
 
-    # This filename needs to start with "Glean" so it can never clash with a
-    # metric category
-    with (output_dir / "GleanBuildInfo.kt").open("w", encoding="utf-8") as fd:
-        fd.write(
-            template.render(
-                namespace=namespace,
-                namespace_package=namespace_package,
-                glean_namespace=glean_namespace,
+    if with_buildinfo:
+        # This filename needs to start with "Glean" so it can never clash with a
+        # metric category
+        with (output_dir / "GleanBuildInfo.kt").open("w", encoding="utf-8") as fd:
+            fd.write(
+                template.render(
+                    namespace=namespace,
+                    namespace_package=namespace_package,
+                    glean_namespace=glean_namespace,
+                )
             )
-        )
-        fd.write("\n")
+            fd.write("\n")
 
     template = util.get_jinja2_template(
         "kotlin.jinja2",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -60,6 +60,42 @@ def test_translate(tmpdir):
         assert "package Foo" in content
 
 
+def test_translate_no_buildinfo(tmpdir):
+    """Test the 'translate' command."""
+    runner = CliRunner()
+    result = runner.invoke(
+        __main__.main,
+        [
+            "translate",
+            str(ROOT / "data" / "core.yaml"),
+            "-o",
+            str(tmpdir),
+            "-f",
+            "kotlin",
+            "-s",
+            "namespace=Foo",
+            "-s",
+            "with_buildinfo=false",
+            "--allow-reserved",
+        ],
+    )
+    assert result.exit_code == 0
+    assert set(os.listdir(str(tmpdir))) == set(
+        [
+            "CorePing.kt",
+            "Telemetry.kt",
+            "Environment.kt",
+            "DottedCategory.kt",
+            "GleanInternalMetrics.kt",
+        ]
+    )
+    for filename in os.listdir(str(tmpdir)):
+        path = Path(str(tmpdir)) / filename
+        with path.open(encoding="utf-8") as fd:
+            content = fd.read()
+        assert "package Foo" in content
+
+
 def test_translate_errors(tmpdir):
     """Test the 'translate' command."""
     runner = CliRunner()


### PR DESCRIPTION
(with `with_buildinfo=true`)

