### PR TITLE
Bug 1739126: Add linter about use of private bugtracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- A new linter warning, `PRIVATE_BUGTRACKER`, will be emitted if a `bugs` URL points to a known private bugtracker. This warning will become an error in a future release.
+
 ## 4.3.1
 
 - BUGFIX: Skip tags for code generation ([#409](https://github.com/mozilla/glean_parser/pull/409))

--- a/glean_parser/lint.py
+++ b/glean_parser/lint.py
@@ -18,6 +18,7 @@ from typing import (
     Tuple,
     Union,
 )  # noqa
+from urllib.parse import urlparse
 
 
 from . import metrics
@@ -273,6 +274,18 @@ def check_expired_metric(
         yield ("Metric has expired. Please consider removing it.")
 
 
+PRIVATE_BUGTRACKER_DISALLOW_LIST = set(["mozilla-hub.atlassian.net"])
+
+
+def check_private_bugtracker(
+    metric: metrics.Metric, parser_config: Dict[str, Any]
+) -> LintGenerator:
+    for bug in metric.bugs:
+        parsed = urlparse(bug)
+        if parsed.hostname in PRIVATE_BUGTRACKER_DISALLOW_LIST:
+            yield (f"Bug url '{bug}' points to a private bugtracker.")
+
+
 def check_redundant_ping(
     pings: pings.Ping, parser_config: Dict[str, Any]
 ) -> LintGenerator:
@@ -318,6 +331,7 @@ METRIC_CHECKS: Dict[
     "EXPIRATION_DATE_TOO_FAR": (check_expired_date, CheckType.warning),
     "USER_LIFETIME_EXPIRATION": (check_user_lifetime_expiration, CheckType.warning),
     "EXPIRED": (check_expired_metric, CheckType.warning),
+    "PRIVATE_BUGTRACKER": (check_private_bugtracker, CheckType.warning),
 }
 
 

--- a/glean_parser/schemas/metrics.2-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.2-0-0.schema.yaml
@@ -230,9 +230,11 @@ definitions:
         description: |
           **Required.**
 
-          A list of bug URLs (e.g. Bugzilla and Github) that are relevant to
-          this metric, e.g., tracking its original implementation or later
-          changes to it.
+          A list of bug URLs that are relevant to this metric, e.g., tracking
+          its original implementation or later changes to it.
+
+          This URL should be openly visible, and not behind authorization. (e.g.
+          a public Github repository or Bugzilla, not a private JIRA instance).
 
           Prior to version 2.0.0 of the schema, bugs could also be integers.
         type: array

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -467,3 +467,24 @@ def test_check_ping_tag_names(tags, expected_nits):
         assert nits[0].check_name == "INVALID_TAGS"
         assert nits[0].name == "search"
         assert nits[0].msg == "Invalid tags specified in ping: grapefruit"
+
+
+def test_private_bugtracker():
+    contents = [
+        {
+            "user_data": {
+                "too_far": {
+                    "bugs": ["https://mozilla-hub.atlassian.net/browse/FXIOS-1808"],
+                }
+            }
+        }
+    ]
+
+    contents = [util.add_required(x) for x in contents]
+    all_metrics = parser.parse_objects(contents)
+    errs = list(all_metrics)
+    assert len(errs) == 0
+
+    nits = lint.lint_metrics(all_metrics.value)
+    assert len(nits) == 1
+    assert set(["PRIVATE_BUGTRACKER"]) == set(v.check_name for v in nits)


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
