### PR TITLE
Bug 1820648 - Sort generated Metrics, Pings and Tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - ENHANCEMENT: Labels in `labels:` fields may now contain any printable ASCII characters ([bug 1672273](https://bugzilla.mozilla.org/show_bug.cgi?id=1672273))
+- BUGFIX: Enforce ordering of generation of Pings, Metrics and Tags such that order is deterministic ([bug 1820334](https://bugzilla.mozilla.org/show_bug.cgi?id=1820334))
 
 ## 7.0.0
 

--- a/glean_parser/parser.py
+++ b/glean_parser/parser.py
@@ -182,7 +182,7 @@ def _instantiate_metrics(
     global_tags = content.get("$tags", [])
     assert isinstance(global_tags, list)
 
-    for category_key, category_val in content.items():
+    for category_key, category_val in sorted(content.items()):
         if category_key.startswith("$"):
             continue
         if category_key == "no_lint":
@@ -200,7 +200,7 @@ def _instantiate_metrics(
         if not isinstance(category_val, dict):
             raise TypeError(f"Invalid content for {category_key}")
 
-        for metric_key, metric_val in category_val.items():
+        for metric_key, metric_val in sorted(category_val.items()):
             try:
                 metric_obj = Metric.make_metric(
                     category_key, metric_key, metric_val, validated=True, config=config
@@ -268,7 +268,7 @@ def _instantiate_pings(
     global_no_lint = content.get("no_lint", [])
     assert isinstance(global_no_lint, list)
 
-    for ping_key, ping_val in content.items():
+    for ping_key, ping_val in sorted(content.items()):
         if ping_key.startswith("$"):
             continue
         if ping_key == "no_lint":
@@ -328,7 +328,7 @@ def _instantiate_tags(
     global_no_lint = content.get("no_lint", [])
     assert isinstance(global_no_lint, list)
 
-    for tag_key, tag_val in content.items():
+    for tag_key, tag_val in sorted(content.items()):
         if tag_key.startswith("$"):
             continue
         if tag_key == "no_lint":

--- a/tests/data/ordering.yaml
+++ b/tests/data/ordering.yaml
@@ -1,0 +1,45 @@
+# Any copyright is dedicated to the Public Domain.
+# https://creativecommons.org/publicdomain/zero/1.0/
+
+---
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+
+testing.ordering:
+  first_test_metric:
+    type: counter
+    lifetime: application
+    description: >
+      Test metric to check ordering. Second alphabetically.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1820648
+    data_reviews:
+      - http://example.com/reviews
+    notification_emails:
+      - CHANGE-ME@example.com
+    expires: never
+
+  a_second_test_metric:
+    type: counter
+    lifetime: application
+    description: >
+      An additional test metric to check ordering. First alphabetically.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1820648
+    data_reviews:
+      - http://example.com/reviews
+    notification_emails:
+      - CHANGE-ME@example.com
+    expires: never
+
+  third_test_metric:
+    type: counter
+    lifetime: application
+    description: >
+      Final test metric to check ordering. Third alphabetically.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1820648
+    data_reviews:
+      - http://example.com/reviews
+    notification_emails:
+      - CHANGE-ME@example.com
+    expires: never

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -844,6 +844,51 @@ def test_rates():
     )  # Hasn't been transformed to "denominator" yet
 
 
+def test_ping_ordering():
+    contents = parser.parse_objects(
+        [ROOT / "data" / "pings.yaml"],
+        config={"allow_reserved": False},
+    )
+
+    errs = list(contents)
+    assert len(errs) == 0
+
+    pings = list(contents.value["pings"].keys())
+
+    assert pings == sorted(pings)
+
+
+def test_metric_ordering():
+    all_metrics = parser.parse_objects(
+        [ROOT / "data" / "ordering.yaml"], config={"allow_reserved": False}
+    )
+
+    errs = list(all_metrics)
+    assert len(errs) == 0
+
+    category = all_metrics.value["testing.ordering"]
+
+    assert len(category.values()) > 0
+    test_metrics = [f"{m.category}.{m.name}" for m in category.values()]
+
+    # Alphabetically ordered
+    assert test_metrics == [
+        "testing.ordering.a_second_test_metric",
+        "testing.ordering.first_test_metric",
+        "testing.ordering.third_test_metric",
+    ]
+
+
+def test_tag_ordering():
+    all_metrics = parser.parse_objects(ROOT / "data" / "metric-with-tags.yaml")
+
+    errs = list(all_metrics)
+    assert len(errs) == 0
+
+    tags = all_metrics.value["telemetry"]["client_id"].metadata["tags"]
+    assert tags == sorted(tags)
+
+
 def test_text_valid():
     """
     Ensure that `text` metrics parse properly.

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -226,10 +226,13 @@ def test_rates(tmpdir):
         numerators = [
             f"{m.category}.{m.name}" for m in category["the_denominator"].numerators
         ]
-        assert numerators == [
-            "testing.rates.has_external_denominator",
-            "testing.rates.also_has_external_denominator",
-        ]
+        # Because generation gaurantees order, this must be sorted.
+        assert numerators == sorted(
+            [
+                "testing.rates.has_external_denominator",
+                "testing.rates.also_has_external_denominator",
+            ]
+        )
 
     translate.translate_metrics(
         ROOT / "data" / "rate.yaml",


### PR DESCRIPTION
Here's a take on making sure we have a deterministic order from `glean_parser`.

Ordered Dict is a weird one. It preserves insertion order, true, but in doing some research it's had rather a lot of changes recently and performance hasn't always been great. While this isn't a perf critical application, this method (calling sort on the `.items()` iterator) is stable, runs once each for Metrics/Pings and Tags, and will always result in a consistent order (alphabetical).

Interestingly, regular `dict` ordering is _supposed_ to be guaranteed as of 3.6, except that it's unsettled what that order should be. 

### Pull Request checklist ###

<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
