### PR TITLE
Bug 1799486 - Restrict time unit for `datetime` to disallow `nanosecond`

### DIFF
--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -299,6 +299,12 @@ class CustomDistribution(Metric):
 class Datetime(TimeBase):
     typename = "datetime"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if self.time_unit == TimeUnit.nanosecond:
+            raise ValueError("`time_unit: nanosecond` not allowed for type `datetime`")
+
 
 class Event(Metric):
     typename = "event"

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -203,3 +203,20 @@ def test_jwe_is_rejected():
             extra_keys={"glean.internal": {"description": "foo"}},
             _config={"allow_reserved": True},
         )
+
+
+def test_datetime_nanoseconds_disallowed():
+    with pytest.raises(ValueError) as e:
+        metrics.Datetime(
+            type="datetime",
+            category="category",
+            name="metric",
+            bugs=["http://bugzilla.mozilla.com/12345"],
+            notification_emails=["nobody@example.com"],
+            description="description...",
+            expires="never",
+            time_unit="nanosecond",
+            _config={"allow_reserved": True},
+        )
+
+    assert "time_unit" in str(e.value)


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
