### PR TITLE
Bug 1703577 - Check for redundant words in ping names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- New lint: Check for redundant words in ping names ([#355](https://github.com/mozilla/glean_parser/pull/355))
+
 ## 3.6.0 (2021-06-11)
 
 - Add a command `data-review` to generate a skeleton Data Review Request for all metrics matching a supplied bug number. ([bug 1704541](https://bugzilla.mozilla.org/show_bug.cgi?id=1704541))

--- a/glean_parser/lint.py
+++ b/glean_parser/lint.py
@@ -42,7 +42,7 @@ def _split_words(name: str) -> List[str]:
     """
     Helper function to split words on either `.` or `_`.
     """
-    return re.split("[._]", name)
+    return re.split("[._-]", name)
 
 
 def _english_list(items: List[str]) -> str:

--- a/glean_parser/lint.py
+++ b/glean_parser/lint.py
@@ -262,6 +262,36 @@ def check_expired_metric(
         yield ("Metric has expired. Please consider removing it.")
 
 
+def check_redundant_ping(
+    pings: Iterable[pings.Ping]
+) -> LintGenerator:
+    '''
+    Check if the pings contains 'ping' as the prefix or suffix, or 'ping' or 'custom'
+    '''
+    ping_words = sorted([_split_words(ping.name) for ping in pings])
+
+    if len(ping_words) != 0:
+        ping_first_word = ping_words[0]
+        ping_last_word = ping_words[-1]
+
+        if ping_first_word == "ping":
+            yield (
+                "The prefix 'ping' is redundant."
+            )
+        elif ping_last_word == "ping":
+            yield (
+                "The suffix 'ping' is redundant."
+            )
+        elif "ping" in ping_words:
+            yield (
+                "The word 'ping' is redundant."
+            )
+        elif "custom" in ping_words:
+            yield (
+                "The word 'custom' is redundant."
+            )
+
+
 # The checks that operate on an entire category of metrics:
 #    {NAME: (function, is_error)}
 CATEGORY_CHECKS: Dict[
@@ -281,6 +311,7 @@ METRIC_CHECKS: Dict[
     "BUG_NUMBER": (check_bug_number, CheckType.error),
     "BASELINE_PING": (check_valid_in_baseline, CheckType.error),
     "MISSPELLED_PING": (check_misspelled_pings, CheckType.error),
+    "REDUNDANT_PING": (check_redundant_ping, CheckType.error),
     "EXPIRATION_DATE_TOO_FAR": (check_expired_date, CheckType.warning),
     "USER_LIFETIME_EXPIRATION": (check_user_lifetime_expiration, CheckType.warning),
     "EXPIRED": (check_expired_metric, CheckType.warning),

--- a/glean_parser/lint.py
+++ b/glean_parser/lint.py
@@ -263,33 +263,25 @@ def check_expired_metric(
 
 
 def check_redundant_ping(
-    pings: Iterable[pings.Ping]
+    pings: pings.Ping, parser_config: Dict[str, Any]
 ) -> LintGenerator:
-    '''
+    """
     Check if the pings contains 'ping' as the prefix or suffix, or 'ping' or 'custom'
-    '''
-    ping_words = sorted([_split_words(ping.name) for ping in pings])
+    """
+    ping_words = _split_words(pings.name)
 
     if len(ping_words) != 0:
         ping_first_word = ping_words[0]
         ping_last_word = ping_words[-1]
 
         if ping_first_word == "ping":
-            yield (
-                "The prefix 'ping' is redundant."
-            )
+            yield ("The prefix 'ping' is redundant.")
         elif ping_last_word == "ping":
-            yield (
-                "The suffix 'ping' is redundant."
-            )
+            yield ("The suffix 'ping' is redundant.")
         elif "ping" in ping_words:
-            yield (
-                "The word 'ping' is redundant."
-            )
+            yield ("The word 'ping' is redundant.")
         elif "custom" in ping_words:
-            yield (
-                "The word 'custom' is redundant."
-            )
+            yield ("The word 'custom' is redundant.")
 
 
 # The checks that operate on an entire category of metrics:
@@ -311,7 +303,6 @@ METRIC_CHECKS: Dict[
     "BUG_NUMBER": (check_bug_number, CheckType.error),
     "BASELINE_PING": (check_valid_in_baseline, CheckType.error),
     "MISSPELLED_PING": (check_misspelled_pings, CheckType.error),
-    "REDUNDANT_PING": (check_redundant_ping, CheckType.error),
     "EXPIRATION_DATE_TOO_FAR": (check_expired_date, CheckType.warning),
     "USER_LIFETIME_EXPIRATION": (check_user_lifetime_expiration, CheckType.warning),
     "EXPIRED": (check_expired_metric, CheckType.warning),
@@ -324,6 +315,7 @@ PING_CHECKS: Dict[
     str, Tuple[Callable[[pings.Ping, dict], LintGenerator], CheckType]
 ] = {
     "BUG_NUMBER": (check_bug_number, CheckType.error),
+    "REDUNDANT_PING": (check_redundant_ping, CheckType.error),
 }
 
 

--- a/tests/data/pings.yaml
+++ b/tests/data/pings.yaml
@@ -14,6 +14,7 @@ custom-ping:
     - http://nowhere.com/reviews
   notification_emails:
     - CHANGE-ME@test-only.com
+  no_lint: [REDUNDANT_PING]
 
 really-custom-ping:
   description: >
@@ -31,6 +32,7 @@ really-custom-ping:
     - http://nowhere.com/reviews
   notification_emails:
     - CHANGE-ME@test-only.com
+  no_lint: [REDUNDANT_PING]
 
 custom-ping-might-be-empty:
   description:
@@ -48,3 +50,4 @@ custom-ping-might-be-empty:
       A silly reason for sending a ping.
     serious:
       A serious reason for sending a ping.
+  no_lint: [REDUNDANT_PING]

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -342,9 +342,7 @@ def test_redundant_pings():
     """
     Test that name contains '-ping' or 'ping-' or 'ping' or 'custom' yields lint errors.
     """
-    content = {
-            "ping": {}
-    }
+    content = {"ping": {}}
 
     content = util.add_required_ping(content)
     all_pings = parser.parse_objects([content])

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -314,9 +314,9 @@ def test_translate_missing_input_files(tmpdir):
 @pytest.mark.parametrize(
     "content,num_nits",
     [
-        ({"ping": {"bugs": [12345]}}, 1),
-        ({"ping": {"bugs": [12345], "no_lint": ["BUG_NUMBER"]}}, 0),
-        ({"ping": {"bugs": [12345]}, "no_lint": ["BUG_NUMBER"]}, 0),
+        ({"search": {"bugs": [12345]}}, 1),
+        ({"search": {"bugs": [12345], "no_lint": ["BUG_NUMBER"]}}, 0),
+        ({"search": {"bugs": [12345]}, "no_lint": ["BUG_NUMBER"]}, 0),
     ],
 )
 def test_bug_number_pings(content, num_nits):
@@ -342,16 +342,10 @@ def test_redundant_pings():
     """
     Test that name contains '-ping' or 'ping-' or 'ping' or 'custom' yields lint errors.
     """
-    content = [
-        {
-            "ping_test": {
-                "description": "testing the ping in the prefix",
-                "send_if_empty": True,
-                "bugs": ["https://bugzilla.mozilla.org/show_bug.cgi?id=1703577"],
-                "data_review": ["https://bugzilla.mozilla.org/show_bug.cgi?id=1703577"],
-            }
-        }
-    ]
+    content = {
+            "ping": {}
+    }
+
     content = util.add_required_ping(content)
     all_pings = parser.parse_objects([content])
     errs = list(all_pings)

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -336,3 +336,27 @@ def test_bug_number_pings(content, num_nits):
     assert len(nits) == num_nits
     if num_nits > 0:
         assert set(["BUG_NUMBER"]) == set(v.check_name for v in nits)
+
+
+def test_redundant_pings():
+    """
+    Test that name contains '-ping' or 'ping-' or 'ping' or 'custom' yields lint errors.
+    """
+    content = [
+        {
+            "ping_test": {
+                "description": "testing the ping in the prefix",
+                "send_if_empty": True,
+                "bugs": ["https://bugzilla.mozilla.org/show_bug.cgi?id=1703577"],
+                "data_review": ["https://bugzilla.mozilla.org/show_bug.cgi?id=1703577"],
+            }
+        }
+    ]
+    content = util.add_required_ping(content)
+    all_pings = parser.parse_objects([content])
+    errs = list(all_pings)
+    assert len(errs) == 0
+
+    nits = lint.lint_metrics(all_pings.value)
+    assert len(nits) == 1
+    assert set(["REDUNDANT_PING"]) == set(v.check_name for v in nits)


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: ### This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly

make lint fails with error that says "would reformat glean_parser/lint.py"
Haven't made the tests, but creating a PR to look for feedback on my code