### PR TITLE
Bug 1811888 - Kotlin: Generate plain enums for ping reason codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - BUGFIX: Remove internal-only fields from serialized metrics data ([#550](https://github.com/mozilla/glean_parser/pull/550))
 - FEATURE: New subcommand: `dump` to dump the metrics data as JSON ([#550](https://github.com/mozilla/glean_parser/pull/550))
+- BUGFIX: Kotlin: Generate enums with the right generic bound for ping reason codes ([#551](https://github.com/mozilla/glean_parser/pull/551)).
 
 ## 6.4.0
 

--- a/glean_parser/templates/kotlin.jinja2
+++ b/glean_parser/templates/kotlin.jinja2
@@ -34,6 +34,18 @@ Jinja2 template is not. Please file bugs! #}
 {% if lazy %}}{% endif %}
 {%- endmacro -%}
 
+{%- macro reason_enum_decl(obj, name, suffix) -%}
+@Suppress("ClassNaming", "EnumNaming")
+enum class {{ obj.name|camelize }}{{ suffix }} : ReasonCode {
+{% for key in obj|attr(name) %}
+    {{ key|camelize }} {
+        override fun code(): Int = {{ loop.index-1 }}
+    }{{ "," if not loop.last }}{{ ";" if loop.last }}
+
+{% endfor %}
+}
+{%- endmacro %}
+
 {%- macro enum_decl(obj, name, suffix) -%}
 @Suppress("ClassNaming", "EnumNaming")
 enum class {{ obj.name|camelize }}{{ suffix }} : EventExtraKey {
@@ -78,6 +90,7 @@ import {{ glean_namespace }}.private.Lifetime // ktlint-disable import-ordering 
 import {{ glean_namespace }}.private.MemoryUnit // ktlint-disable import-ordering no-unused-imports
 import {{ glean_namespace }}.private.NoExtraKeys // ktlint-disable import-ordering no-unused-imports
 import {{ glean_namespace }}.private.NoExtras // ktlint-disable import-ordering no-unused-imports
+import {{ glean_namespace }}.private.ReasonCode // ktlint-disable import-ordering no-unused-imports
 import {{ glean_namespace }}.private.NoReasonCodes // ktlint-disable import-ordering no-unused-imports
 import {{ glean_namespace }}.private.TimeUnit // ktlint-disable import-ordering no-unused-imports
 {% for obj_type in obj_types %}
@@ -89,6 +102,15 @@ import {{ glean_namespace }}.private.LabeledMetricType // ktlint-disable import-
 
 internal object {{ category_name|Camelize }} {
 {% for obj in objs.values() %}
+    {% if obj.type == "ping" %}
+    {% if obj|attr("_generate_enums") %}
+    {% for name, suffix in obj["_generate_enums"] %}
+    {% if obj|attr(name)|length %}
+    {{ reason_enum_decl(obj, name, suffix)|indent }}
+    {% endif %}
+    {% endfor %}
+    {% endif %}
+    {% else %}
     {% if obj|attr("_generate_enums") %}
     {% for name, suffix in obj["_generate_enums"] %}
     {% if obj|attr(name)|length %}
@@ -99,6 +121,7 @@ internal object {{ category_name|Camelize }} {
     {% endif %}
     {% endif %}
     {% endfor %}
+    {% endif %}
     {% endif %}
 {% endfor %}
 {% for obj in objs.values() %}


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
