### PR TITLE
Support Python 3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,14 +82,14 @@ commands:
 jobs:
     build-36:
         docker:
-            - image: cimg/python:3.6.12
+            - image: cimg/python:3.6
         steps:
             - test-start
             - test-python-version
 
     build-36-min:
         docker:
-            - image: cimg/python:3.6.12
+            - image: cimg/python:3.6
         steps:
             - test-start
             - test-min-requirements
@@ -97,7 +97,7 @@ jobs:
 
     build-37:
         docker:
-            - image: cimg/python:3.7.9
+            - image: cimg/python:3.7
         steps:
             - test-start
             - test-python-version
@@ -112,14 +112,14 @@ jobs:
 
     build-38:
         docker:
-            - image: cimg/python:3.8.5
+            - image: cimg/python:3.8
         steps:
             - test-start
             - test-python-version
 
     build-38-min:
         docker:
-            - image: cimg/python:3.8.5
+            - image: cimg/python:3.8
         steps:
             - test-start
             - test-min-requirements
@@ -127,7 +127,7 @@ jobs:
 
     build-39:
         docker:
-            - image: cimg/python:3.9.0
+            - image: cimg/python:3.9
         steps:
             - test-start
             - test-python-version
@@ -141,7 +141,7 @@ jobs:
 
     lint:
         docker:
-            - image: cimg/python:3.9.0
+            - image: cimg/python:3.9
         steps:
             - test-start
             - lint
@@ -169,7 +169,7 @@ jobs:
 
     pypi-deploy:
         docker:
-            - image: cimg/python:3.7.5
+            - image: cimg/python:3.7
         steps:
             - checkout
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
 
     build-310:
         docker:
-            - image: circleci/python:3.10-rc
+            - image: circleci/python:3.10
         steps:
             - test-start
             - test-python-version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,14 +82,14 @@ commands:
 jobs:
     build-36:
         docker:
-            - image: circleci/python:3.6.12
+            - image: cimg/python:3.6.12
         steps:
             - test-start
             - test-python-version
 
     build-36-min:
         docker:
-            - image: circleci/python:3.6.12
+            - image: cimg/python:3.6.12
         steps:
             - test-start
             - test-min-requirements
@@ -97,7 +97,7 @@ jobs:
 
     build-37:
         docker:
-            - image: circleci/python:3.7.9
+            - image: cimg/python:3.7.9
         steps:
             - test-start
             - test-python-version
@@ -112,14 +112,14 @@ jobs:
 
     build-38:
         docker:
-            - image: circleci/python:3.8.5
+            - image: cimg/python:3.8.5
         steps:
             - test-start
             - test-python-version
 
     build-38-min:
         docker:
-            - image: circleci/python:3.8.5
+            - image: cimg/python:3.8.5
         steps:
             - test-start
             - test-min-requirements
@@ -127,21 +127,21 @@ jobs:
 
     build-39:
         docker:
-            - image: circleci/python:3.9.0
+            - image: cimg/python:3.9.0
         steps:
             - test-start
             - test-python-version
 
     build-310:
         docker:
-            - image: circleci/python:3.10
+            - image: cimg/python:3.10
         steps:
             - test-start
             - test-python-version
 
     lint:
         docker:
-            - image: circleci/python:3.9.0
+            - image: cimg/python:3.9.0
         steps:
             - test-start
             - lint
@@ -169,7 +169,7 @@ jobs:
 
     pypi-deploy:
         docker:
-            - image: circleci/python:3.7.5
+            - image: cimg/python:3.7.5
         steps:
             - checkout
             - run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Improve the schema validation error messages. They will no longer include `OrderedDict(...)` on Python 3.7 and later ([bug 1733395](https://bugzilla.mozilla.org/show_bug.cgi?id=1733395))
+- Officially support Python 3.10
 
 ## 4.1.1 (2021-09-28)
 

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     description="Parser tools for Mozilla's Glean telemetry",
     entry_points={


### PR DESCRIPTION
This also updates the docker images used to the [actively maintained ones](https://circleci.com/developer/images/image/cimg/python).  I don't know what the difference between these and the legacy images are, but Python 3.10 is only available in the new ones.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
