### PR TITLE
Make tag and no_lint order deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - [data-review] Use a template to generate the Data Review Request template ([bug 1772605](https://bugzilla.mozilla.org/show_bug.cgi?id=1772605))
+- Make tag and no\_lint order deterministic ([#518](https://github.com/mozilla/glean_parser/pull/518))
 
 ## 6.1.2
 

--- a/glean_parser/parser.py
+++ b/glean_parser/parser.py
@@ -244,9 +244,9 @@ def _instantiate_metrics(
                     metric_obj = None
 
             if metric_obj is not None:
-                metric_obj.no_lint = list(set(metric_obj.no_lint + global_no_lint))
+                metric_obj.no_lint = sorted(set(metric_obj.no_lint + global_no_lint))
                 if len(global_tags):
-                    metric_obj.metadata["tags"] = list(
+                    metric_obj.metadata["tags"] = sorted(
                         set(metric_obj.metadata.get("tags", []) + global_tags)
                     )
 
@@ -311,7 +311,7 @@ def _instantiate_pings(
             continue
 
         if ping_obj is not None:
-            ping_obj.no_lint = list(set(ping_obj.no_lint + global_no_lint))
+            ping_obj.no_lint = sorted(set(ping_obj.no_lint + global_no_lint))
 
         if isinstance(filepath, Path) and ping_obj.defined_in is not None:
             ping_obj.defined_in["filepath"] = str(filepath)
@@ -363,7 +363,7 @@ def _instantiate_tags(
             continue
 
         if tag_obj is not None:
-            tag_obj.no_lint = list(set(tag_obj.no_lint + global_no_lint))
+            tag_obj.no_lint = sorted(set(tag_obj.no_lint + global_no_lint))
 
             if isinstance(filepath, Path) and tag_obj.defined_in is not None:
                 tag_obj.defined_in["filepath"] = str(filepath)

--- a/tests/util.py
+++ b/tests/util.py
@@ -17,7 +17,7 @@ def add_required(chunk):
     }
 
     for category_key, category_val in chunk.items():
-        if category_key == "$schema":
+        if category_key in ("$schema", "$tags", "no_lint"):
             continue
         for metric in category_val.values():
             for default_name, default_val in DEFAULTS.items():


### PR DESCRIPTION
when list order is not deterministic, probe scraper may think a metric definition changed, and fail to merge equivalent entries in metric history.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
