### PR TITLE
Bug 1741668 - Mark test_validate_ping as requiring a web connection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ fmt: ## autoformat files
 	python3 -m black glean_parser tests setup.py
 
 test: ## run tests quickly with the default Python
-	py.test
+	py.test --run-web-tests
 
 coverage: ## check code coverage quickly with the default Python
 	coverage run --source glean_parser -m pytest

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    web_dependency: mark a test that requires a web connection.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--run-web-tests",
+        action="store_true",
+        default=False,
+        help="Run tests that require a web connection",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--run-web-tests"):
+        return
+    skip_web = pytest.mark.skip(reason="Need --run-web-tests option to run")
+    for item in items:
+        if "web_dependency" in item.keywords:
+            item.add_marker(skip_web)

--- a/tests/test_validate_ping.py
+++ b/tests/test_validate_ping.py
@@ -5,11 +5,13 @@
 
 import io
 import json
+import pytest
 from pytest import raises
 
 from glean_parser import validate_ping
 
 
+@pytest.mark.web_dependency
 def test_validate_ping():
     content = {
         "experiments": {


### PR DESCRIPTION
CI will by default run it, but a simple `pytest` will skip it.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
