### PR TITLE
Bug 1734011 - Support tags in glean parser

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ using Glean is available in `the Glean book <https://mozilla.github.io/glean>`_.
    installation
    metrics-yaml
    pings-yaml
+   tags-yaml
    modules
    contributing
    authors

--- a/docs/tags-yaml.rst
+++ b/docs/tags-yaml.rst
@@ -1,0 +1,13 @@
+``tags.yaml`` file
+=====================
+
+Documentation for the ``tags.yaml`` file is in the `tags parameters in the Glean user documentation <https://mozilla.github.io/glean/book/reference/yaml/tags.html>`_.
+
+JSON Schema
+-----------
+
+There is a formal schema for validating ``tags.yaml`` files, included in its
+entirety below:
+
+.. literalinclude:: ../glean_parser/schemas/tags.1-0-0.schema.yaml
+   :language: yaml

--- a/glean_parser/__main__.py
+++ b/glean_parser/__main__.py
@@ -63,7 +63,14 @@ from . import validate_ping
     is_flag=True,
     help=("Do not treat missing input files as an error."),
 )
-def translate(input, format, output, option, allow_reserved, allow_missing_files):
+@click.option(
+    "--require-tags",
+    is_flag=True,
+    help=("Require tags to be specified for metrics and pings."),
+)
+def translate(
+    input, format, output, option, allow_reserved, allow_missing_files, require_tags
+):
     """
     Translate metrics.yaml and pings.yaml files to other formats.
     """
@@ -81,6 +88,7 @@ def translate(input, format, output, option, allow_reserved, allow_missing_files
             {
                 "allow_reserved": allow_reserved,
                 "allow_missing_files": allow_missing_files,
+                "require_tags": require_tags,
             },
         )
     )
@@ -130,7 +138,12 @@ def check(schema):
     is_flag=True,
     help=("Do not treat missing input files as an error."),
 )
-def glinter(input, allow_reserved, allow_missing_files):
+@click.option(
+    "--require-tags",
+    is_flag=True,
+    help=("Require tags to be specified for metrics and pings."),
+)
+def glinter(input, allow_reserved, allow_missing_files, require_tags):
     """
     Runs a linter over the metrics.
     """
@@ -140,6 +153,7 @@ def glinter(input, allow_reserved, allow_missing_files):
             {
                 "allow_reserved": allow_reserved,
                 "allow_missing_files": allow_missing_files,
+                "require_tags": require_tags,
             },
         )
     )

--- a/glean_parser/kotlin.py
+++ b/glean_parser/kotlin.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, List, Optional, Union  # noqa
 
 from . import metrics
 from . import pings
+from . import tags
 from . import util
 from .util import DictWrapper
 
@@ -187,8 +188,10 @@ def output_gecko_lookup(
         # Glean SDK and GeckoView. See bug 1566356 for more context.
         for metric in category_val.values():
             # This is not a Gecko metric, skip it.
-            if isinstance(metric, pings.Ping) or not getattr(
-                metric, "gecko_datapoint", False
+            if (
+                isinstance(metric, pings.Ping)
+                or isinstance(metric, tags.Tag)
+                or not getattr(metric, "gecko_datapoint", False)
             ):
                 continue
 

--- a/glean_parser/lint.py
+++ b/glean_parser/lint.py
@@ -368,7 +368,7 @@ def _lint_item_tags(
 
 
 def _lint_pings(
-    category: Dict[str, Union[metrics.Metric, pings.Ping]],
+    category: Dict[str, Union[metrics.Metric, pings.Ping, tags.Tag]],
     parser_config: Dict[str, Any],
     valid_tag_names: List[str],
 ) -> List[GlinterNit]:

--- a/glean_parser/lint.py
+++ b/glean_parser/lint.py
@@ -235,7 +235,7 @@ def check_misspelled_pings(
                 yield f"Ping '{ping}' seems misspelled. Did you mean '{builtin}'?"
 
 
-def check_has_tags(
+def check_tags_required(
     metric_or_ping: Union[metrics.Metric, pings.Ping], parser_config: Dict[str, Any]
 ) -> LintGenerator:
 
@@ -314,7 +314,7 @@ METRIC_CHECKS: Dict[
     "BUG_NUMBER": (check_bug_number, CheckType.error),
     "BASELINE_PING": (check_valid_in_baseline, CheckType.error),
     "MISSPELLED_PING": (check_misspelled_pings, CheckType.error),
-    "HAS_TAGS": (check_has_tags, CheckType.error),
+    "TAGS_REQUIRED": (check_tags_required, CheckType.error),
     "EXPIRATION_DATE_TOO_FAR": (check_expired_date, CheckType.warning),
     "USER_LIFETIME_EXPIRATION": (check_user_lifetime_expiration, CheckType.warning),
     "EXPIRED": (check_expired_metric, CheckType.warning),
@@ -327,7 +327,7 @@ PING_CHECKS: Dict[
     str, Tuple[Callable[[pings.Ping, dict], LintGenerator], CheckType]
 ] = {
     "BUG_NUMBER": (check_bug_number, CheckType.error),
-    "HAS_TAGS": (check_has_tags, CheckType.error),
+    "TAGS_REQUIRED": (check_tags_required, CheckType.error),
     "REDUNDANT_PING": (check_redundant_ping, CheckType.error),
 }
 

--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Optional, Type, Union  # noqa
 
 
 from . import pings
+from . import tags
 from . import util
 
 
@@ -404,4 +405,4 @@ class Text(Metric):
     typename = "text"
 
 
-ObjectTree = Dict[str, Dict[str, Union[Metric, pings.Ping]]]
+ObjectTree = Dict[str, Dict[str, Union[Metric, pings.Ping, tags.Tag]]]

--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -47,6 +47,7 @@ class Metric:
         description: str,
         notification_emails: List[str],
         expires: Any,
+        metadata: Optional[Dict] = None,
         data_reviews: Optional[List[str]] = None,
         version: int = 0,
         disabled: bool = False,
@@ -71,6 +72,9 @@ class Metric:
         self.description = description
         self.notification_emails = notification_emails
         self.expires = expires
+        if metadata is None:
+            metadata = {}
+        self.metadata = metadata
         if data_reviews is None:
             data_reviews = []
         self.data_reviews = data_reviews

--- a/glean_parser/parser.py
+++ b/glean_parser/parser.py
@@ -344,7 +344,7 @@ def _instantiate_tags(
         if tag_key == "no_lint":
             continue
         if not isinstance(tag_val, dict):
-            raise TypeError(f"Invalid content for ping {tag_key}")
+            raise TypeError(f"Invalid content for tag {tag_key}")
         tag_val["name"] = tag_key
         try:
             tag_obj = Tag(
@@ -359,8 +359,8 @@ def _instantiate_tags(
         if tag_obj is not None:
             tag_obj.no_lint = list(set(tag_obj.no_lint + global_no_lint))
 
-        if isinstance(filepath, Path) and tag_obj.defined_in is not None:
-            tag_obj.defined_in["filepath"] = str(filepath)
+            if isinstance(filepath, Path) and tag_obj.defined_in is not None:
+                tag_obj.defined_in["filepath"] = str(filepath)
 
         already_seen = sources.get(tag_key)
         if already_seen is not None:

--- a/glean_parser/parser.py
+++ b/glean_parser/parser.py
@@ -405,7 +405,7 @@ def parse_objects(
 ) -> Generator[str, None, ObjectTree]:
     """
     Parse one or more metrics.yaml and/or pings.yaml files, returning a tree of
-    `metrics.Metric` and `pings.Ping` instances.
+    `metrics.Metric`, `pings.Ping`, and `tags.Tag` instances.
 
     The result is a generator over any errors.  If there are no errors, the
     actual metrics can be obtained from `result.value`.  For example::

--- a/glean_parser/pings.py
+++ b/glean_parser/pings.py
@@ -24,6 +24,7 @@ class Ping:
         description: str,
         bugs: List[str],
         notification_emails: List[str],
+        metadata: Optional[Dict] = None,
         data_reviews: Optional[List[str]] = None,
         include_client_id: bool = False,
         send_if_empty: bool = False,
@@ -40,6 +41,9 @@ class Ping:
 
         self.bugs = bugs
         self.notification_emails = notification_emails
+        if metadata is None:
+            metadata = {}
+        self.metadata = metadata
         if data_reviews is None:
             data_reviews = []
         self.data_reviews = data_reviews
@@ -53,7 +57,7 @@ class Ping:
             no_lint = []
         self.no_lint = no_lint
 
-        # _validated indicates whether this metric has already been jsonschema
+        # _validated indicates whether this ping has already been jsonschema
         # validated (but not any of the Python-level validation).
         if not _validated:
             data: Dict[str, util.JSONType] = {

--- a/glean_parser/schemas/metrics.2-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.2-0-0.schema.yaml
@@ -153,6 +153,22 @@ definitions:
           syntax](https://www.markdownguide.org/basic-syntax/).
         type: string
 
+      metadata:
+        title: Metadata
+        description: |
+          Additional metadata about this metric. Currently limited to a list of
+          tags.
+        type: object
+        properties:
+          tags:
+            title: Tags
+            description: Which tags are specified for this metric.
+            type: array
+            items:
+              type: string
+              maxLength: 80
+        default: {}
+
       lifetime:
         title: Lifetime
         description: |
@@ -519,6 +535,9 @@ propertyNames:
         - not:
             description: "'pings' is reserved as a category name."
             const: pings
+        - not:
+            description: "'tags' is reserved as a category name."
+            const: tags
     - enum: ['$schema']
 
 properties:

--- a/glean_parser/schemas/pings.2-0-0.schema.yaml
+++ b/glean_parser/schemas/pings.2-0-0.schema.yaml
@@ -62,6 +62,22 @@ additionalProperties:
         syntax](https://www.markdownguide.org/basic-syntax/).
       type: string
 
+      metadata:
+        title: Metadata
+        description: |
+          Additional metadata about this ping. Currently limited to a list of
+          tags.
+        type: object
+        properties:
+          tags:
+            title: Tags
+            description: Which tags are specified for this ping.
+            type: array
+            items:
+              type: string
+              maxLength: 80
+        default: {}
+
     include_client_id:
       title: Include client id
       description: |

--- a/glean_parser/schemas/pings.2-0-0.schema.yaml
+++ b/glean_parser/schemas/pings.2-0-0.schema.yaml
@@ -62,21 +62,21 @@ additionalProperties:
         syntax](https://www.markdownguide.org/basic-syntax/).
       type: string
 
-      metadata:
-        title: Metadata
-        description: |
-          Additional metadata about this ping. Currently limited to a list of
-          tags.
-        type: object
-        properties:
-          tags:
-            title: Tags
-            description: Which tags are specified for this ping.
-            type: array
-            items:
-              type: string
-              maxLength: 80
-        default: {}
+    metadata:
+      title: Metadata
+      description: |
+        Additional metadata about this ping. Currently limited to a list of
+        tags.
+      type: object
+      properties:
+        tags:
+          title: Tags
+          description: Which tags are specified for this ping.
+          type: array
+          items:
+            type: string
+            maxLength: 80
+      default: {}
 
     include_client_id:
       title: Include client id

--- a/glean_parser/schemas/tags.1-0-0.schema.yaml
+++ b/glean_parser/schemas/tags.1-0-0.schema.yaml
@@ -1,0 +1,50 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+---
+$schema: http://json-schema.org/draft-07/schema#
+title: Tags
+description: |
+  Schema for the tags.yaml files for Mozilla's Glean telemetry SDK.
+
+  The top-level of the `tags.yaml` file has a key defining the name of each
+  tag. The values contain metadata about that tag (currently just a description).
+
+$id: moz://mozilla.org/schemas/glean/tags/1-0-0
+
+type: object
+
+propertyNames:
+  type: string
+  maxLength: 80
+
+properties:
+  $schema:
+    type: string
+    format: url
+
+  no_lint:
+    title: Lint checks to skip globally
+    description: |
+      This parameter lists any lint checks to skip for this whole file.
+    type: array
+    items:
+      type: string
+
+additionalProperties:
+  type: object
+  properties:
+    description:
+      title: Description
+      description: |
+        **Required.**
+
+        A textual description of this tag.
+
+        Descriptions may contain [markdown
+        syntax](https://www.markdownguide.org/basic-syntax/).
+      type: string
+  required:
+    - description
+  additionalProperties: false

--- a/glean_parser/schemas/tags.1-0-0.schema.yaml
+++ b/glean_parser/schemas/tags.1-0-0.schema.yaml
@@ -9,7 +9,8 @@ description: |
   Schema for the tags.yaml files for Mozilla's Glean telemetry SDK.
 
   The top-level of the `tags.yaml` file has a key defining the name of each
-  tag. The values contain metadata about that tag (currently just a description).
+  tag. The values contain metadata about that tag (currently just a
+  description).
 
 $id: moz://mozilla.org/schemas/glean/tags/1-0-0
 

--- a/glean_parser/swift.py
+++ b/glean_parser/swift.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, Optional, Union
 
 from . import metrics
 from . import pings
+from . import tags
 from . import util
 
 # An (imcomplete) list of reserved keywords in Swift.
@@ -139,7 +140,7 @@ class Category:
     """
 
     name: str
-    objs: Dict[str, Union[metrics.Metric, pings.Ping]]
+    objs: Dict[str, Union[metrics.Metric, pings.Ping, tags.Tag]]
     contains_pings: bool
 
 

--- a/glean_parser/tags.py
+++ b/glean_parser/tags.py
@@ -31,6 +31,15 @@ class Tag:
             for error in parser.validate(data):
                 raise ValueError(error)
 
+    @property
+    def type(self) -> str:
+        return "tag"
+
+    def _serialize_input(self) -> Dict[str, util.JSONType]:
+        d = self.serialize()
+        modified_dict = util.remove_output_params(d, "defined_in")
+        return modified_dict
+
     def serialize(self) -> Dict[str, util.JSONType]:
         """
         Serialize the tag back to JSON object model.

--- a/glean_parser/tags.py
+++ b/glean_parser/tags.py
@@ -1,0 +1,32 @@
+from typing import Dict, List, Optional
+from . import util
+
+
+class Tag:
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        defined_in: Optional[Dict] = None,
+        no_lint: Optional[List[str]] = None,
+        _validated: bool = False,
+    ):
+        # Avoid cyclical import
+        from . import parser
+
+        self.name = name
+        self.description = description
+        self.defined_in = defined_in
+        if no_lint is None:
+            no_lint = []
+        self.no_lint = no_lint
+
+        # _validated indicates whether this tag has already been jsonschema
+        # validated (but not any of the Python-level validation).
+        if not _validated:
+            data: Dict[str, util.JSONType] = {
+                "$schema": parser.TAGS_ID,
+                self.name: self._serialize_input(),
+            }
+            for error in parser.validate(data):
+                raise ValueError(error)

--- a/glean_parser/tags.py
+++ b/glean_parser/tags.py
@@ -30,3 +30,11 @@ class Tag:
             }
             for error in parser.validate(data):
                 raise ValueError(error)
+
+    def serialize(self) -> Dict[str, util.JSONType]:
+        """
+        Serialize the tag back to JSON object model.
+        """
+        d = self.__dict__.copy()
+        del d["name"]
+        return d

--- a/tests/data/metric-with-tags.yaml
+++ b/tests/data/metric-with-tags.yaml
@@ -1,0 +1,27 @@
+# Any copyright is dedicated to the Public Domain.
+# https://creativecommons.org/publicdomain/zero/1.0/
+
+---
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+
+telemetry:
+  client_id:
+    type: uuid
+    lifetime: user
+    description: >
+      A UUID identifying a profile and allowing user-oriented
+      Correlation of data.
+      Some Unicode: جمع 搜集
+    bugs:
+      - https://bugzilla.mozilla.org/1137353
+    data_reviews:
+      - http://example.com/reviews
+    notification_emails:
+      - CHANGE-ME@example.com
+    send_in_pings:
+      - metrics
+    metadata:
+      tags:
+        - banana
+        - apple
+    expires: 2100-01-01

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -377,7 +377,7 @@ def test_metric_no_tags(require_tags, expected_nits):
     nits = lint.lint_metrics(objs.value, {"require_tags": require_tags})
     assert len(nits) == expected_nits
     if expected_nits:
-        assert nits[0].check_name == "HAS_TAGS"
+        assert nits[0].check_name == "TAGS_REQUIRED"
         assert nits[0].name == "foo.bar"
         assert nits[0].msg == "Tags are required but no tags specified"
 
@@ -398,7 +398,7 @@ def test_ping_no_tags(require_tags, expected_nits):
     nits = lint.lint_metrics(objs.value, {"require_tags": require_tags})
     assert len(nits) == expected_nits
     if expected_nits:
-        assert nits[0].check_name == "HAS_TAGS"
+        assert nits[0].check_name == "TAGS_REQUIRED"
         assert nits[0].name == "search"
         assert nits[0].msg == "Tags are required but no tags specified"
 

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -361,7 +361,7 @@ def test_redundant_pings():
         (True, 1),
     ],
 )
-def test_no_tags(require_tags, expected_nits):
+def test_metric_no_tags(require_tags, expected_nits):
     """Test what happens when a metric has no tags (depends on parser configuration)"""
     metric = {
         "foo": {
@@ -383,13 +383,34 @@ def test_no_tags(require_tags, expected_nits):
 
 
 @pytest.mark.parametrize(
+    "require_tags,expected_nits",
+    [
+        (False, 0),
+        (True, 1),
+    ],
+)
+def test_ping_no_tags(require_tags, expected_nits):
+    """Test what happens when a metric has no tags (depends on parser configuration)"""
+    objs = parser.parse_objects([util.add_required_ping({"search": {}})])
+    errs = list(objs)
+    assert len(errs) == 0
+
+    nits = lint.lint_metrics(objs.value, {"require_tags": require_tags})
+    assert len(nits) == expected_nits
+    if expected_nits:
+        assert nits[0].check_name == "HAS_TAGS"
+        assert nits[0].name == "search"
+        assert nits[0].msg == "Tags are required but no tags specified"
+
+
+@pytest.mark.parametrize(
     "tags,expected_nits",
     [
         (["apple"], 0),
         (["grapefruit"], 1),
     ],
 )
-def test_check_tag_names(tags, expected_nits):
+def test_check_metric_tag_names(tags, expected_nits):
     """
     Test that specifying an invalid tag name inside a metric produces an error
     """
@@ -401,12 +422,12 @@ def test_check_tag_names(tags, expected_nits):
             },
         },
     }
-    tags = {
+    defined_tags = {
         "$schema": "moz://mozilla.org/schemas/glean/tags/1-0-0",
         "apple": {"description": "apple is a banana"},
     }
 
-    objs = parser.parse_objects([util.add_required(metric), tags])
+    objs = parser.parse_objects([util.add_required(metric), defined_tags])
     errs = list(objs)
     assert len(errs) == 0
 
@@ -416,3 +437,33 @@ def test_check_tag_names(tags, expected_nits):
         assert nits[0].check_name == "INVALID_TAGS"
         assert nits[0].name == "foo.bar"
         assert nits[0].msg == "Invalid tags specified in metric: grapefruit"
+
+
+@pytest.mark.parametrize(
+    "tags,expected_nits",
+    [
+        (["apple"], 0),
+        (["grapefruit"], 1),
+    ],
+)
+def test_check_ping_tag_names(tags, expected_nits):
+    """
+    Test that specifying an invalid tag name inside a metric produces an error
+    """
+    defined_tags = {
+        "$schema": "moz://mozilla.org/schemas/glean/tags/1-0-0",
+        "apple": {"description": "apple is a banana"},
+    }
+
+    objs = parser.parse_objects(
+        [util.add_required_ping({"search": {"metadata": {"tags": tags}}}), defined_tags]
+    )
+    errs = list(objs)
+    assert len(errs) == 0
+
+    nits = lint.lint_metrics(objs.value)
+    assert len(nits) == expected_nits
+    if expected_nits:
+        assert nits[0].check_name == "INVALID_TAGS"
+        assert nits[0].name == "search"
+        assert nits[0].msg == "Invalid tags specified in ping: grapefruit"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -558,7 +558,20 @@ def test_send_in_pings_restrictions():
     all_metrics = parser.parse_objects(ROOT / "data" / "invalid-ping-names.yaml")
     errors = list(all_metrics)
     assert len(errors) == 1
+
     assert "'invalid_ping_name' does not match" in errors[0]
+
+
+def test_tags():
+    """Tests that tags can be specified."""
+    all_metrics = parser.parse_objects(ROOT / "data" / "metric-with-tags.yaml")
+    errors = list(all_metrics)
+
+    assert errors == []
+    assert len(all_metrics.value) == 1
+    assert all_metrics.value["telemetry"]["client_id"].metadata == {
+        "tags": ["banana", "apple"]
+    }
 
 
 def test_custom_expires():

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,0 +1,47 @@
+from glean_parser import parser
+
+
+def test_basic_tags():
+    content = {
+        "$schema": "moz://mozilla.org/schemas/glean/tags/1-0-0",
+        "Tag": {"description": "Normal tag"},
+        "Testing :: General": {"description": "Testing / General"},
+    }
+    objs = parser.parse_objects([content])
+
+    errors = list(objs)
+    assert len(errors) == 0
+
+    tags = objs.value["tags"]
+    assert set(tags.keys()) == set(["Tag", "Testing :: General"])
+    assert tags["Tag"].description == content["Tag"]["description"]
+
+
+def test_tags_description_required():
+    content = {
+        "$schema": "moz://mozilla.org/schemas/glean/tags/1-0-0",
+        "Tag": {},
+    }
+    errors = list(parser.parse_objects([content]))
+    assert len(errors) == 1
+    assert "Missing required properties: description" in errors[0]
+
+
+def test_tags_extra_keys_not_allowed():
+    content = {
+        "$schema": "moz://mozilla.org/schemas/glean/tags/1-0-0",
+        "Tag": {"description": "Normal tag", "extra": "Extra stuff"},
+    }
+    errors = list(parser.parse_objects([content]))
+    assert len(errors) == 1
+    assert "Additional properties are not allowed" in errors[0]
+
+
+def test_tags_name_too_long():
+    content = {
+        "$schema": "moz://mozilla.org/schemas/glean/tags/1-0-0",
+        "Tag" * 80: {"description": "This name is way too long"},
+    }
+    errors = list(parser.parse_objects([content]))
+    assert len(errors) == 1
+    assert "TagTagTag' is too long" in errors[0]


### PR DESCRIPTION
How it works:

* You can specify a `tags.yaml` file, which has a list of tag names
  along with a description key (very similar to `pings.yaml`, but
  simpler)
* Metrics and pings now have an optional `metadata` section, in which tags can
  be specified as a list of strings (e.g. metadata -> tags -> ["apple",
  "banana"])
* You can force tags to be defined by passing `--require-tags` to either the translator or the linter.

Still to-do:

- [x] Think about whether we want to restrict tags defined in a metric to those specified in the same invocation of glean parser?
- [x] <strike>Upstream in probe scraper, what is the desired behaviour if a tag is defined more than once?</strike> Tags are per application/library, and are stored in a dictionary. So there shouldn't be a problem at this level. We will need to think about how to do this on the Glean Dictionary level, but I'm not too worried.
- [x] Do a proof of concept of making probe scraper use this functionality for a simple application (see mozilla/burnham#299, mozilla/probe-scraper#358)
- [x] Add docs on how to specify these in your application.
