### PR TITLE
[Bug 1765855] Glean parser missing extra args in Rust constructor generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- BUGFIX: Add missing `extra_args` to Rust constructor generation ([bug 1765855](https://bugzilla.mozilla.org/show_bug.cgi?id=1765855))
+
 ## 5.1.2
 
 - BUGFIX: Revert changes made on v5.1.1.

--- a/glean_parser/rust.py
+++ b/glean_parser/rust.py
@@ -197,5 +197,6 @@ def output_rust(
                 parser_version=__version__,
                 categories=categories,
                 extra_args=util.metric_args,
+                common_metric_args=util.common_metric_args,
             )
         )

--- a/glean_parser/templates/rust.jinja2
+++ b/glean_parser/templates/rust.jinja2
@@ -56,7 +56,7 @@ pub static {{ obj.name|snake_case }}: Lazy<Ping> =
 {% else %}
 pub mod {{ category.name|snake_case }} {
     #[allow(unused_imports)] // HistogramType might be unusued, let's avoid warnings
-    use glean::{private::*, traits::ExtraKeys, CommonMetricData, HistogramType, Lifetime};
+    use glean::{private::*, traits::ExtraKeys, CommonMetricData, HistogramType, Lifetime, TimeUnit, MemoryUnit};
     use once_cell::sync::Lazy;
     {% for obj in category.objs.values() %}
 
@@ -75,7 +75,11 @@ pub mod {{ category.name|snake_case }} {
             lifetime: {{ obj.lifetime|rust }},
             disabled: {{ obj.is_disabled()|rust }},
             ..Default::default()
-        }{{ ", " if obj.labeled else ")\n" }}
+        }
+        {%- for arg_name in extra_args if obj[arg_name] is defined and arg_name not in common_metric_args and arg_name != 'allowed_extra_keys' -%}
+            , {{ obj[arg_name]|rust }}
+        {%- endfor -%}
+        {{ ", " if obj.labeled else ")\n" }}
         {%- if obj.labeled -%}
         {%- if obj.labels -%}
         Some({{ obj.labels|rust }})


### PR DESCRIPTION
Adds missing `extra_args` to the constructor parameter list for things with TimeUnits, MemoryUnits, etc...