### PR TITLE
[Bug 1749471] List options accepted by each translation target in glean_parser

### DIFF
--- a/glean_parser/__main__.py
+++ b/glean_parser/__main__.py
@@ -24,7 +24,10 @@ from . import validate_ping
 from . import translation_options
 
 
-@click.command()
+CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+
+
+@click.command(context_settings=CONTEXT_SETTINGS)
 @click.argument(
     "input",
     type=click.Path(exists=False, dir_okay=False, file_okay=True, readable=True),
@@ -46,10 +49,13 @@ from . import translation_options
 @click.option(
     "--option",
     "-s",
-    help="backend-specific option. Must be of the form key=value",
+    help="Backend-specific option. Must be of the form key=value.\
+ Pass 'help' for valid options",
     type=str,
     multiple=True,
     required=False,
+    is_eager=True,
+    callback=translation_options.translate_options,
 )
 @click.option(
     "--allow-reserved",
@@ -75,14 +81,6 @@ from . import translation_options
     type=click.INT,
     required=False,
 )
-@click.option(
-    "--list-options",
-    is_flag=True,
-    default=False,
-    help="List valid options for target language",
-    is_eager=True,
-    callback=translation_options.translate_options,
-)
 def translate(
     input,
     format,
@@ -92,7 +90,6 @@ def translate(
     allow_missing_files,
     require_tags,
     expire_by_version,
-    list_options,
 ):
     """
     Translate metrics.yaml and pings.yaml files to other formats.

--- a/glean_parser/__main__.py
+++ b/glean_parser/__main__.py
@@ -21,6 +21,7 @@ from . import data_review as mod_data_review
 from . import lint
 from . import translate as mod_translate
 from . import validate_ping
+from . import translation_options
 
 
 @click.command()
@@ -73,6 +74,13 @@ from . import validate_ping
     help="Expire metrics by version, with the provided major version.",
     type=click.INT,
     required=False,
+)
+@click.option(
+    "--list-options",
+    is_flag=True,
+    help="List valid options for target language",
+    is_eager=True,
+    callback=translation_options.translate_options,
 )
 def translate(
     input,

--- a/glean_parser/__main__.py
+++ b/glean_parser/__main__.py
@@ -78,6 +78,7 @@ from . import translation_options
 @click.option(
     "--list-options",
     is_flag=True,
+    default=False,
     help="List valid options for target language",
     is_eager=True,
     callback=translation_options.translate_options,
@@ -91,6 +92,7 @@ def translate(
     allow_missing_files,
     require_tags,
     expire_by_version,
+    list_options,
 ):
     """
     Translate metrics.yaml and pings.yaml files to other formats.

--- a/glean_parser/translation_options.py
+++ b/glean_parser/translation_options.py
@@ -20,6 +20,7 @@ Swift:
         it will use that date.
         Other values will throw an error.
         If not set it will use the current date & time.
+
 Kotlin:
 - `namespace`: The package namespace to declare at the top of the
         generated files. Defaults to `GleanMetrics`.

--- a/glean_parser/translation_options.py
+++ b/glean_parser/translation_options.py
@@ -3,7 +3,7 @@ import pydoc
 import click
 
 def translate_options(ctx, param, value):
-    text = """Target language options for Translate function
+        text = """Target language options for Translate function
 
 These are backend specific and optional, provide as key:value
 
@@ -44,6 +44,7 @@ Markdown:
 - `project_title`: The projects title.
 
 (press q to exit)"""
-    pydoc.pager(text)
-    ctx.exit()
-    
+
+        if value:
+                pydoc.pager(text)
+                ctx.exit()

--- a/glean_parser/translation_options.py
+++ b/glean_parser/translation_options.py
@@ -6,8 +6,7 @@ def translate_options(ctx, param, value):
 
 These are backend specific and optional, provide as key:value
 
-Rust:
-- not used
+Rust: no options.
 Swift:
 - namespace: The namespace to generate metrics in
 - glean_namespace: The namespace to import Glean from

--- a/glean_parser/translation_options.py
+++ b/glean_parser/translation_options.py
@@ -7,6 +7,7 @@ def translate_options(ctx, param, value):
 These are backend specific and optional, provide as key:value
 
 Rust: no options.
+
 Swift:
 - namespace: The namespace to generate metrics in
 - glean_namespace: The namespace to import Glean from

--- a/glean_parser/translation_options.py
+++ b/glean_parser/translation_options.py
@@ -27,6 +27,7 @@ Kotlin:
 - `glean_namespace`: The package namespace of the glean library itself.
         This is where glean objects will be imported from in the generated
         code.
+
 JavaScript:
 - `platform`: Which platform are we building for. Options are `webext` and `qt`.
         Default is `webext`.

--- a/glean_parser/translation_options.py
+++ b/glean_parser/translation_options.py
@@ -1,9 +1,8 @@
 import pydoc
 
-import click
 
 def translate_options(ctx, param, value):
-        text = """Target language options for Translate function
+    text = """Target language options for Translate function
 
 These are backend specific and optional, provide as key:value
 
@@ -45,6 +44,6 @@ Markdown:
 
 (press q to exit)"""
 
-        if value:
-                pydoc.pager(text)
-                ctx.exit()
+    if value:
+        pydoc.pager(text)
+        ctx.exit()

--- a/glean_parser/translation_options.py
+++ b/glean_parser/translation_options.py
@@ -9,13 +9,13 @@ These are backend specific and optional, provide as key:value
 Rust: no options.
 
 Swift:
-- namespace: The namespace to generate metrics in
-- glean_namespace: The namespace to import Glean from
-- allow_reserved: When True, this is a Glean-internal build
-- with_buildinfo: If "true" the `GleanBuildInfo` is generated.
+- `namespace`: The namespace to generate metrics in
+- `glean_namespace`: The namespace to import Glean from
+- `allow_reserved`: When True, this is a Glean-internal build
+- `with_buildinfo`: If "true" the `GleanBuildInfo` is generated.
         Otherwise generation of that file is skipped.
         Defaults to "true".
-- build_date: If set to `0` a static unix epoch time will be used.
+- `build_date`: If set to `0` a static unix epoch time will be used.
         If set to a ISO8601 datetime string (e.g. `2022-01-03T17:30:00`)
         it will use that date.
         Other values will throw an error.

--- a/glean_parser/translation_options.py
+++ b/glean_parser/translation_options.py
@@ -39,6 +39,7 @@ JavaScript:
         it will use that date.
         Other values will throw an error.
         If not set it will use the current date & time.
+
 Markdown:
 - `project_title`: The projects title.
 

--- a/glean_parser/translation_options.py
+++ b/glean_parser/translation_options.py
@@ -45,5 +45,7 @@ Markdown:
 (press q to exit)"""
 
     if value:
-        pydoc.pager(text)
-        ctx.exit()
+        if value[0].lower() == "help":
+            pydoc.pager(text)
+            ctx.exit()
+    return value

--- a/glean_parser/translation_options.py
+++ b/glean_parser/translation_options.py
@@ -46,3 +46,4 @@ Markdown:
 (press q to exit)"""
     pydoc.pager(text)
     ctx.exit()
+    

--- a/glean_parser/translation_options.py
+++ b/glean_parser/translation_options.py
@@ -1,0 +1,48 @@
+import pydoc
+
+import click
+
+def translate_options(ctx, param, value):
+    text = """Target language options for Translate function
+
+These are backend specific and optional, provide as key:value
+
+Rust:
+- not used
+Swift:
+- namespace: The namespace to generate metrics in
+- glean_namespace: The namespace to import Glean from
+- allow_reserved: When True, this is a Glean-internal build
+- with_buildinfo: If "true" the `GleanBuildInfo` is generated.
+        Otherwise generation of that file is skipped.
+        Defaults to "true".
+- build_date: If set to `0` a static unix epoch time will be used.
+        If set to a ISO8601 datetime string (e.g. `2022-01-03T17:30:00`)
+        it will use that date.
+        Other values will throw an error.
+        If not set it will use the current date & time.
+Kotlin:
+- `namespace`: The package namespace to declare at the top of the
+        generated files. Defaults to `GleanMetrics`.
+- `glean_namespace`: The package namespace of the glean library itself.
+        This is where glean objects will be imported from in the generated
+        code.
+JavaScript:
+- `platform`: Which platform are we building for. Options are `webext` and `qt`.
+        Default is `webext`.
+- `version`: The version of the Glean.js Qt library being used.
+        This option is mandatory when targeting Qt. Note that the version
+        string must only contain the major and minor version i.e. 0.14.
+- `with_buildinfo`: If "true" a `gleanBuildInfo.(js|ts)` file is generated.
+        Otherwise generation of that file is skipped. Defaults to "false".
+- `build_date`: If set to `0` a static unix epoch time will be used.
+        If set to a ISO8601 datetime string (e.g. `2022-01-03T17:30:00`)
+        it will use that date.
+        Other values will throw an error.
+        If not set it will use the current date & time.
+Markdown:
+- `project_title`: The projects title.
+
+(press q to exit)"""
+    pydoc.pager(text)
+    ctx.exit()

--- a/glean_parser/translation_options.py
+++ b/glean_parser/translation_options.py
@@ -43,7 +43,7 @@ JavaScript:
         If not set it will use the current date & time.
 
 Markdown:
-- `project_title`: The projects title.
+- `project_title`: The project's title.
 
 (press q to exit)"""
 


### PR DESCRIPTION
@badboy ~tests seem to be failing locally for me; but they arent in any files I've changed~ chmod to the rescue

also the way I handled this is that if you use the --list-options flag ala

`glean_parser translate --list-options`

 it will show a paged view of them and then exit. This has the nicety of avoiding having to set a language target (which is normally required), however this is just how it makes sense to me. I could change this implementation to work as

`glean_parser translate -o output_loc/ -f lang --list-options`

it would show you only the options for that language.  Im open to suggestion as to which is more ergonomic.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
