### PR TITLE
Fix MarkupSafe dependency to previous version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ requirements = [
     "diskcache>=4",
     "iso8601>=0.1.10; python_version<='3.6'",
     "Jinja2>=2.10.1",
+    "MarkupSafe==2.0.1",
     "jsonschema>=3.0.2",
     "PyYAML>=5.3.1",
     "yamllint>=1.18.0",


### PR DESCRIPTION
The new 2.1.0 release of MarkupSafe contains a breaking change (removal
of a deprecated function).
This breaks jinja2 down the line (for its 2.10 version).
The only way to fix that right now is to use the previous release.

Release notes: https://github.com/pallets/markupsafe/blob/73da17aa9cb4139b7192e859e7ca563fa299d907/CHANGES.rst

Note: The minimal jinja2 version we depend on is probably EOL, but
updating that might be a bigger change.

---

Fixes CI failures.