### PR TITLE
Bug 1753194 - add support for expiring metrics by major version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Report an error if no files are passed ([bug 1751730](https://bugzilla.mozilla.org/show_bug.cgi?id=1751730))
 - [data-review] Report an error if no metrics match provided bug number ([bug 1752576](https://bugzilla.mozilla.org/show_bug.cgi?id=1752576))
 - [data-review] Include notification_emails in list of those responsible ([bug 1752576](https://bugzilla.mozilla.org/show_bug.cgi?id=1752576))
+- Add support for expiring metrics by the provided major version ([bug 1753194](https://bugzilla.mozilla.org/show_bug.cgi?id=1753194))
 
 ## 4.4.0
 

--- a/glean_parser/__main__.py
+++ b/glean_parser/__main__.py
@@ -68,8 +68,21 @@ from . import validate_ping
     is_flag=True,
     help=("Require tags to be specified for metrics and pings."),
 )
+@click.option(
+    "--expire-by-version",
+    help="Expire metrics by version, with the provided major version.",
+    type=click.INT,
+    required=False,
+)
 def translate(
-    input, format, output, option, allow_reserved, allow_missing_files, require_tags
+    input,
+    format,
+    output,
+    option,
+    allow_reserved,
+    allow_missing_files,
+    require_tags,
+    expire_by_version,
 ):
     """
     Translate metrics.yaml and pings.yaml files to other formats.
@@ -89,6 +102,7 @@ def translate(
                 "allow_reserved": allow_reserved,
                 "allow_missing_files": allow_missing_files,
                 "require_tags": require_tags,
+                "expire_by_version": expire_by_version,
             },
         )
     )

--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -198,10 +198,16 @@ class Metric:
         return self.disabled or self.is_expired()
 
     def is_expired(self) -> bool:
-        return self._config.get("custom_is_expired", util.is_expired)(self.expires)
+        def default_handler(expires) -> bool:
+            return util.is_expired(expires, self._config.get("expire_by_version"))
+
+        return self._config.get("custom_is_expired", default_handler)(self.expires)
 
     def validate_expires(self):
-        return self._config.get("custom_validate_expires", util.validate_expires)(
+        def default_handler(expires):
+            return util.validate_expires(expires, self._config.get("expire_by_version"))
+
+        return self._config.get("custom_validate_expires", default_handler)(
             self.expires
         )
 

--- a/glean_parser/schemas/metrics.2-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.2-0-0.schema.yaml
@@ -270,12 +270,22 @@ definitions:
               metric expires. For example, `2019-03-13`. This date is checked at
               build time. Except in special cases, this form should be used so
               that the metric automatically "sunsets" after a period of time.
+            - `<major version>`: A positive integer representing the major
+              version the metric expires in. For example, `11`. The version is
+              checked at build time against the major provided to the
+              glean_parser and is only valid if a major version is provided at
+              built time. If no major version is provided at built time and
+              expiration by major version is used for a metric, an error is
+              raised.
             - `never`: This metric never expires.
             - `expired`: This metric is manually expired.
 
           The default may be overriden in certain applications by the
           `custom_validate_expires` and `custom_is_expired` configs.
-        type: string
+        oneOf:
+          - type: string
+          - type: integer
+            minimum: 0
 
       version:
         title: Metric version

--- a/glean_parser/schemas/metrics.2-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.2-0-0.schema.yaml
@@ -270,13 +270,15 @@ definitions:
               metric expires. For example, `2019-03-13`. This date is checked at
               build time. Except in special cases, this form should be used so
               that the metric automatically "sunsets" after a period of time.
-            - `<major version>`: A positive integer representing the major
-              version the metric expires in. For example, `11`. The version is
-              checked at build time against the major provided to the
+            - `<major version>`: An integer greater than 0 representing the
+              major version the metric expires in. For example, `11`. The
+              version is checked at build time against the major provided to the
               glean_parser and is only valid if a major version is provided at
-              built time. If no major version is provided at built time and
+              built time. If no major version is provided at build time and
               expiration by major version is used for a metric, an error is
               raised.
+              Note that mixing expiration by date and version is not allowed
+              within a product.
             - `never`: This metric never expires.
             - `expired`: This metric is manually expired.
 
@@ -285,7 +287,7 @@ definitions:
         oneOf:
           - type: string
           - type: integer
-            minimum: 0
+            minimum: 1
 
       version:
         title: Metric version

--- a/glean_parser/util.py
+++ b/glean_parser/util.py
@@ -374,7 +374,7 @@ def format_error(
         return f"{filepath}:\n{textwrap.indent(content, '    ')}"
 
 
-def parse_expires(expires: str) -> datetime.date:
+def parse_expiration_date(expires: str) -> datetime.date:
     """
     Parses the expired field date (yyyy-mm-dd) as a date.
     Raises a ValueError in case the string is not properly formatted.
@@ -388,7 +388,24 @@ def parse_expires(expires: str) -> datetime.date:
         )
 
 
-def is_expired(expires: str) -> bool:
+def parse_expiration_version(expires: str) -> int:
+    """
+    Parses the expired field version string as an integer.
+    Raises a ValueError in case the string does not contain a valid
+    positive integer.
+    """
+    try:
+        version_number = int(expires)
+        if version_number < 0:
+            raise ValueError()
+        return version_number
+    except ValueError:
+        raise ValueError(
+            f"Invalid expiration version '{expires}'. Must be a positive integer."
+        )
+
+
+def is_expired(expires: str, major_version: Optional[int] = None) -> bool:
     """
     Parses the `expires` field in a metric or ping and returns whether
     the object should be considered expired.
@@ -397,20 +414,32 @@ def is_expired(expires: str) -> bool:
         return False
     elif expires == "expired":
         return True
+    elif major_version is not None:
+        return parse_expiration_version(expires) >= major_version
     else:
-        date = parse_expires(expires)
+        date = parse_expiration_date(expires)
         return date <= datetime.datetime.utcnow().date()
 
 
-def validate_expires(expires: str) -> None:
+def validate_expires(expires: str, major_version: Optional[int] = None) -> None:
     """
-    Raises a ValueError in case the `expires` is not ISO8601 parseable,
-    or in case the date is more than 730 days (~2 years) in the future.
+    If expiration by major version is enabled, raises a ValueError in
+    case `expires` is not a positive integer.
+    Otherwise raises a ValueError in case the `expires` is not ISO8601
+    parseable, or in case the date is more than 730 days (~2 years) in
+    the future.
     """
     if expires in ("never", "expired"):
         return
 
-    date = parse_expires(expires)
+    if major_version is not None:
+        parse_expiration_version(expires)
+        # Don't need to keep parsing dates if expiration by version
+        # is enabled. We don't allow mixing dates and versions for a
+        # single product.
+        return
+
+    date = parse_expiration_date(expires)
     max_date = datetime.datetime.now() + datetime.timedelta(days=730)
     if date > max_date.date():
         raise ValueError(

--- a/glean_parser/util.py
+++ b/glean_parser/util.py
@@ -395,10 +395,13 @@ def parse_expiration_version(expires: str) -> int:
     positive integer.
     """
     try:
-        version_number = int(expires)
-        if version_number < 0:
-            raise ValueError()
-        return version_number
+        if isinstance(expires, int):
+            version_number = int(expires)
+            if version_number > 0:
+                return version_number
+        # Fall-through: if it's not an integer or is not greater than zero,
+        # raise an error.
+        raise ValueError()
     except ValueError:
         raise ValueError(
             f"Invalid expiration version '{expires}'. Must be a positive integer."

--- a/glean_parser/util.py
+++ b/glean_parser/util.py
@@ -381,7 +381,7 @@ def parse_expiration_date(expires: str) -> datetime.date:
     """
     try:
         return date_fromisoformat(expires)
-    except ValueError:
+    except (TypeError, ValueError):
         raise ValueError(
             f"Invalid expiration date '{expires}'. "
             "Must be of the form yyyy-mm-dd in UTC."

--- a/tests/data/mixed-expirations.yaml
+++ b/tests/data/mixed-expirations.yaml
@@ -1,0 +1,36 @@
+# Any copyright is dedicated to the Public Domain.
+# https://creativecommons.org/publicdomain/zero/1.0/
+
+---
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+
+category:
+  counter:
+    type: counter
+    lifetime: user
+    description: >
+      Foo
+    bugs:
+      - https://bugzilla.mozilla.org/11137353
+    data_reviews:
+      - http://example.com/reviews
+    notification_emails:
+      - CHANGE-ME@example.com
+    send_in_pings:
+      - core
+    expires: 2100-01-01
+
+  other_counter:
+    type: counter
+    lifetime: user
+    description: >
+      Foo
+    bugs:
+      - https://bugzilla.mozilla.org/11137353
+    data_reviews:
+      - http://example.com/reviews
+    notification_emails:
+      - CHANGE-ME@example.com
+    send_in_pings:
+      - core
+    expires: 99

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -247,7 +247,7 @@ def test_user_lifetime_expiration():
 
 
 def test_expired_metric():
-    """Test that expiring 'user' lifetime metrics generate a warning."""
+    """Test that expiring 'ping' lifetime metrics generate a warning."""
     contents = [
         {
             "user_data": {

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -613,6 +613,63 @@ def test_custom_expires():
         errors = list(all_metrics)
 
 
+def test_expire_by_major_version():
+    failing_metrics = [
+        {
+            "category": {
+                "metric_fail_date": {
+                    "type": "boolean",
+                    "expires": "1986-07-03",
+                },
+            }
+        }
+    ]
+    failing_metrics = [util.add_required(x) for x in failing_metrics]
+
+    with pytest.raises(ValueError):
+        # Dates are not allowed if expiration by major version is enabled.
+        all_metrics = parser.parse_objects(
+            failing_metrics,
+            {
+                "expire_by_version": 15,
+            },
+        )
+        errors = list(all_metrics)
+
+    contents = [
+        {
+            "category": {
+                "metric_expired_version": {
+                    "type": "boolean",
+                    "expires": 18,
+                },
+                "metric_expired": {
+                    "type": "boolean",
+                    "expires": "expired",
+                },
+                "metric": {
+                    "type": "boolean",
+                    "expires": 7,
+                },
+            }
+        }
+    ]
+    contents = [util.add_required(x) for x in contents]
+
+    # Double-check that parsing without custom functions breaks
+    all_metrics = parser.parse_objects(
+        contents,
+        {
+            "expire_by_version": 15,
+        },
+    )
+    errors = list(all_metrics)
+    assert len(errors) == 0
+    assert all_metrics.value["category"]["metric_expired_version"].disabled is True
+    assert all_metrics.value["category"]["metric_expired"].disabled is True
+    assert all_metrics.value["category"]["metric"].disabled is False
+
+
 def test_historical_versions():
     """
     Make sure we can load the correct version of the schema and it will

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -688,6 +688,25 @@ def test_parser_mixed_expirations():
         list(all_metrics)
 
 
+def test_expire_by_version_must_fail_if_disabled():
+    failing_metrics = [
+        {
+            "category": {
+                "metric_fail_date": {
+                    "type": "boolean",
+                    "expires": 99,
+                },
+            }
+        }
+    ]
+    failing_metrics = [util.add_required(x) for x in failing_metrics]
+
+    with pytest.raises(ValueError):
+        # Versions are not allowed if expiration by major version is enabled.
+        all_metrics = parser.parse_objects(failing_metrics)
+        list(all_metrics)
+
+
 def test_historical_versions():
     """
     Make sure we can load the correct version of the schema and it will

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -670,6 +670,24 @@ def test_expire_by_major_version():
     assert all_metrics.value["category"]["metric"].disabled is False
 
 
+def test_parser_mixed_expirations():
+    """Validate that mixing expiration types fail"""
+    with pytest.raises(ValueError):
+        # Mixing expiration types must fail when expiring by version.
+        all_metrics = parser.parse_objects(
+            ROOT / "data" / "mixed-expirations.yaml",
+            {
+                "expire_by_version": 15,
+            },
+        )
+        list(all_metrics)
+
+    with pytest.raises(ValueError):
+        # Mixing expiration types must fail when expiring by date.
+        all_metrics = parser.parse_objects(ROOT / "data" / "mixed-expirations.yaml")
+        list(all_metrics)
+
+
 def test_historical_versions():
     """
     Make sure we can load the correct version of the schema and it will


### PR DESCRIPTION
This introduces a new command line argument that allows the integrator to provide the major version number of the product.

If that's provided, glean_parse will only allow metrics to expire by major version instead than date.

@mdboom do you think we should bump the schema version? This feels a pretty safe change (famous last words), as we are increasing the set of allowed values instead of restricting more.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
