### PR TITLE
Add lint warning for using default pings with SDKs that don't provide them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Glinter: warn against using any of the default pings while translating to a language whose SDK does not provide any of the default pings (JavaScript, TypeScript and Python) ([bug 1744768](https://bugzilla.mozilla.org/show_bug.cgi?id=1744768))
+
 ## 5.0.1
 
 - Fix the logic for the metric expiration by version ([bug 1753194](https://bugzilla.mozilla.org/show_bug.cgi?id=1753194))

--- a/glean_parser/lint.py
+++ b/glean_parser/lint.py
@@ -225,6 +225,28 @@ def check_valid_in_baseline(
         )
 
 
+def check_default_in_pings(
+    metric: metrics.Metric, parser_config: Dict[str, Any]
+) -> LintGenerator:
+    output_format = parser_config.get("output_format")
+    allow_reserved = parser_config.get("allow_reserved", False)
+
+    # language SDKs that don't provide the default pings
+    TARGETS_WITHOUT_DEFAULT = ["javascript", "typescript", "python"]
+
+    for ping in metric.send_in_pings:
+        if (
+            not allow_reserved
+            and ping in pings.RESERVED_PING_NAMES
+            and output_format in TARGETS_WITHOUT_DEFAULT
+        ):
+            yield (
+                f"The Glean ${util.camelize(output_format)} SDK does not provide "
+                "default pings other than the deletion-request. Adding one of the "
+                "default pings to `send_in_pings` will have no effect."
+            )
+
+
 def check_misspelled_pings(
     metric: metrics.Metric, parser_config: Dict[str, Any]
 ) -> LintGenerator:
@@ -318,6 +340,7 @@ METRIC_CHECKS: Dict[
     "EXPIRATION_DATE_TOO_FAR": (check_expired_date, CheckType.warning),
     "USER_LIFETIME_EXPIRATION": (check_user_lifetime_expiration, CheckType.warning),
     "EXPIRED": (check_expired_metric, CheckType.warning),
+    "DEFAULT_PING": (check_default_in_pings, CheckType.warning),
 }
 
 

--- a/glean_parser/translate.py
+++ b/glean_parser/translate.py
@@ -212,6 +212,9 @@ def translate(
     if format_desc is None:
         raise ValueError(f"Unknown output format '{output_format}'")
 
+    # Output format is relevant for the linters
+    parser_config["output_format"] = output_format
+
     return translate_metrics(
         input_filepaths,
         output_dir,

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -176,6 +176,22 @@ def test_baseline_restriction():
     assert set(["BASELINE_PING"]) == set(v.check_name for v in nits)
 
 
+def test_default_warning():
+    contents = [
+        {"user_data": {"counter": {"type": "counter", "send_in_pings": ["default"]}}}
+    ]
+    contents = [util.add_required(x) for x in contents]
+    all_metrics = parser.parse_objects(contents)
+
+    errs = list(all_metrics)
+    assert len(errs) == 0
+
+    nits = lint.lint_metrics(all_metrics.value, {"output_format": "javascript"})
+
+    assert len(nits) == 1
+    assert set(["DEFAULT_PING"]) == set(v.check_name for v in nits)
+
+
 def test_misspelling_pings():
     contents = [
         {


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
