### PR TITLE
Bug 1713398 - Enable custom distribution without a gecko_datapoint 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add a command `data-review` to generate a skeleton Data Review Request for all metrics matching a supplied bug number. ([bug 1704541](https://bugzilla.mozilla.org/show_bug.cgi?id=1704541))
+- Enable custom distribution outside of GeckoView (`gecko_datapoint` becomes optional)
 
 ## 3.5.0 (2021-06-03)
 

--- a/glean_parser/schemas/metrics.2-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.2-0-0.schema.yaml
@@ -571,18 +571,6 @@ additionalProperties:
         if:
           properties:
             type:
-              enum:
-                - custom_distribution
-        then:
-          required:
-            - gecko_datapoint
-          description: |
-            `custom_distribution` is only allowed for Gecko
-            metrics.
-      -
-        if:
-          properties:
-            type:
               const: custom_distribution
         then:
           required:

--- a/glean_parser/util.py
+++ b/glean_parser/util.py
@@ -420,14 +420,16 @@ common_metric_args = [
 
 
 # Names of parameters that only apply to some of the metrics types.
+# **CAUTION**: This list needs to be in the order the Swift & Rust type constructors
+# expects them. (The other language bindings don't care about the order).
 extra_metric_args = [
     "time_unit",
     "memory_unit",
     "allowed_extra_keys",
     "reason_codes",
-    "bucket_count",
-    "range_max",
     "range_min",
+    "range_max",
+    "bucket_count",
     "histogram_type",
     "numerators",
 ]
@@ -435,7 +437,7 @@ extra_metric_args = [
 
 # This includes only things that the language bindings care about, not things
 # that are metadata-only or are resolved into other parameters at parse time.
-# **CAUTION**: This list needs to be in the order the Swift type constructors
+# **CAUTION**: This list needs to be in the order the Swift & Rust type constructors
 # expects them. (The other language bindings don't care about the order). The
 # `test_order_of_fields` test checks that the generated code is valid.
 # **DO NOT CHANGE THE ORDER OR ADD NEW FIELDS IN THE MIDDLE**

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -338,9 +338,6 @@ def test_geckoview_only_on_valid_metrics():
         ]
         contents = [util.add_required(x) for x in contents]
 
-        all_metrics = parser.parse_objects(contents)
-        errs = list(all_metrics)
-
     contents = [{"category1": {"metric1": {"type": "event", "gecko_datapoint": "FOO"}}}]
     contents = [util.add_required(x) for x in contents]
 
@@ -390,7 +387,7 @@ def test_all_pings_reserved():
 
 
 def test_custom_distribution():
-    # Test that custom_distribution isn't allowed on non-Gecko metric
+    # Test plain custom_distribution, now also allowed generally
     contents = [
         {
             "category": {
@@ -408,8 +405,7 @@ def test_custom_distribution():
     contents = [util.add_required(x) for x in contents]
     all_metrics = parser.parse_objects(contents)
     errors = list(all_metrics)
-    assert len(errors) == 1
-    assert "is only allowed for Gecko" in errors[0]
+    assert len(errors) == 0
 
     # Test that custom_distribution has required parameters
     contents = [
@@ -456,7 +452,6 @@ def test_custom_distribution():
             "category": {
                 "metric": {
                     "type": "custom_distribution",
-                    "gecko_datapoint": "FROM_GECKO",
                     "range_max": 60000,
                     "bucket_count": 100,
                     "histogram_type": "exponential",


### PR DESCRIPTION
Rust doesn't have named arguments, so we need to ensure they are in
order.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
