### PR TITLE
In test mode dump snippets to yaml and load them again

### DIFF
--- a/glean_parser/util.py
+++ b/glean_parser/util.py
@@ -112,7 +112,7 @@ def load_yaml_or_json(path: Path):
     """
     # If in py.test, support bits of literal JSON/YAML content
     if TESTING_MODE and isinstance(path, dict):
-        return path
+        return yaml_load(yaml.dump(path))
 
     if path.suffix == ".json":
         with path.open("r", encoding="utf-8") as fd:


### PR DESCRIPTION
`yaml_load` does some extra work, such as adding the `defined_in` metadata.
We need to replicate this for data snippets used in tests. The easiest
is to just roundtrip through `yaml.dump`.

---

Necessary for #375 to work!