### PR TITLE
Bug 1719136 - Expose ping reasons enum on JS/TS templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Expose ping reasons enum on JavaScript / TypeScript templates. ([bug 1719136](https://bugzilla.mozilla.org/show_bug.cgi?id=1719136))
+
 ## 3.7.0 (2021-07-13)
 
 - New lint: Check for redundant words in ping names ([#355](https://github.com/mozilla/glean_parser/pull/355))

--- a/glean_parser/javascript.py
+++ b/glean_parser/javascript.py
@@ -44,7 +44,7 @@ def javascript_datatypes_filter(value: util.JSONType) -> str:
 def class_name_factory(platform: str) -> Callable[[str], str]:
     """
     Returns a function that receives an obj_type and
-    returns the correct class name for that time in the current platform.
+    returns the correct class name for that type in the current platform.
     """
 
     def class_name(obj_type: str) -> str:

--- a/glean_parser/templates/javascript.jinja2
+++ b/glean_parser/templates/javascript.jinja2
@@ -28,6 +28,7 @@ import {{ type|class_name }} from "@mozilla/glean/{{ platform }}/private/{{ type
 {% else %}
 .import org.mozilla.Glean {{ version }} as Glean
 {% endif %}
+
 {% for obj in objs.values() %}
 /**
  * {{ obj.description|wordwrap() | replace("\n", "\n * ") }}
@@ -40,4 +41,29 @@ import {{ type|class_name }} from "@mozilla/glean/{{ platform }}/private/{{ type
 {% if platform != "qt" %}export {% endif %}const {{ obj.name|camelize }} = {{ obj_declaration(obj) }};
 {% endif %}
 
+{% if obj|attr("_generate_enums") %}
+{% for name, suffix in obj["_generate_enums"] %}
+{% if obj|attr(name)|length and name == "reason_codes" %}
+/**
+ * Reason codes for `{{ obj.identifier() }}`.
+ *
+ * @readonly
+ * @enum {string}
+ */
+{% if lang == "typescript" %}
+export enum {{ obj.name|Camelize }}{{ name|Camelize }} {
+    {% for key in obj|attr(name) %}
+    {{ key|Camelize }} = "{{ key }}",
+    {% endfor %}
+}
+{% else %}
+{% if platform != "qt" %}export {% endif %}const {{ obj.name|Camelize }}{{ name|Camelize }} = {
+    {% for key in obj|attr(name) %}
+    "{{ key|Camelize }}": "{{ key }}",
+    {% endfor %}
+}
+{% endif %}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% endfor %}

--- a/tests/test_javascript.py
+++ b/tests/test_javascript.py
@@ -245,6 +245,26 @@ def test_duplicate(tmpdir):
         )
 
 
+def test_reasons(tmpdir):
+    tmpdir = Path(str(tmpdir))
+
+    translate.translate(ROOT / "data" / "pings.yaml", "javascript", tmpdir, None)
+
+    translate.translate(ROOT / "data" / "pings.yaml", "typescript", tmpdir, None)
+
+    assert set(x.name for x in tmpdir.iterdir()) == set(["pings.js", "pings.ts"])
+
+    with (tmpdir / "pings.js").open("r", encoding="utf-8") as fd:
+        content = fd.read()
+        assert "export const CustomPingMightBeEmptyReasonCodes" in content
+        assert "export const RealPingMightBeEmptyReasonCodes" not in content
+
+    with (tmpdir / "pings.ts").open("r", encoding="utf-8") as fd:
+        content = fd.read()
+        assert "export enum CustomPingMightBeEmptyReasonCodes" in content
+        assert "export enum RealPingMightBeEmptyReasonCodes" not in content
+
+
 def test_event_extra_keys_in_correct_order(tmpdir):
     """
     Assert that the extra keys appear in the parameter and the enumeration in


### PR DESCRIPTION
**JavaScript**: 

```js

...

/**
 * This is another custom ping
 *
 * Generated from `custom-ping-might-be-empty`.
 */
export const customPingMightBeEmpty = new PingType({
    includeClientId: true,
    sendIfEmpty: true,
    name: "custom-ping-might-be-empty",
    reasonCodes: ["serious", "silly"],
});

export const customPingMightBeEmptyReasonCodes = {
    "Serious": "serious",
    "Silly": "silly",
}
```

**TypeScript**:

```ts

...

/**
 * This is another custom ping
 *
 * Generated from `custom-ping-might-be-empty`.
 */
export const customPingMightBeEmpty = new PingType({
    includeClientId: true,
    sendIfEmpty: true,
    name: "custom-ping-might-be-empty",
    reasonCodes: ["serious", "silly"],
});

/**
 * Reason codes for `custom-ping-might-be-empty`.
 *
 * @readonly
 * @enum {string}
 */
export enum CustomPingMightBeEmptyReasonCodes {
    Serious = "serious",
    Silly = "silly",
}
```

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
