### PR TITLE
Bug 1769225 - Generate Kotlin/Swift code for the new UniFFI-generated API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - BUGFIX: Add missing `extra_args` to Rust constructor generation ([bug 1765855](https://bugzilla.mozilla.org/show_bug.cgi?id=1765855))
 - Generate Rate, Denominator and Numerator metrics for Kotlin and Swift
+- Explicitly skip Rate, Denominator and Numerator metrics for JavaScript.
+  These will cause a build failure by default, but can be turned into warnings on request.
 
 ## 5.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - BUGFIX: Add missing `extra_args` to Rust constructor generation ([bug 1765855](https://bugzilla.mozilla.org/show_bug.cgi?id=1765855))
+- Generate Rate, Denominator and Numerator metrics for Kotlin and Swift
 
 ## 5.1.2
 

--- a/glean_parser/kotlin.py
+++ b/glean_parser/kotlin.py
@@ -56,7 +56,8 @@ def kotlin_datatypes_filter(value: util.JSONType) -> str:
                     first = False
                 yield ")"
             elif isinstance(value, enum.Enum):
-                yield (value.__class__.__name__ + "." + util.Camelize(value.name))
+                # UniFFI generates SCREAMING_CASE enum variants.
+                yield (value.__class__.__name__ + "." + util.screaming_case(value.name))
             elif isinstance(value, set):
                 yield "setOf("
                 first = True
@@ -338,7 +339,9 @@ def output_kotlin(
                     category_name=category_key,
                     objs=category_val,
                     obj_types=obj_types,
-                    extra_args=util.extra_args,
+                    common_metric_args=util.common_metric_args,
+                    extra_metric_args=util.extra_metric_args,
+                    ping_args=util.ping_args,
                     namespace=namespace,
                     has_labeled_metrics=has_labeled_metrics,
                     glean_namespace=glean_namespace,

--- a/glean_parser/kotlin.py
+++ b/glean_parser/kotlin.py
@@ -31,6 +31,8 @@ def kotlin_datatypes_filter(value: util.JSONType) -> str:
       - dicts to use mapOf
       - sets to use setOf
       - enums to use the like-named Kotlin enum
+      - Rate objects to a CommonMetricData initializer
+        (for external Denominators' Numerators lists)
     """
 
     class KotlinEncoder(json.JSONEncoder):
@@ -66,6 +68,17 @@ def kotlin_datatypes_filter(value: util.JSONType) -> str:
                         yield ", "
                     yield from self.iterencode(subvalue)
                     first = False
+                yield ")"
+            elif isinstance(value, metrics.Rate):
+                yield "CommonMetricData("
+                first = True
+                for arg_name in util.common_metric_args:
+                    if hasattr(value, arg_name):
+                        if not first:
+                            yield ", "
+                        yield f"{util.camelize(arg_name)} = "
+                        yield from self.iterencode(getattr(value, arg_name))
+                        first = False
                 yield ")"
             else:
                 yield from super().iterencode(value)

--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -407,6 +407,12 @@ class Rate(Metric):
         super().__init__(*args, **kwargs)
 
 
+class Denominator(Counter):
+    typename = "denominator"
+    # A denominator is a counter with an additional list of numerators.
+    numerators: List[Rate] = []
+
+
 class Text(Metric):
     typename = "text"
 

--- a/glean_parser/swift.py
+++ b/glean_parser/swift.py
@@ -238,7 +238,8 @@ def output_swift(
             template.render(
                 parser_version=__version__,
                 categories=categories,
-                extra_args=util.metric_args,
+                common_metric_args=util.common_metric_args,
+                extra_metric_args=util.extra_metric_args,
                 namespace=namespace,
                 glean_namespace=glean_namespace,
                 allow_reserved=options.get("allow_reserved", False),

--- a/glean_parser/templates/kotlin.jinja2
+++ b/glean_parser/templates/kotlin.jinja2
@@ -14,19 +14,34 @@ Jinja2 template is not. Please file bugs! #}
 @get:JvmName("{{ obj.name|camelize }}{{ suffix }}")
 {% endif -%}
 {{ access }}val {{ obj.name|camelize }}{{ suffix }}: {{ obj|type_name }}{% if lazy %} by lazy { {%- else %} ={% endif %} // generated from {{ obj.identifier() }}
+{% if obj.type == 'ping' %}
     {{ obj|type_name }}(
-        {% for arg_name in extra_args if obj[arg_name] is defined %}
+        {% for arg_name in ping_args if obj[arg_name] is defined %}
         {{ arg_name|camelize }} = {{ obj[arg_name]|kotlin }}{{ "," if not loop.last }}
         {% endfor %}
     )
+{% else %}
+    {{ obj|type_name }}(
+        CommonMetricData(
+            {% for arg_name in common_metric_args if obj[arg_name] is defined %}
+            {{ arg_name|camelize }} = {{ obj[arg_name]|kotlin }}{{ "," if not loop.last }}
+            {% endfor %}
+        ){%- for arg_name in extra_metric_args if obj[arg_name] is defined -%}
+        , {{ arg_name|camelize }} = {{ obj[arg_name]|kotlin }}
+        {%- endfor -%}
+    )
+{% endif %}
 {% if lazy %}}{% endif %}
 {%- endmacro -%}
 
 {%- macro enum_decl(obj, name, suffix) -%}
 @Suppress("ClassNaming", "EnumNaming")
-enum class {{ obj.name|camelize }}{{ suffix }} {
+enum class {{ obj.name|camelize }}{{ suffix }} : EventExtraKey {
 {% for key in obj|attr(name) %}
-    {{ key|camelize }}{{ "," if not loop.last }}
+    {{ key|camelize }} {
+        override fun keyName(): String = "{{ key }}"
+    }{{ "," if not loop.last }}{{ ";" if loop.last }}
+
 {% endfor %}
 }
 {%- endmacro %}
@@ -38,17 +53,15 @@ data class {{ obj.name|Camelize }}{{ suffix }}(
     val {{ item|camelize }}: {{typ|extra_type_name}}? = null{{ "," if not loop.last }}
 {% endfor %}
 ) : EventExtras {
-    override fun toFfiExtra(): Pair<IntArray, List<String>> {
-        val keys = mutableListOf<Int>()
-        val values = mutableListOf<String>()
+    override fun toExtraRecord(): Map<String, String> {
+        val map = mutableMapOf<String, String>()
 
         {% for item in obj|attr(name) %}
         this.{{ item[0]|camelize }}?.let {
-            keys.add({{loop.index-1}})
-            values.add(it.toString())
+            map.put("{{item[0]}}", it.toString())
         }
         {% endfor %}
-        return Pair(IntArray(keys.size, { keys[it] }), values)
+        return map
     }
 }
 {%- endmacro -%}
@@ -57,6 +70,8 @@ data class {{ obj.name|Camelize }}{{ suffix }}(
 @file:Suppress("PackageNaming", "MaxLineLength")
 package {{ namespace }}
 
+import {{ glean_namespace }}.private.CommonMetricData // ktlint-disable import-ordering no-unused-imports
+import {{ glean_namespace }}.private.EventExtraKey // ktlint-disable import-ordering no-unused-imports
 import {{ glean_namespace }}.private.EventExtras // ktlint-disable import-ordering no-unused-imports
 import {{ glean_namespace }}.private.HistogramType // ktlint-disable import-ordering no-unused-imports
 import {{ glean_namespace }}.private.Lifetime // ktlint-disable import-ordering no-unused-imports

--- a/glean_parser/templates/swift.jinja2
+++ b/glean_parser/templates/swift.jinja2
@@ -9,8 +9,13 @@ Jinja2 template is not. Please file bugs! #}
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 {% macro obj_declaration(obj, suffix='', access='') %}
 {{ access }}static let {{ obj.name|camelize|variable_name }}{{ suffix }} = {{ obj|type_name }}( // generated from {{ obj.identifier() }}
-        {% for arg_name in extra_args if obj[arg_name] is defined %}
-        {{ arg_name|camelize }}: {{ obj[arg_name]|swift }}{{ "," if not loop.last }}
+        CommonMetricData(
+            {% for arg_name in common_metric_args if obj[arg_name] is defined %}
+            {{ arg_name|camelize }}: {{ obj[arg_name]|swift }}{{ "," if not loop.last }}
+            {% endfor %}
+        )
+        {% for arg_name in extra_metric_args if obj[arg_name] is defined %}
+        , {{ obj[arg_name]|swift }}
         {% endfor %}
     )
 {% endmacro %}
@@ -33,18 +38,16 @@ struct {{ obj.name|Camelize }}{{ suffix }}: EventExtras {
         var {{ item|camelize|variable_name }}: {{typ|extra_type_name}}?
         {% endfor %}
 
-        func toFfiExtra() -> ([Int32], [String]) {
-            var keys = [Int32]()
-            var values = [String]()
+        func toExtraRecord() -> [String: String] {
+            var record = [String: String]()
 
             {% for item in obj|attr(name) %}
             if let {{ item[0]|camelize }} = self.{{item[0]|camelize}} {
-                keys.append({{ loop.index - 1 }})
-                values.append(String({{ item[0]|camelize }}))
+                record["{{item[0]}}"] = String({{ item[0]|camelize }})
             }
             {% endfor %}
 
-            return (keys, values)
+            return record
         }
     }
 {% endmacro %}

--- a/glean_parser/translation_options.py
+++ b/glean_parser/translation_options.py
@@ -41,6 +41,8 @@ JavaScript:
         it will use that date.
         Other values will throw an error.
         If not set it will use the current date & time.
+- `fail_rates`: Whether to fail or just warn and skip rate metrics.
+                Defaults to "true".
 
 Markdown:
 - `project_title`: The project's title.

--- a/glean_parser/util.py
+++ b/glean_parser/util.py
@@ -212,6 +212,13 @@ def snake_case(value: str) -> str:
     return value.lower().replace(".", "_").replace("-", "_")
 
 
+def screaming_case(value: str) -> str:
+    """
+    Convert the value to SCREAMING_SNAKE_CASE.
+    """
+    return value.upper().replace(".", "_").replace("-", "_")
+
+
 @functools.lru_cache()
 def get_jinja2_template(
     template_name: str, filters: Iterable[Tuple[str, Callable]] = ()
@@ -233,6 +240,7 @@ def get_jinja2_template(
 
     env.filters["camelize"] = camelize
     env.filters["Camelize"] = Camelize
+    env.filters["scream"] = screaming_case
     for filter_name, filter_func in filters:
         env.filters[filter_name] = filter_func
 
@@ -541,9 +549,9 @@ metric_args = common_metric_args + extra_metric_args
 
 # Names of ping parameters to pass to constructors.
 ping_args = [
+    "name",
     "include_client_id",
     "send_if_empty",
-    "name",
     "reason_codes",
 ]
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,7 +3,6 @@ coverage==6.3.1; python_version > '3.6'
 coverage==6.2; python_version <= '3.6'
 flake8==4.0.1
 flake8-bugbear==22.4.25
-m2r==0.2.1
 mypy==0.942
 pip
 pytest-runner==5.3.1
@@ -14,6 +13,5 @@ twine==3.8.0
 types-Jinja2==2.11.9
 types-pkg_resources==0.1.3
 types-PyYAML==6.0.6
-watchdog==2.1.7
 wheel
 yamllint==1.26.3

--- a/tests/test_javascript.py
+++ b/tests/test_javascript.py
@@ -58,7 +58,7 @@ def test_parser_js_all_metrics(tmpdir):
         ROOT / "data" / "all_metrics.yaml",
         "javascript",
         tmpdir,
-        None,
+        {"fail_rates": "false"},  # Don't fail on rate metrics.
         {"allow_reserved": True},
     )
 

--- a/tests/test_kotlin.py
+++ b/tests/test_kotlin.py
@@ -147,7 +147,7 @@ def test_kotlin_generator():
         kdf(DictWrapper([("key", "value"), ("key2", "value2")]))
         == r'mapOf("key" to "value", "key2" to "value2")'
     )
-    assert kdf(metrics.Lifetime.ping) == "Lifetime.Ping"
+    assert kdf(metrics.Lifetime.ping) == "Lifetime.PING"
 
 
 def test_metric_type_name():
@@ -377,7 +377,9 @@ def test_event_extra_keys_in_correct_order(tmpdir):
     with (tmpdir / "Event.kt").open("r", encoding="utf-8") as fd:
         content = fd.read()
         content = " ".join(content.split())
-        assert "exampleKeys { alice, bob, charlie }" in content
+        assert "EventExtraKey { alice {" in content
+        assert "bob {" in content
+        assert "charlie {" in content
         assert 'allowedExtraKeys = listOf("alice", "bob", "charlie")' in content
 
 
@@ -404,7 +406,7 @@ def test_arguments_are_generated_in_deterministic_order(tmpdir):
     with (tmpdir / "Event.kt").open("r", encoding="utf-8") as fd:
         content = fd.read()
         content = " ".join(content.split())
-        expected = 'EventMetricType<exampleKeys, NoExtras> by lazy { // generated from event.example EventMetricType<exampleKeys, NoExtras>( category = "event", name = "example", sendInPings = listOf("events"), lifetime = Lifetime.Ping, disabled = false, allowedExtraKeys = listOf("alice", "bob", "charlie") ) } }'  # noqa
+        expected = 'EventMetricType<exampleKeys, NoExtras> by lazy { // generated from event.example EventMetricType<exampleKeys, NoExtras>( CommonMetricData( category = "event", name = "example", sendInPings = listOf("events"), lifetime = Lifetime.PING, disabled = false ), allowedExtraKeys = listOf("alice", "bob", "charlie")) } }'  # noqa
         assert expected in content
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -18,9 +18,11 @@ def test_metrics_match_schema():
     """
     schema, validator = parser._get_schema(parser.METRICS_ID)
 
+    # "ERROR": The unset typename of `Metric`
+    # "denominator": The special wrapper type around counter for external denominators
     assert set(metrics.Metric.metric_types.keys()) == set(
         schema["definitions"]["metric"]["properties"]["type"]["enum"]
-    ) | set(["ERROR"])
+    ) | set(["ERROR", "denominator"])
 
 
 def test_enforcement():

--- a/tests/test_swift.py
+++ b/tests/test_swift.py
@@ -245,7 +245,7 @@ def test_order_of_fields(tmpdir):
             # Collect only the fields
             field = line.strip().split(":")[0]
             first_metric_fields.append(field)
-        elif re.search("MetricType", line):
+        elif re.search("CommonMetricData", line):
             found_metric = True
 
     expected_fields = ["category", "name", "sendInPings", "lifetime", "disabled"]
@@ -309,7 +309,7 @@ def test_event_extra_keys_in_correct_order(tmpdir):
             "enum ExampleKeys: Int32, ExtraKeys "
             "{ case alice = 0 case bob = 1 case charlie = 2" in content
         )
-        assert 'allowedExtraKeys: ["alice", "bob", "charlie"]' in content
+        assert ', ["alice", "bob", "charlie"]' in content
 
 
 def test_event_extra_keys_with_types(tmpdir):
@@ -336,4 +336,4 @@ def test_event_extra_keys_with_types(tmpdir):
             "{ var enabled: Bool? var preference: String? "
             "var swapped: Int32?" in content
         )
-        assert 'allowedExtraKeys: ["enabled", "preference", "swapped"]' in content
+        assert ', ["enabled", "preference", "swapped"]' in content

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -209,12 +209,6 @@ def test_getting_line_number():
 
 def test_rates(tmpdir):
     def external_translator(all_objects, output_dir, options):
-        assert (
-            all_objects["testing.rates"]["has_external_denominator"].type == "rate"
-        )  # Hasn't yet been transformed
-
-        translate.transform_metrics(all_objects)
-
         category = all_objects["testing.rates"]
         assert category["has_internal_denominator"].type == "rate"
         assert category["has_external_denominator"].type == "numerator"
@@ -228,7 +222,11 @@ def test_rates(tmpdir):
             == "testing.rates.the_denominator"
         )
         assert category["the_denominator"].type == "denominator"
-        assert category["the_denominator"].numerators == [
+
+        numerators = [
+            f"{m.category}.{m.name}" for m in category["the_denominator"].numerators
+        ]
+        assert numerators == [
             "testing.rates.has_external_denominator",
             "testing.rates.also_has_external_denominator",
         ]


### PR DESCRIPTION
The new UniFFI-powered API changes some things:
Metric constructors now always take a `CommonMetricData` object as the first argument.
Additional type-specific arguments come after that.

This also includes the fix for [bug 1720494](https://bugzilla.mozilla.org/show_bug.cgi?id=1720494).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
