### PR TITLE
Pick setuptools-scm <7 for Python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,11 @@ requirements = [
     "yamllint>=1.18.0",
 ]
 
-setup_requirements = ["pytest-runner", "setuptools-scm"]
+setup_requirements = [
+    "pytest-runner",
+    "setuptools-scm<7; python_version<='3.6'",
+    "setuptools-scm>=7; python_version>'3.6'",
+]
 
 test_requirements = [
     "pytest",


### PR DESCRIPTION
Later versions dropped Python 3.6 support.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
