### PR TITLE
Bug 1713314 - Replace jsonschema's indent utility with textwrap

### DIFF
--- a/glean_parser/util.py
+++ b/glean_parser/util.py
@@ -313,7 +313,9 @@ def pprint_validation_error(error) -> str:
 
     description = error.schema.get("description")
     if description:
-        parts.extend(["", "Documentation for this node:", _utils.indent(description)])
+        parts.extend(
+            ["", "Documentation for this node:", textwrap.indent(description, "    ")]
+        )
 
     return "\n".join(parts)
 
@@ -327,9 +329,9 @@ def format_error(filepath: Union[str, Path], header: str, content: str) -> str:
     else:
         filepath = "<string>"
     if header:
-        return f"{filepath}: {header}\n{_utils.indent(content)}"
+        return f"{filepath}: {header}\n{textwrap.indent(content, '    ')}"
     else:
-        return f"{filepath}:\n{_utils.indent(content)}"
+        return f"{filepath}:\n{textwrap.indent(content, '    ')}"
 
 
 def parse_expires(expires: str) -> datetime.date:

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ requirements = [
     "diskcache>=4",
     "iso8601>=0.1.10; python_version<='3.6'",
     "Jinja2>=2.10.1",
-    "jsonschema>=3.0.2,<4",
+    "jsonschema>=3.0.2",
     "PyYAML>=5.3.1",
     "yamllint>=1.18.0",
 ]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -8,7 +8,6 @@ import re
 import textwrap
 
 import pytest
-from jsonschema import _utils
 
 from glean_parser import metrics
 from glean_parser import parser
@@ -183,7 +182,7 @@ def test_parser_schema_violation():
     ]
 
     expected_errors = set(
-        re.sub(r"\s", "", _utils.indent(textwrap.dedent(x)).strip())
+        re.sub(r"\s", "", textwrap.indent(textwrap.dedent(x), "    ").strip())
         for x in expected_errors
     )
 


### PR DESCRIPTION
It was a simpler version of that anyway and now got replaced.
See https://github.com/Julian/jsonschema/commit/b0be7bf48e6554a00296307f7c84283a77738267

We should be jsonschema v4 compatible now.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
