### PR TITLE
Remove unused dependencies

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,7 +3,6 @@ coverage==6.3.1; python_version > '3.6'
 coverage==6.2; python_version <= '3.6'
 flake8==4.0.1
 flake8-bugbear==22.4.25
-m2r==0.2.1
 mypy==0.950
 pip
 pytest-runner==5.3.1
@@ -14,6 +13,5 @@ twine==3.8.0
 types-Jinja2==2.11.9
 types-pkg_resources==0.1.3
 types-PyYAML==6.0.6
-watchdog==2.1.7
 wheel
 yamllint==1.26.3


### PR DESCRIPTION
m2r's last use was removed in 9ffcfdac4e2e003875fa0d863ef66bd16844bb0e.
watchdog was never used, it was brought in by the cookiecutter template.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
