### PR TITLE
Rust: Use re-exported `Lazy`

### DIFF
--- a/glean_parser/templates/rust.jinja2
+++ b/glean_parser/templates/rust.jinja2
@@ -43,21 +43,17 @@ impl ExtraKeys for {{ obj.name|Camelize }}{{ suffix }} {
 {% endmacro %}
 {% for category in categories %}
 {% if category.contains_pings %}
-use glean::private::Ping;
-use once_cell::sync::Lazy;
 {% for obj in category.objs.values() %}
-
 #[allow(non_upper_case_globals, dead_code)]
 /// {{ obj.description|wordwrap() | replace('\n', '\n/// ') }}
 #[rustfmt::skip]
-pub static {{ obj.name|snake_case }}: Lazy<Ping> =
-    Lazy::new(|| Ping::new("{{ obj.name }}", {{ obj.include_client_id|rust }}, {{ obj.send_if_empty|rust }}, {{ obj.reason_codes|rust }}));
+pub static {{ obj.name|snake_case }}: ::glean::private::__export::Lazy<::glean::private::PingType> =
+    ::glean::private::__export::Lazy::new(|| Ping::new("{{ obj.name }}", {{ obj.include_client_id|rust }}, {{ obj.send_if_empty|rust }}, {{ obj.reason_codes|rust }}));
 {% endfor %}
 {% else %}
 pub mod {{ category.name|snake_case }} {
     #[allow(unused_imports)] // HistogramType might be unusued, let's avoid warnings
     use glean::{private::*, traits::ExtraKeys, CommonMetricData, HistogramType, Lifetime, TimeUnit, MemoryUnit};
-    use once_cell::sync::Lazy;
     {% for obj in category.objs.values() %}
 
     {% if obj|attr("_generate_enums") %}
@@ -67,7 +63,7 @@ pub mod {{ category.name|snake_case }} {
     /// generated from {{ category.name }}.{{ obj.name }}
     ///
     /// {{ obj.description|wordwrap() | replace('\n', '\n    /// ') }}
-    pub static {{ obj.name|snake_case }}: Lazy<{{ obj|type_name }}> = Lazy::new(|| {
+    pub static {{ obj.name|snake_case }}: ::glean::private::__export::Lazy<{{ obj|type_name }}> = ::glean::private::__export::Lazy::new(|| {
         {{ obj|ctor }}(CommonMetricData {
             category: {{ obj.category|rust }},
             name: {{ obj.name|rust }},
@@ -100,10 +96,9 @@ pub(crate) mod __glean_metric_maps {
 
     use super::{id_for_extra_key, extra_keys_len};
     use crate::private::*;
-    use once_cell::sync::Lazy;
 
 {% for typ, metrics in metric_by_type.items() %}
-    pub static {{typ.0}}: Lazy<HashMap<MetricId, &Lazy<{{typ.1}}>>> = Lazy::new(|| {
+    pub static {{typ.0}}: ::glean::private::__export::Lazy<HashMap<MetricId, &Lazy<{{typ.1}}>>> = ::glean::private::__export::Lazy::new(|| {
         let mut map = HashMap::with_capacity({{metrics|length}});
         {% for metric in metrics %}
         map.insert({{metric.0}}.into(), &super::{{metric.1}});
@@ -269,13 +264,13 @@ pub(crate) mod __glean_metric_maps {
 
         pub(crate) const MIN_LABELED_SUBMETRIC_ID: u32 = {{min_submetric_id}};
         pub(crate) static NEXT_LABELED_SUBMETRIC_ID: AtomicU32 = AtomicU32::new(MIN_LABELED_SUBMETRIC_ID);
-        pub(crate) static LABELED_METRICS_TO_IDS: Lazy<RwLock<HashMap<(u32, String), u32>>> = Lazy::new(||
+        pub(crate) static LABELED_METRICS_TO_IDS: ::glean::private::__export::Lazy<RwLock<HashMap<(u32, String), u32>>> = ::glean::private::__export::Lazy::new(||
             RwLock::new(HashMap::new())
         );
 
 {% for typ, metrics in metric_by_type.items() %}
 {% if typ.0 in ('BOOLEAN_MAP', 'COUNTER_MAP', 'STRING_MAP') %}
-        pub static {{typ.0}}: Lazy<RwLock<HashMap<MetricId, Labeled{{typ.1}}>>> = Lazy::new(||
+        pub static {{typ.0}}: ::glean::private::__export::Lazy<RwLock<HashMap<MetricId, Labeled{{typ.1}}>>> = ::glean::private::__export::Lazy::new(||
             RwLock::new(HashMap::new())
         );
 {% endif %}

--- a/tests/test_rust.py
+++ b/tests/test_rust.py
@@ -86,8 +86,16 @@ def test_ping_parser(tmpdir):
         content = fd.read()
 
         assert "This is a custom ping" in content
-        assert "custom_ping: Lazy<Ping> =\n    Lazy::new" in content
-        assert "custom_ping_might_be_empty: Lazy<Ping> =\n    Lazy::new" in content
+        assert (
+            "custom_ping: ::glean::private::__export::Lazy<::glean::private::"
+            + "PingType> =\n    ::glean::private::__export::Lazy::new"
+            in content
+        )
+        assert (
+            "custom_ping_might_be_empty: ::glean::private::__export::Lazy<"
+            + "::glean::private::PingType> =\n    ::glean::private::__export::Lazy::new"
+            in content
+        )
 
     # TODO we need a cargo.toml to run `cargo fmt` and `cargo clippy`
     # and I'm not quite sure how to do that in a non-Rust project for


### PR DESCRIPTION
That way consumers don't need to also depend on the right version of
`once_cell`

See https://github.com/mozilla/glean/pull/2085

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
