### PR TITLE
Bug 1751730 - Skip message if no metrics are found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Remove C# support ([#436](https://github.com/mozilla/glean_parser/pull/436)).
 - Add support for Rust code generation ([bug 1677434](https://bugzilla.mozilla.org/show_bug.cgi?id=1677434))
+- Report an error if no files are passed ([bug 1751730](https://bugzilla.mozilla.org/show_bug.cgi?id=1751730))
 
 ## 4.4.0
 

--- a/glean_parser/translate.py
+++ b/glean_parser/translate.py
@@ -136,6 +136,12 @@ def translate_metrics(
 
     input_filepaths = util.ensure_list(input_filepaths)
 
+    allow_missing_files = parser_config.get("allow_missing_files", False)
+    if not input_filepaths and not allow_missing_files:
+        print("❌ No metric files specified. ", end="")
+        print("Use `--allow-missing-files` to not treat this as an error.")
+        return 1
+
     if lint.glinter(input_filepaths, parser_config):
         return 1
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -249,3 +249,29 @@ def test_wrong_key_lint(tmpdir):
     # wrong `unit` key for datetime, timing_distribution, timespan.
     # a missing key is NOT an error.
     assert "Found 3 errors" in result.output
+
+
+def test_no_file_is_an_error(tmpdir):
+    """Test that 'translate' fails when no files are passed."""
+    runner = CliRunner()
+    result = runner.invoke(
+        __main__.main,
+        [
+            "translate",
+            "-o",
+            str(tmpdir),
+            "-f",
+            "kotlin",
+        ],
+    )
+    assert result.exit_code == 1
+
+
+def test_no_file_can_be_skipped(tmpdir):
+    """Test that 'translate' works when no files are passed but flag is set."""
+    runner = CliRunner()
+    result = runner.invoke(
+        __main__.main,
+        ["translate", "-o", str(tmpdir), "-f", "kotlin", "--allow-missing-files"],
+    )
+    assert result.exit_code == 0


### PR DESCRIPTION
~~This can be for 2 reasons: no files passed or empty files passed.~~
~~Both cases are actually acceptable use of Glean:~~
~~You might want to use Glean _only_ for the baseline ping.~~
~~Especially initially, when you don't have metrics.~~

~~We still need to generate the build info so users can call~~
~~Glean.initialize with valid values.~~

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
