### PR TITLE
Rust: Wrap labels in Cow

### DIFF
--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -364,6 +364,30 @@ class Jwe(Metric):
         )
 
 
+class CowString(str):
+    """
+    Wrapper class for strings that should be represented
+    as a `Cow<'static, str>` in Rust,
+    or `String` in other target languages.
+
+    This wraps `str`, so unless `CowString` is specifically
+    handled it acts (and serializes)
+    as a string.
+    """
+
+    def __init__(self, val: str):
+        self.inner: str = val
+
+    def __eq__(self, other):
+        return self.inner == other.inner
+
+    def __hash__(self):
+        return self.inner.__hash__()
+
+    def __lt__(self, other):
+        return self.inner.__lt__(other.inner)
+
+
 class Labeled(Metric):
     labeled = True
 
@@ -371,7 +395,7 @@ class Labeled(Metric):
         labels = kwargs.pop("labels", None)
         if labels is not None:
             self.ordered_labels = labels
-            self.labels = set(labels)
+            self.labels = set([CowString(label) for label in labels])
         else:
             self.ordered_labels = None
             self.labels = None

--- a/glean_parser/rust.py
+++ b/glean_parser/rust.py
@@ -61,6 +61,9 @@ def rust_datatypes_filter(value):
                 yield "]"
             elif value is None:
                 yield "None"
+            # `CowStr` is a `str`, so needs to be before next case
+            elif isinstance(value, metrics.CowString):
+                yield f'::std::borrow::Cow::from("{value.inner}")'
             elif isinstance(value, str):
                 yield f'"{value}".into()'
             elif isinstance(value, metrics.Rate):


### PR DESCRIPTION
Based on #533 and work for https://github.com/mozilla/glean/pull/2272.
It would be nice to have that land when we land 2272 as well, but it's not necessary. The old way still works and FOG does its own thing anyway (though it can do it better with this).

This allows us to generate non-generic code to turn strings into the correct type.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
