### PR TITLE
Revert "Bug 1761791 - Fix issues with Swift template"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
+- BUGFIX: Revert changes made on v5.1.1. 
+    - The issues addressed by those changes, were non-issues and result of misuse of the APIs.
+
 ## 5.1.1
+
+- BUGFIX: Fix issues with Swift templates ([bug 1749494](https://bugzilla.mozilla.org/show_bug.cgi?id=1749494))
+    - Make metrics and pings all `public`
+    - Make pings `static`
 
 ## 5.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## 5.1.1
 
-- BUGFIX: Fix issues with Swift templates ([bug 1749494](https://bugzilla.mozilla.org/show_bug.cgi?id=1749494))
-    - Make metrics and pings all `public`
-    - Make pings `static`
-
 ## 5.1.0
 
 - Add support for build info generation for JavaScript and Typescript targets ([bug 1749494](https://bugzilla.mozilla.org/show_bug.cgi?id=1749494))

--- a/glean_parser/templates/swift.jinja2
+++ b/glean_parser/templates/swift.jinja2
@@ -7,8 +7,8 @@ Jinja2 template is not. Please file bugs! #}
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-{% macro obj_declaration(obj, suffix='') %}
-public static let {{ obj.name|camelize|variable_name }}{{ suffix }} = {{ obj|type_name }}( // generated from {{ obj.identifier() }}
+{% macro obj_declaration(obj, suffix='', access='') %}
+{{ access }}static let {{ obj.name|camelize|variable_name }}{{ suffix }} = {{ obj|type_name }}( // generated from {{ obj.identifier() }}
         {% for arg_name in extra_args if obj[arg_name] is defined %}
         {{ arg_name|camelize }}: {{ obj[arg_name]|swift }}{{ "," if not loop.last }}
         {% endfor %}
@@ -28,22 +28,12 @@ enum {{ obj.name|Camelize }}{{ suffix }}: Int32, ExtraKeys {
 {% endmacro %}
 
 {% macro struct_decl(obj, name, suffix) %}
-public struct {{ obj.name|Camelize }}{{ suffix }}: EventExtras {
+struct {{ obj.name|Camelize }}{{ suffix }}: EventExtras {
         {% for item, typ in obj|attr(name) %}
         var {{ item|camelize|variable_name }}: {{typ|extra_type_name}}?
         {% endfor %}
 
-        public init(
-            {% for item, typ in obj|attr(name) %}
-            {{ item|camelize|variable_name }}: {{typ|extra_type_name}}?{% if not loop.last %},{% endif %}
-            {% endfor %}
-        ) {
-            {% for item, typ in obj|attr(name) %}
-            self.{{ item|camelize|variable_name }} = {{ item|camelize|variable_name }}
-            {% endfor %}
-        }
-
-        public func toFfiExtra() -> ([Int32], [String]) {
+        func toFfiExtra() -> ([Int32], [String]) {
             var keys = [Int32]()
             var values = [String]()
 
@@ -69,7 +59,7 @@ import {{ glean_namespace }}
 // swiftlint:disable identifier_name
 // swiftlint:disable force_try
 
-public extension {{ namespace }} {
+extension {{ namespace }} {
     {% if build_info %}
     class GleanBuild {
         private init() {
@@ -106,7 +96,7 @@ public extension {{ namespace }} {
         {% endfor %}
         {% endif %}
         /// {{ obj.description|wordwrap() | replace('\n', '\n        /// ') }}
-        public static let {{ obj.name|camelize|variable_name }} = {{obj|type_name}}(
+        let {{ obj.name|camelize|variable_name }} = {{obj|type_name}}(
             name: {{ obj.name|swift }},
             includeClientId: {{obj.include_client_id|swift}},
             sendIfEmpty: {{obj.send_if_empty|swift}},
@@ -133,9 +123,9 @@ public extension {{ namespace }} {
     {% endfor %}
     {% for obj in category.objs.values() %}
         {% if obj.labeled %}
-        {{ obj_declaration(obj, 'Label') | indent }}
+        {{ obj_declaration(obj, 'Label', 'private ') | indent }}
         /// {{ obj.description|wordwrap() | replace('\n', '\n        /// ') }}
-        public static let {{ obj.name|camelize|variable_name }} = try! LabeledMetricType<{{ obj|type_name }}>( // generated from {{ obj.identifier() }}
+        static let {{ obj.name|camelize|variable_name }} = try! LabeledMetricType<{{ obj|type_name }}>( // generated from {{ obj.identifier() }}
             category: {{ obj.category|swift }},
             name: {{ obj.name|swift }},
             sendInPings: {{ obj.send_in_pings|swift }},


### PR DESCRIPTION
Reverts mozilla/glean_parser#469

These changes ended up being unnecessary. They change the way to access pings and break the template when pings have reasons. Other workarounds can be used to access metrics that are module private, such as having a different Metrics.swift file per module.