### PR TITLE
Bug 1793777 - Support rate metric for Glean.js/JavaScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add support for Rate, Denominator and Numerator metrics for JavaScript. ([bug 1793777](https://bugzilla.mozilla.org/show_bug.cgi?id=1793777))
+
 ## 6.2.0
 
 - [data-review] Use a template to generate the Data Review Request template ([bug 1772605](https://bugzilla.mozilla.org/show_bug.cgi?id=1772605))

--- a/glean_parser/javascript.py
+++ b/glean_parser/javascript.py
@@ -148,16 +148,11 @@ def output(
                         it will use that date.
                         Other values will throw an error.
                         If not set it will use the current date & time.
-        - `fail_rates`: When `true` it fails when encountering rate metrics.
-                        When `false` it will warn and skip rate metrics.
-                        Defaults to "true".
     """
 
     if options is None:
         options = {}
 
-    fail_rates = options.get("fail_rates", "true").lower() == "true"
-    fail_rate_level = "ERROR" if fail_rates else "WARN"
     platform = options.get("platform", "webext")
     accepted_platforms = ["qt", "webext", "node"]
     if platform not in accepted_platforms:
@@ -185,26 +180,6 @@ def output(
         extension = ".js" if lang == "javascript" else ".ts"
         filename = util.camelize(category_key) + extension
         filepath = output_dir / filename
-
-        # FIXME: Add support for rate (and numerator & denominator) in Glean.js
-        todelete = []
-        for key, metric in category_val.items():
-            if isinstance(metric, metrics.Rate):
-                print(
-                    f"{fail_rate_level}: Rate metric not supported. Metric: {category_key}.{metric.name}",  # noqa: E501
-                    file=sys.stderr,
-                )
-                todelete.append(key)
-            if isinstance(metric, metrics.Denominator):
-                print(
-                    f"{fail_rate_level}: Rate metric not supported. Dropping numerators. Metric: {category_key}.{metric.name}",  # noqa: E501
-                    file=sys.stderr,
-                )
-                del metric.numerators
-
-        if fail_rates and todelete:
-            print("Failed due to previous errors.", file=sys.stderr)
-            raise ValueError("Unsupported metric type encountered.")
 
         types = set(
             [

--- a/glean_parser/javascript.py
+++ b/glean_parser/javascript.py
@@ -10,7 +10,6 @@ Outputter to generate Javascript code for metrics.
 
 import enum
 import json
-import sys
 from pathlib import Path
 from typing import Any, Dict, Optional, Callable
 

--- a/glean_parser/translation_options.py
+++ b/glean_parser/translation_options.py
@@ -41,9 +41,6 @@ JavaScript:
         it will use that date.
         Other values will throw an error.
         If not set it will use the current date & time.
-- `fail_rates`: When `true` it fails when encountering rate metrics.
-                When `false` it will warn and skip rate metrics.
-                Defaults to "true".
 
 Markdown:
 - `project_title`: The project's title.

--- a/tests/test_javascript.py
+++ b/tests/test_javascript.py
@@ -58,7 +58,7 @@ def test_parser_js_all_metrics(tmpdir):
         ROOT / "data" / "all_metrics.yaml",
         "javascript",
         tmpdir,
-        {"fail_rates": "false"},  # Don't fail on rate metrics.
+        None,
         {"allow_reserved": True},
     )
 


### PR DESCRIPTION
When trying to upgrade the version of `glean_parser` that Glean.js is using, we were seeing errors that the `rate` metric was not supported. The `rate` metric already exists in Glean.js and works in previous versions, but the newer versions of `glean_parser` did not support the `rate` metric for JS.

This PR
- Updates the javascript parser to correctly serialize the `rate` metric
- Removes the code that was throwing `rate` errors and skipping `rate` metrics for Glean.js (https://github.com/mozilla/glean_parser/commit/19a14a7604aaae9e8cfca83daed9e021ce10ec70)

### Testing
Testing Glean.js with different versions of `glean_parser`
- 5.1.0 (current version used by glean.js) - rate works fine
- 6.2.0 (latest version) - tests fail, error saying `rate` metric is unsupported
- this branch - rate works fine, no errors again

I tested this by
- pushing this code up to this branch
- creating a `venv` locally and using pip to install `glean_parser` directly from this branch (`python3 -m pip install git+ssh://git@github.com/rosahbruno/glean_parser@1793777-JS-rate-metric#egg=glean_parser`)

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
