### PR TITLE
Separate linting into its own step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,9 +44,6 @@ commands:
                         sudo apt install openjdk-11-jdk-headless
                         make install-kotlin-linters
             - run:
-                    name: lint
-                    command: make lint
-            - run:
                     name: install
                     # Set CC to something that isn't a working compiler so we
                     # can detect if any of the dependencies require a compiler
@@ -58,6 +55,29 @@ commands:
             - run:
                     name: test
                     command: make test
+
+    lint:
+        parameters:
+            requirements-file:
+                type: string
+                default: "requirements_dev.txt"
+        steps:
+            - run:
+                    name: install
+                    command: |
+                        pip install --progress-bar off --user -U -r <<parameters.requirements-file>>
+            - run:
+                    name: install
+                    # Set CC to something that isn't a working compiler so we
+                    # can detect if any of the dependencies require a compiler
+                    # to be installed. We can't count on a working compiler
+                    # being available to pip on all of the platforms we need to
+                    # support, so we need to make sure the dependencies are all
+                    # pure Python or provide pre-built wheels.
+                    command: CC=broken_compiler pip install . --user
+            - run:
+                    name: lint
+                    command: make lint
 
 jobs:
     build-36:
@@ -119,6 +139,13 @@ jobs:
             - test-start
             - test-python-version
 
+    lint:
+        docker:
+            - image: circleci/python:3.9.0
+        steps:
+            - test-start
+            - lint
+
     docs-deploy:
         docker:
             - image: node:8.10.0
@@ -168,6 +195,10 @@ workflows:
     version: 2
     build:
         jobs:
+            - lint:
+                    filters:
+                        tags:
+                            only: /.*/
             - build-36:
                     filters:
                         tags:

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ clean-test: ## remove test and coverage artifacts
 
 lint: ## check style with flake8
 	python3 -m flake8 glean_parser tests
-	python3 -m black --check glean_parser tests setup.py
+	python3 -m black --check --diff glean_parser tests setup.py
 	python3 -m yamllint glean_parser tests
 	python3 -m mypy glean_parser
 


### PR DESCRIPTION
This makes the tests run regardless of lint failures.
Not all lint failures will lead to test failures.
This way those test failures will show up quicker.### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
