### PR TITLE
Reserve the `default` ping name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add support for Text metric type ([#374](https://github.com/mozilla/glean_parser/pull/374))
+- Reserve the `default` ping name. It can't be used as a ping name, but it can be used in `send_in_pings` ([#376](https://github.com/mozilla/glean_parser/pull/376))
 
 ## 3.8.0 (2021-08-18)
 

--- a/glean_parser/pings.py
+++ b/glean_parser/pings.py
@@ -14,7 +14,7 @@ from typing import Dict, List, Optional
 from . import util
 
 
-RESERVED_PING_NAMES = ["baseline", "metrics", "events", "deletion-request"]
+RESERVED_PING_NAMES = ["baseline", "metrics", "events", "deletion-request", "default"]
 
 
 class Ping:

--- a/tests/test_pings.py
+++ b/tests/test_pings.py
@@ -3,7 +3,7 @@
 # Any copyright is dedicated to the Public Domain.
 # http://creativecommons.org/publicdomain/zero/1.0/
 
-from glean_parser import parser
+from glean_parser import parser, pings
 
 import util
 
@@ -12,17 +12,19 @@ def test_reserved_ping_name():
     """
     Make sure external users can't use a reserved ping name.
     """
-    content = {"baseline": {"include_client_id": True}}
 
-    util.add_required_ping(content)
-    errors = list(parser._instantiate_pings({}, {}, content, "", {}))
-    assert len(errors) == 1
-    assert "Ping uses a reserved name" in errors[0]
+    for ping in pings.RESERVED_PING_NAMES:
+        content = {ping: {"include_client_id": True}}
 
-    errors = list(
-        parser._instantiate_pings({}, {}, content, "", {"allow_reserved": True})
-    )
-    assert len(errors) == 0
+        util.add_required_ping(content)
+        errors = list(parser._instantiate_pings({}, {}, content, "", {}))
+        assert len(errors) == 1, f"Ping '{ping}' should not be allowed"
+        assert "Ping uses a reserved name" in errors[0]
+
+        errors = list(
+            parser._instantiate_pings({}, {}, content, "", {"allow_reserved": True})
+        )
+        assert len(errors) == 0
 
 
 def test_reserved_metrics_category():


### PR DESCRIPTION
It can't be used as a ping name, but it can be used in `send_in_pings`.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
