### PR TITLE
bug 1767027 - [data-review] Add rows to data review metric table to describe extra keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [data-review] Include extra keys' names and descriptions in data review template ([bug 1767027](https://bugzilla.mozilla.org/show_bug.cgi?id=1767027))
+
 ## 6.0.1
 
 - Relax version requirement for MarkupSafe.

--- a/glean_parser/data_review.py
+++ b/glean_parser/data_review.py
@@ -59,6 +59,13 @@ def generate(
             last_bug = metric.bugs[-1]
             metrics_table += f"`{category_name}.{metric_name}` | "
             metrics_table += f"{one_line_desc} | {sensitivity} | {last_bug}\n"
+            if metric.type == "event" and len(metric.allowed_extra_keys):
+                for extra_name, extra_detail in metric.extra_keys.items():
+                    extra_one_line_desc = extra_detail["description"].replace("\n", " ")
+                    metrics_table += f"`{category_name}.{metric_name}#{extra_name}` | "
+                    metrics_table += (
+                        f"{extra_one_line_desc} | {sensitivity} | {last_bug}\n"
+                    )
 
             durations.add(metric.expires)
 


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not (does not, because data-review)
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly

Tested manually on events with and without extra keys.
Uses data sensitivity and bug link from the parent event metric.