### PR TITLE
Relax version requirement for MarkupSafe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ requirements = [
     "diskcache>=4",
     "iso8601>=0.1.10; python_version<='3.6'",
     "Jinja2>=2.10.1",
-    "MarkupSafe==2.0.1",
+    "MarkupSafe>=1.1.1,<=2.0.1",
     "jsonschema>=3.0.2",
     "PyYAML>=5.3.1",
     "yamllint>=1.18.0",


### PR DESCRIPTION
Upgraded to 2.0.1 in 644c8493170eb7fb44501a629ace5ffe3fbf1c8a,
but m-c requires 1.1.1.
That works for us so we can just allow it.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
