### PR TITLE
Bug 1811857 - Fully remove support for the old events API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - BUGFIX: Remove internal-only fields from serialized metrics data ([#550](https://github.com/mozilla/glean_parser/pull/550))
 - FEATURE: New subcommand: `dump` to dump the metrics data as JSON ([#550](https://github.com/mozilla/glean_parser/pull/550))
 - BUGFIX: Kotlin: Generate enums with the right generic bound for ping reason codes ([#551](https://github.com/mozilla/glean_parser/pull/551)).
+- **BREAKING CHANGE:** Fully remove support for the old events API ([#549](https://github.com/mozilla/glean_parser/pull/549))
+  Adds a new lint `OLD_EVENT_API` to warn about missing `type` attributes on event extra keys.
+  Note that the Glean SDK already dropped support for the old events API.
 
 ## 6.4.0
 

--- a/glean_parser/kotlin.py
+++ b/glean_parser/kotlin.py
@@ -92,31 +92,20 @@ def type_name(obj: Union[metrics.Metric, pings.Ping]) -> str:
     """
     generate_enums = getattr(obj, "_generate_enums", [])
     if len(generate_enums):
-        template_args = []
+        generic = None
         for member, suffix in generate_enums:
             if len(getattr(obj, member)):
-                # Ugly hack to support the newer event extras API
-                # along the deprecated API.
-                # We need to specify both generic parameters,
-                # but only for event metrics.
-                # Plus `eventExtraKeys` use camelCase (lower),
-                # whereas proper class names should use CamelCase.
-                if suffix == "Extra":
-                    if isinstance(obj, metrics.Event):
-                        template_args.append("NoExtraKeys")
-                    template_args.append(util.Camelize(obj.name) + suffix)
+                if isinstance(obj, metrics.Event):
+                    generic = util.Camelize(obj.name) + suffix
                 else:
-                    template_args.append(util.camelize(obj.name) + suffix)
-                    if isinstance(obj, metrics.Event):
-                        template_args.append("NoExtras")
+                    generic = util.camelize(obj.name) + suffix
             else:
-                if suffix == "Keys":
-                    template_args.append("NoExtraKeys")
-                    template_args.append("NoExtras")
+                if isinstance(obj, metrics.Event):
+                    generic = "NoExtras"
                 else:
-                    template_args.append("No" + suffix)
+                    generic = "No" + suffix
 
-        return "{}<{}>".format(class_name(obj.type), ", ".join(template_args))
+        return "{}<{}>".format(class_name(obj.type), generic)
 
     return class_name(obj.type)
 

--- a/glean_parser/lint.py
+++ b/glean_parser/lint.py
@@ -273,6 +273,21 @@ def check_expired_metric(
         yield ("Metric has expired. Please consider removing it.")
 
 
+def check_old_event_api(
+    metric: metrics.Metric, parser_config: Dict[str, Any]
+) -> LintGenerator:
+    # Glean v52.0.0 removed the old events API.
+    # The metrics-2-0-0 schema still supports it.
+    # We want to warn about it.
+    # This can go when we introduce 3-0-0
+
+    if not isinstance(metric, metrics.Event):
+        return
+
+    if not all("type" in x for x in metric.extra_keys.values()):
+        yield ("The old event API is gone. Extra keys require a type.")
+
+
 def check_redundant_ping(
     pings: pings.Ping, parser_config: Dict[str, Any]
 ) -> LintGenerator:
@@ -318,6 +333,7 @@ METRIC_CHECKS: Dict[
     "EXPIRATION_DATE_TOO_FAR": (check_expired_date, CheckType.warning),
     "USER_LIFETIME_EXPIRATION": (check_user_lifetime_expiration, CheckType.warning),
     "EXPIRED": (check_expired_metric, CheckType.warning),
+    "OLD_EVENT_API": (check_old_event_api, CheckType.warning),
 }
 
 

--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -307,14 +307,11 @@ class Event(Metric):
 
     default_store_names = ["events"]
 
-    _generate_enums = [("allowed_extra_keys", "Keys")]
-
     def __init__(self, *args, **kwargs):
         self.extra_keys = kwargs.pop("extra_keys", {})
         self.validate_extra_keys(self.extra_keys, kwargs.get("_config", {}))
-        if self.has_extra_types:
-            self._generate_enums = [("allowed_extra_keys_with_types", "Extra")]
         super().__init__(*args, **kwargs)
+        self._generate_enums = [("allowed_extra_keys_with_types", "Extra")]
 
     @property
     def allowed_extra_keys(self):
@@ -328,14 +325,6 @@ class Event(Metric):
             [(k, v.get("type", "string")) for (k, v) in self.extra_keys.items()],
             key=lambda x: x[0],
         )
-
-    @property
-    def has_extra_types(self):
-        """
-        If any extra key has a `type` specified,
-        we generate the new struct/object-based API.
-        """
-        return any("type" in x for x in self.extra_keys.values())
 
     @staticmethod
     def validate_extra_keys(extra_keys: Dict[str, str], config: Dict[str, Any]) -> None:

--- a/glean_parser/parser.py
+++ b/glean_parser/parser.py
@@ -150,22 +150,6 @@ def _get_schema_for_content(
     return _get_schema(schema_url, filepath)
 
 
-def get_parameter_doc(key: str) -> str:
-    """
-    Returns documentation about a specific metric parameter.
-    """
-    schema, _ = _get_schema(METRICS_ID)
-    return schema["definitions"]["metric"]["properties"][key]["description"]
-
-
-def get_ping_parameter_doc(key: str) -> str:
-    """
-    Returns documentation about a specific ping parameter.
-    """
-    schema, _ = _get_schema(PINGS_ID)
-    return schema["additionalProperties"]["properties"][key]["description"]
-
-
 def validate(
     content: Dict[str, util.JSONType], filepath: Union[str, Path] = "<input>"
 ) -> Generator[str, None, None]:

--- a/glean_parser/rust.py
+++ b/glean_parser/rust.py
@@ -103,16 +103,18 @@ def type_name(obj):
         return "LabeledMetric<{}>".format(class_name(obj.type))
     generate_enums = getattr(obj, "_generate_enums", [])  # Extra Keys? Reasons?
     if len(generate_enums):
+        generic = None
         for name, suffix in generate_enums:
-            if not len(getattr(obj, name)) and suffix == "Keys":
-                return class_name(obj.type) + "<NoExtraKeys>"
+            if len(getattr(obj, name)):
+                generic = util.Camelize(obj.name) + suffix
             else:
-                # we always use the `extra` suffix,
-                # because we only expose the new event API
-                suffix = "Extra"
-                return "{}<{}>".format(
-                    class_name(obj.type), util.Camelize(obj.name) + suffix
-                )
+                if isinstance(obj, metrics.Event):
+                    generic = "NoExtra"
+                else:
+                    generic = "No" + suffix
+
+        return "{}<{}>".format(class_name(obj.type), generic)
+
     return class_name(obj.type)
 
 

--- a/glean_parser/swift.py
+++ b/glean_parser/swift.py
@@ -94,29 +94,17 @@ def type_name(obj: Union[metrics.Metric, pings.Ping]) -> str:
     """
     generate_enums = getattr(obj, "_generate_enums", [])
     if len(generate_enums):
-        template_args = []
+        generic = None
         for member, suffix in generate_enums:
             if len(getattr(obj, member)):
-                # Ugly hack to support the newer event extras API
-                # along the deprecated API.
-                # We need to specify both generic parameters,
-                # but only for event metrics.
-                if suffix == "Extra":
-                    if isinstance(obj, metrics.Event):
-                        template_args.append("NoExtraKeys")
-                    template_args.append(util.Camelize(obj.name) + suffix)
-                else:
-                    template_args.append(util.Camelize(obj.name) + suffix)
-                    if isinstance(obj, metrics.Event):
-                        template_args.append("NoExtras")
+                generic = util.Camelize(obj.name) + suffix
             else:
-                if suffix == "Keys":
-                    template_args.append("NoExtraKeys")
-                    template_args.append("NoExtras")
+                if isinstance(obj, metrics.Event):
+                    generic = "NoExtras"
                 else:
-                    template_args.append("No" + suffix)
+                    generic = "No" + suffix
 
-        return "{}<{}>".format(class_name(obj.type), ", ".join(template_args))
+        return "{}<{}>".format(class_name(obj.type), generic)
 
     return class_name(obj.type)
 

--- a/glean_parser/templates/kotlin.jinja2
+++ b/glean_parser/templates/kotlin.jinja2
@@ -46,18 +46,6 @@ enum class {{ obj.name|camelize }}{{ suffix }} : ReasonCode {
 }
 {%- endmacro %}
 
-{%- macro enum_decl(obj, name, suffix) -%}
-@Suppress("ClassNaming", "EnumNaming")
-enum class {{ obj.name|camelize }}{{ suffix }} : EventExtraKey {
-{% for key in obj|attr(name) %}
-    {{ key|camelize }} {
-        override fun keyName(): String = "{{ key }}"
-    }{{ "," if not loop.last }}{{ ";" if loop.last }}
-
-{% endfor %}
-}
-{%- endmacro %}
-
 {%- macro struct_decl(obj, name, suffix) -%}
 @Suppress("ClassNaming", "EnumNaming")
 data class {{ obj.name|Camelize }}{{ suffix }}(
@@ -83,12 +71,10 @@ data class {{ obj.name|Camelize }}{{ suffix }}(
 package {{ namespace }}
 
 import {{ glean_namespace }}.private.CommonMetricData // ktlint-disable import-ordering no-unused-imports
-import {{ glean_namespace }}.private.EventExtraKey // ktlint-disable import-ordering no-unused-imports
 import {{ glean_namespace }}.private.EventExtras // ktlint-disable import-ordering no-unused-imports
 import {{ glean_namespace }}.private.HistogramType // ktlint-disable import-ordering no-unused-imports
 import {{ glean_namespace }}.private.Lifetime // ktlint-disable import-ordering no-unused-imports
 import {{ glean_namespace }}.private.MemoryUnit // ktlint-disable import-ordering no-unused-imports
-import {{ glean_namespace }}.private.NoExtraKeys // ktlint-disable import-ordering no-unused-imports
 import {{ glean_namespace }}.private.NoExtras // ktlint-disable import-ordering no-unused-imports
 import {{ glean_namespace }}.private.ReasonCode // ktlint-disable import-ordering no-unused-imports
 import {{ glean_namespace }}.private.NoReasonCodes // ktlint-disable import-ordering no-unused-imports
@@ -114,11 +100,7 @@ internal object {{ category_name|Camelize }} {
     {% if obj|attr("_generate_enums") %}
     {% for name, suffix in obj["_generate_enums"] %}
     {% if obj|attr(name)|length %}
-    {% if obj.has_extra_types %}
     {{ struct_decl(obj, name, suffix)|indent }}
-    {% else %}
-    {{ enum_decl(obj, name, suffix)|indent }}
-    {% endif %}
     {% endif %}
     {% endfor %}
     {% endif %}

--- a/glean_parser/templates/rust.jinja2
+++ b/glean_parser/templates/rust.jinja2
@@ -13,11 +13,7 @@ Jinja2 template is not. Please file bugs! #}
 {# we always use the `extra` suffix, because we only expose the new event API #}
 {% set suffix = "Extra" %}
 {% if obj|attr(name)|length %}
-    {% if obj.has_extra_types %}
     {{ extra_keys_with_types(obj, name, suffix)|indent }}
-    {% else %}
-    compile_error!("Untyped event extras not supported. Please annotate event extras with a type. See documentation for details. (Metric: {{obj.category}}.{{obj.name}}, defined in: {{obj.defined_in['filepath']}}:{{obj.defined_in['line']}})");
-    {% endif %}
 {% endif %}
 {% endfor %}
 {% endmacro %}

--- a/glean_parser/templates/swift.jinja2
+++ b/glean_parser/templates/swift.jinja2
@@ -24,18 +24,6 @@ Jinja2 template is not. Please file bugs! #}
     )
 {% endmacro %}
 
-{% macro enum_decl(obj, name, suffix) %}
-enum {{ obj.name|Camelize }}{{ suffix }}: Int32, ExtraKeys {
-        {% for key in obj|attr(name) %}
-        case {{ key|camelize|variable_name }} = {{ loop.index-1 }}
-        {% endfor %}
-
-        public func index() -> Int32 {
-            return self.rawValue
-        }
-    }
-{% endmacro %}
-
 {% macro struct_decl(obj, name, suffix) %}
 struct {{ obj.name|Camelize }}{{ suffix }}: EventExtras {
         {% for item, typ in obj|attr(name) %}
@@ -119,11 +107,7 @@ extension {{ namespace }} {
         {% if obj|attr("_generate_enums") %}
         {% for name, suffix in obj["_generate_enums"] %}
         {% if obj|attr(name)|length %}
-        {% if obj.has_extra_types %}
         {{ struct_decl(obj, name, suffix)|indent }}
-        {% else %}
-        {{ enum_decl(obj, name, suffix)|indent }}
-        {% endif %}
         {% endif %}
         {% endfor %}
         {% endif %}

--- a/tests/data/core.yaml
+++ b/tests/data/core.yaml
@@ -37,8 +37,10 @@ telemetry:
     extra_keys:
       key1:
         description: "This is key one"
+        type: string
       key2:
         description: "This is key two"
+        type: string
     expires: never
 
   preference_toggled:
@@ -337,8 +339,10 @@ environment:
     extra_keys:
       key1:
         description: "This is key one"
+        type: string
       key2:
         description: "This is key two"
+        type: string
     expires: 2100-01-01
 
   event_no_keys:

--- a/tests/data/event_key_ordering.yaml
+++ b/tests/data/event_key_ordering.yaml
@@ -20,8 +20,11 @@ event:
       # sorted by glean_parser
       charlie:
         description: "one"
+        type: string
       alice:
         description: "two"
+        type: string
       bob:
         description: "three"
+        type: string
     expires: 2100-01-01

--- a/tests/data/events_with_types.yaml
+++ b/tests/data/events_with_types.yaml
@@ -5,23 +5,6 @@
 $schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
 
 core:
-  event_example:
-    type: event
-    description: >
-      Just testing events
-    bugs:
-      - https://bugzilla.mozilla.org/1123456789
-    data_reviews:
-      - http://example.com/reviews
-    notification_emails:
-      - CHANGE-ME@example.com
-    extra_keys:
-      key1:
-        description: "This is key one"
-      key2:
-        description: "This is key two"
-    expires: never
-
   preference_toggled:
     type: event
     description: |

--- a/tests/data/old_event_api.yamlx
+++ b/tests/data/old_event_api.yamlx
@@ -1,0 +1,27 @@
+# Any copyright is dedicated to the Public Domain.
+# https://creativecommons.org/publicdomain/zero/1.0/
+
+# Note: we're using YAML anchors to re-use the values
+# defined in the first metric.
+# Saves us some typing.
+---
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+
+old_event:
+  name:
+    type: event
+    # note: this _should_ have been time_unit
+    lifetime: ping
+    description: for testing
+    bugs:
+      - https://bugzilla.mozilla.org/1137353
+    data_reviews:
+      - http://example.com/
+    notification_emails:
+      - CHANGE-ME@example.com
+    expires: never
+    extra_keys:
+      key_a:
+        description: none
+      key_b:
+        description: none

--- a/tests/data/schema-violation.yaml
+++ b/tests/data/schema-violation.yaml
@@ -48,33 +48,49 @@ gleantest.event:
     extra_keys:
       key_1:
         description: Sample extra key
+        type: string
       key_2:
         description: Sample extra key
+        type: string
       key_3:
         description: Sample extra key
+        type: string
       key_4:
         description: Sample extra key
+        type: string
       key_5:
         description: Sample extra key
+        type: string
       key_6:
         description: Sample extra key
+        type: string
       key_7:
         description: Sample extra key
+        type: string
       key_8:
         description: Sample extra key
+        type: string
       key_9:
         description: Sample extra key
+        type: string
       key_10:
         description: Sample extra key
+        type: string
       key_11:
         description: Sample extra key
+        type: string
       key_12:
         description: Sample extra key
+        type: string
       key_13:
         description: Sample extra key
+        type: string
       key_14:
         description: Sample extra key
+        type: string
       key_15:
         description: Sample extra key
+        type: string
       key_16:
         description: Sample extra key
+        type: string

--- a/tests/test_javascript.py
+++ b/tests/test_javascript.py
@@ -138,7 +138,7 @@ def test_metric_class_name():
         notification_emails=["nobody@example.com"],
         description="description...",
         expires="never",
-        extra_keys={"my_extra": {"description": "an extra"}},
+        extra_keys={"my_extra": {"description": "an extra", "type": "string"}},
     )
 
     webext_class_name = javascript.class_name_factory("webext")
@@ -179,7 +179,7 @@ def test_import_path():
         notification_emails=["nobody@example.com"],
         description="description...",
         expires="never",
-        extra_keys={"my_extra": {"description": "an extra"}},
+        extra_keys={"my_extra": {"description": "an extra", "type": "string"}},
     )
 
     assert javascript.import_path(event.type) == "metrics/event"

--- a/tests/test_kotlin.py
+++ b/tests/test_kotlin.py
@@ -159,10 +159,10 @@ def test_metric_type_name():
         notification_emails=["nobody@example.com"],
         description="description...",
         expires="never",
-        extra_keys={"my_extra": {"description": "an extra"}},
+        extra_keys={"my_extra": {"description": "an extra", "type": "string"}},
     )
 
-    assert kotlin.type_name(event) == "EventMetricType<metricKeys, NoExtras>"
+    assert kotlin.type_name(event) == "EventMetricType<MetricExtra>"
 
     event = metrics.Event(
         type="event",
@@ -174,7 +174,7 @@ def test_metric_type_name():
         expires="never",
     )
 
-    assert kotlin.type_name(event) == "EventMetricType<NoExtraKeys, NoExtras>"
+    assert kotlin.type_name(event) == "EventMetricType<NoExtras>"
 
     boolean = metrics.Boolean(
         type="boolean",
@@ -377,9 +377,11 @@ def test_event_extra_keys_in_correct_order(tmpdir):
     with (tmpdir / "Event.kt").open("r", encoding="utf-8") as fd:
         content = fd.read()
         content = " ".join(content.split())
-        assert "EventExtraKey { alice {" in content
-        assert "bob {" in content
-        assert "charlie {" in content
+        assert "ExampleExtra(" in content
+        assert "alice:" in content
+        assert "bob:" in content
+        assert "charlie:" in content
+        assert ": EventExtras" in content
         assert 'allowedExtraKeys = listOf("alice", "bob", "charlie")' in content
 
 
@@ -406,7 +408,7 @@ def test_arguments_are_generated_in_deterministic_order(tmpdir):
     with (tmpdir / "Event.kt").open("r", encoding="utf-8") as fd:
         content = fd.read()
         content = " ".join(content.split())
-        expected = 'EventMetricType<exampleKeys, NoExtras> by lazy { // generated from event.example EventMetricType<exampleKeys, NoExtras>( CommonMetricData( category = "event", name = "example", sendInPings = listOf("events"), lifetime = Lifetime.PING, disabled = false ), allowedExtraKeys = listOf("alice", "bob", "charlie")) } }'  # noqa
+        expected = 'EventMetricType<ExampleExtra> by lazy { // generated from event.example EventMetricType<ExampleExtra>( CommonMetricData( category = "event", name = "example", sendInPings = listOf("events"), lifetime = Lifetime.PING, disabled = false ), allowedExtraKeys = listOf("alice", "bob", "charlie")) } }'  # noqa
         assert expected in content
 
 

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -467,3 +467,16 @@ def test_check_ping_tag_names(tags, expected_nits):
         assert nits[0].check_name == "INVALID_TAGS"
         assert nits[0].name == "search"
         assert nits[0].msg == "Invalid tags specified in ping: grapefruit"
+
+
+def test_old_event_api():
+    """Test that the 'glinter' reports issues with the old event API."""
+    all_metrics = parser.parse_objects([ROOT / "data" / "old_event_api.yamlx"])
+    errs = list(all_metrics)
+    assert len(errs) == 0
+
+    nits = lint.lint_metrics(all_metrics.value, parser_config={})
+    assert len(nits) == 1
+    assert nits[0].check_name == "OLD_EVENT_API"
+    assert nits[0].name == "old_event.name"
+    assert "Extra keys require a type" in nits[0].msg

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -53,7 +53,7 @@ def test_extra_info_generator():
         notification_emails=["nobody@example.com"],
         description="description...",
         expires="never",
-        extra_keys={"my_extra": {"description": "an extra"}},
+        extra_keys={"my_extra": {"description": "an extra", "type": "string"}},
     )
 
     assert markdown.extra_info(event) == [("my_extra", "an extra")]
@@ -237,7 +237,7 @@ def test_data_sensitivity():
         notification_emails=["nobody@example.com"],
         description="description...",
         expires="never",
-        extra_keys={"my_extra": {"description": "an extra"}},
+        extra_keys={"my_extra": {"description": "an extra", "type": "string"}},
         data_sensitivity=["technical", "interaction"],
     )
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -158,7 +158,7 @@ def test_reserved_extra_keys():
             notification_emails=["nobody@example.com"],
             description="description...",
             expires="never",
-            extra_keys={"glean.internal": {"description": "foo"}},
+            extra_keys={"glean.internal": {"description": "foo", "type": "string"}},
         )
 
     metrics.Event(
@@ -169,7 +169,7 @@ def test_reserved_extra_keys():
         notification_emails=["nobody@example.com"],
         description="description...",
         expires="never",
-        extra_keys={"glean.internal": {"description": "foo"}},
+        extra_keys={"glean.internal": {"description": "foo", "type": "string"}},
         _config={"allow_reserved": True},
     )
 
@@ -183,7 +183,7 @@ def test_no_unit():
         notification_emails=["nobody@example.com"],
         description="description...",
         expires="never",
-        extra_keys={"glean.internal": {"description": "foo"}},
+        extra_keys={"glean.internal": {"description": "foo", "type": "string"}},
         _config={"allow_reserved": True},
     )
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -144,53 +144,69 @@ def test_parser_schema_violation():
             extra_keys:
                 key_1:
                 description: Sample extra key
+                type: string
                 key_2:
                 description: Sample extra key
+                type: string
                 key_3:
                 description: Sample extra key
+                type: string
                 key_4:
                 description: Sample extra key
+                type: string
                 key_5:
                 description: Sample extra key
+                type: string
                 key_6:
                 description: Sample extra key
+                type: string
                 key_7:
                 description: Sample extra key
+                type: string
                 key_8:
                 description: Sample extra key
+                type: string
                 key_9:
                 description: Sample extra key
+                type: string
                 key_10:
                 description: Sample extra key
+                type: string
                 key_11:
                 description: Sample extra key
+                type: string
                 key_12:
-                  description: Sample extra key
+                description: Sample extra key
+                type: string
                 key_13:
-                  description: Sample extra key
+                description: Sample extra key
+                type: string
                 key_14:
-                  description: Sample extra key
+                description: Sample extra key
+                type: string
                 key_15:
-                  description: Sample extra key
+                description: Sample extra key
+                type: string
                 key_16:
-                  description: Sample extra key
+                description: Sample extra key
+                type: string
         ```
-        {'key_1': {'description': 'Sample extra key'},
-        'key_2': {'description': 'Sample extra key'},
-        'key_3': {'description': 'Sample extra key'},
-        'key_4': {'description': 'Sample extra key'},
-        'key_5': {'description': 'Sample extra key'},
-        'key_6': {'description': 'Sample extra key'},
-        'key_7': {'description': 'Sample extra key'},
-        'key_8': {'description': 'Sample extra key'},
-        'key_9': {'description': 'Sample extra key'},
-        'key_10': {'description': 'Sample extra key'},
-        'key_11': {'description': 'Sample extra key'},
-        'key_12': {'description': 'Sample extra key'},
-        'key_13': {'description': 'Sample extra key'},
-        'key_14': {'description': 'Sample extra key'},
-        'key_15': {'description': 'Sample extra key'},
-        'key_16': {'description': 'Sample extra key'}
+        {'key_1': {'description': 'Sample extra key','type': 'string'},
+        'key_2': {'description': 'Sample extra key','type': 'string'},
+        'key_3': {'description': 'Sample extra key','type': 'string'},
+        'key_4': {'description': 'Sample extra key','type': 'string'},
+        'key_5': {'description': 'Sample extra key','type': 'string'},
+        'key_6': {'description': 'Sample extra key','type': 'string'},
+        'key_7': {'description': 'Sample extra key','type': 'string'},
+        'key_8': {'description': 'Sample extra key','type': 'string'},
+        'key_9': {'description': 'Sample extra key','type': 'string'},
+        'key_10': {'description': 'Sample extra key','type': 'string'},
+        'key_11': {'description': 'Sample extra key','type': 'string'},
+        'key_12': {'description': 'Sample extra key','type': 'string'},
+        'key_13': {'description': 'Sample extra key','type': 'string'},
+        'key_14': {'description': 'Sample extra key','type': 'string'},
+        'key_15': {'description': 'Sample extra key','type': 'string'},
+        'key_16': {'description': 'Sample extra key','type': 'string'}
         } has too many properties
         Documentation for this node:
             The acceptable keys on the "extra" object sent with events. This is an
@@ -738,10 +754,20 @@ def test_historical_versions():
     Make sure we can load the correct version of the schema and it will
     correctly reject or not reject entries based on that.
     """
+
+    # No issues:
+    # * Bugs as numbers
+    # * event extra keys don't have a type
     contents = [
         {
             "$schema": "moz://mozilla.org/schemas/glean/metrics/1-0-0",
-            "category": {"metric": {"type": "event", "bugs": [42]}},
+            "category": {
+                "metric": {
+                    "type": "event",
+                    "extra_keys": {"key_a": {"description": "foo"}},
+                    "bugs": [42],
+                }
+            },
         }
     ]
     contents = [util.add_required(x) for x in contents]
@@ -751,10 +777,20 @@ def test_historical_versions():
     errors = list(all_metrics)
     assert len(errors) == 0
 
+    # 1 issue:
+    # * Bugs as numbers are disallowed
+    #
+    # events: not having a `type` is fine in version 2.
     contents = [
         {
             "$schema": "moz://mozilla.org/schemas/glean/metrics/2-0-0",
-            "category": {"metric": {"type": "event", "bugs": [42]}},
+            "category": {
+                "metric": {
+                    "type": "event",
+                    "extra_keys": {"key_a": {"description": "foo"}},
+                    "bugs": [42],
+                }
+            },
         }
     ]
     contents = [util.add_required(x) for x in contents]

--- a/tests/test_rust.py
+++ b/tests/test_rust.py
@@ -120,7 +120,7 @@ def test_metric_type_name():
         notification_emails=["nobody@example.com"],
         description="description...",
         expires="never",
-        extra_keys={"my_extra": {"description": "an extra"}},
+        extra_keys={"my_extra": {"description": "an extra", "type": "string"}},
     )
 
     assert rust.type_name(event) == "EventMetric<MetricExtra>"
@@ -135,7 +135,7 @@ def test_metric_type_name():
         expires="never",
     )
 
-    assert rust.type_name(event) == "EventMetric<NoExtraKeys>"
+    assert rust.type_name(event) == "EventMetric<NoExtra>"
 
     boolean = metrics.Boolean(
         type="boolean",
@@ -155,7 +155,7 @@ def test_metric_type_name():
         bugs=["http://bugzilla.mozilla.com/12345"],
         notification_emails=["nobody@nowhere.com"],
     )
-    assert rust.type_name(ping) == "Ping<CustomExtra>"
+    assert rust.type_name(ping) == "Ping<NoReasonCodes>"
 
     ping = pings.Ping(
         name="custom",
@@ -165,7 +165,7 @@ def test_metric_type_name():
         notification_emails=["nobody@nowhere.com"],
         reasons={"foo": "foolicious", "bar": "barlicious"},
     )
-    assert rust.type_name(ping) == "Ping<CustomExtra>"
+    assert rust.type_name(ping) == "Ping<CustomReasonCodes>"
 
 
 def test_order_of_fields(tmpdir):

--- a/tests/test_swift.py
+++ b/tests/test_swift.py
@@ -170,10 +170,10 @@ def test_metric_type_name():
         notification_emails=["nobody@example.com"],
         description="description...",
         expires="never",
-        extra_keys={"my_extra": {"description": "an extra"}},
+        extra_keys={"my_extra": {"description": "an extra", "type": "string"}},
     )
 
-    assert swift.type_name(event) == "EventMetricType<MetricKeys, NoExtras>"
+    assert swift.type_name(event) == "EventMetricType<MetricExtra>"
 
     event = metrics.Event(
         type="event",
@@ -185,7 +185,7 @@ def test_metric_type_name():
         expires="never",
     )
 
-    assert swift.type_name(event) == "EventMetricType<NoExtraKeys, NoExtras>"
+    assert swift.type_name(event) == "EventMetricType<NoExtras>"
 
     boolean = metrics.Boolean(
         type="boolean",
@@ -306,8 +306,8 @@ def test_event_extra_keys_in_correct_order(tmpdir):
         content = fd.read()
         content = " ".join(content.split())
         assert (
-            "enum ExampleKeys: Int32, ExtraKeys "
-            "{ case alice = 0 case bob = 1 case charlie = 2" in content
+            "struct ExampleExtra: EventExtras "
+            "{ var alice: String? var bob: String? var charlie: String?" in content
         )
         assert ', ["alice", "bob", "charlie"]' in content
 

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -204,7 +204,7 @@ def test_getting_line_number():
     metrics = load_yaml_or_json(ROOT / "data" / "core.yaml")
 
     assert pings["custom-ping"].defined_in["line"] == 7
-    assert metrics["core_ping"]["seq"].defined_in["line"] == 67
+    assert metrics["core_ping"]["seq"].defined_in["line"] == 69
 
 
 def test_rates(tmpdir):


### PR DESCRIPTION
For https://github.com/mozilla/glean/pull/2346
Based on #551 

---

Can't just change it in the schema because that would be breaking.
I still need to check if this breaks anything in probe-scraper. I guess it would break because we can't parse old files anymore?
In that case we would need to bump the schema to 3-0-0 and migrate all users eventually.