### PR TITLE
BUGFIX: Add NoExtraKeys import to rust template

### DIFF
--- a/glean_parser/templates/rust.jinja2
+++ b/glean_parser/templates/rust.jinja2
@@ -53,7 +53,7 @@ pub static {{ obj.name|snake_case }}: ::glean::private::__export::Lazy<::glean::
 {% else %}
 pub mod {{ category.name|snake_case }} {
     #[allow(unused_imports)] // HistogramType might be unusued, let's avoid warnings
-    use glean::{private::*, traits::ExtraKeys, CommonMetricData, HistogramType, Lifetime, TimeUnit, MemoryUnit};
+    use glean::{private::*, traits::ExtraKeys, traits::NoExtraKeys, CommonMetricData, HistogramType, Lifetime, TimeUnit, MemoryUnit};
     {% for obj in category.objs.values() %}
 
     {% if obj|attr("_generate_enums") %}


### PR DESCRIPTION
Been getting the following error:

```
171 |     pub static purchase_ack_failed: ::glean::private::__export::Lazy<EventMetric<NoExtraKeys>> = ::glean::private::__export::Lazy::new(|| {
    |                                                                                  ^^^^^^^^^^^
    |
   ::: /home/brizental/.cargo/registry/src/github.com-1ecc6299db9ec823/glean-core-51.1.0/src/traits/event.rs:22:1
    |
22  | pub trait ExtraKeys {
    | ------------------- similarly named trait `ExtraKeys` defined here
    |
help: a trait with a similar name exists
    |
171 |     pub static purchase_ack_failed: ::glean::private::__export::Lazy<EventMetric<ExtraKeys>> = ::glean::private::__export::Lazy::new(|| {
    |                                                                                  ~~~~~~~~~
help: consider importing this enum
    |
30  |     use glean::traits::NoExtraKeys;
```

This fixes it.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
