### PR TITLE
bug 1672273 - Loosen label restrictions to 'at most 71 characters of printable ASCII'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- ENHANCEMENT: Labels in `labels:` fields may now contain any printable ASCII characters ([bug 1672273](https://bugzilla.mozilla.org/show_bug.cgi?id=1672273))
+
 ## 7.0.0
 
 - BUGFIX: Remove internal-only fields from serialized metrics data ([#550](https://github.com/mozilla/glean_parser/pull/550))

--- a/glean_parser/schemas/metrics.2-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.2-0-0.schema.yaml
@@ -46,7 +46,7 @@ definitions:
 
   labeled_metric_id:
     type: string
-    pattern: "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z_][a-z0-9_-]{0,29})*$"
+    pattern: "^[ -~]+$"
     maxLength: 71  # Note: this should be category + metric + 1
 
   metric:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -340,10 +340,8 @@ def invalid_in_label(name):
 @pytest.mark.parametrize(
     "name",
     [
-        "name/with_slash",
-        "name#with_pound",
-        "this_name_is_too_long_and_shouldnt_be_used",
-        "",
+        "1" * 72,
+        "Møøse",
     ],
 )
 def test_invalid_names(location, name):


### PR DESCRIPTION
Brings it in line with dynamic labels in mozilla/glean#2364

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
