### PR TITLE
Bug 1833393 - New lint: check that all referenced pings are known

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - BREAKING CHANGE: Remove exposed `lint_yaml_files` function ([#580](https://github.com/mozilla/glean_parser/pull/580))
 - Rust: Removed `__glean_metric_maps` from the Rust Jinja template. This functionality is better placed downstream ([Bug 1816526](https://bugzilla.mozilla.org/show_bug.cgi?id=1816526))
+- New lint: check that all referenced pings are known ([#584](https://github.com/mozilla/glean_parser/pull/584))
 
 ## 7.2.1
 

--- a/glean_parser/lint.py
+++ b/glean_parser/lint.py
@@ -27,7 +27,11 @@ from . import tags
 from . import util
 
 
+# Yield only an error message
 LintGenerator = Generator[str, None, None]
+
+# Yield fully constructed GlinterNits
+NitGenerator = Generator["GlinterNit", None, None]
 
 
 class CheckType(enum.Enum):
@@ -304,6 +308,40 @@ def check_redundant_ping(
             yield ("The word 'custom' is redundant.")
 
 
+def check_unknown_ping(
+    check_name: str,
+    check_type: CheckType,
+    all_pings: Dict[str, pings.Ping],
+    metrics: Dict[str, metrics.Metric],
+    parser_config: Dict[str, Any],
+) -> NitGenerator:
+    """
+    Check that all pings in `send_in_pings` for all metrics are either a builtin ping
+    or in the list of defined custom pings.
+    """
+    available_pings = [p for p in all_pings]
+
+    for _, metric in metrics.items():
+        if check_name in metric.no_lint:
+            continue
+
+        send_in_pings = metric.send_in_pings
+        for target_ping in send_in_pings:
+            if target_ping in pings.RESERVED_PING_NAMES:
+                continue
+
+            if target_ping not in available_pings:
+                msg = f"Ping `{target_ping} `in `send_in_pings` is unknown."
+                name = ".".join([metric.category, metric.name])
+                nit = GlinterNit(
+                    check_name,
+                    name,
+                    msg,
+                    check_type,
+                )
+                yield nit
+
+
 # The checks that operate on an entire category of metrics:
 #    {NAME: (function, is_error)}
 CATEGORY_CHECKS: Dict[
@@ -339,6 +377,20 @@ PING_CHECKS: Dict[
     "BUG_NUMBER": (check_bug_number, CheckType.error),
     "TAGS_REQUIRED": (check_tags_required, CheckType.error),
     "REDUNDANT_PING": (check_redundant_ping, CheckType.error),
+}
+
+ALL_OBJECT_CHECKS: Dict[
+    str,
+    Tuple[
+        Callable[
+            # check name, check type, pings, metrics, config
+            [str, CheckType, dict, dict, dict],
+            NitGenerator,
+        ],
+        CheckType,
+    ],
+] = {
+    "UNKNOWN_PING_REFERENCED": (check_unknown_ping, CheckType.error),
 }
 
 
@@ -410,6 +462,29 @@ def _lint_pings(
     return nits
 
 
+def _lint_all_objects(
+    objects: Dict[str, Dict[str, Union[metrics.Metric, pings.Ping, tags.Tag]]],
+    parser_config: Dict[str, Any],
+) -> List[GlinterNit]:
+    nits: List[GlinterNit] = []
+
+    pings = objects.get("pings")
+    if not pings:
+        return []
+
+    metrics = objects.get("all_metrics")
+    if not metrics:
+        return []
+
+    for check_name, (check_func, check_type) in ALL_OBJECT_CHECKS.items():
+        new_nits = list(
+            check_func(check_name, check_type, pings, metrics, parser_config)
+        )
+        nits.extend(new_nits)
+
+    return nits
+
+
 def lint_metrics(
     objs: metrics.ObjectTree,
     parser_config: Optional[Dict[str, Any]] = None,
@@ -427,6 +502,9 @@ def lint_metrics(
 
     nits: List[GlinterNit] = []
     valid_tag_names = [tag for tag in objs.get("tags", [])]
+
+    nits.extend(_lint_all_objects(objs, parser_config))
+
     for category_name, category in sorted(list(objs.items())):
         if category_name == "pings":
             nits.extend(_lint_pings(category, parser_config, valid_tag_names))

--- a/tests/data/unknown_ping_used.yaml
+++ b/tests/data/unknown_ping_used.yaml
@@ -1,0 +1,39 @@
+# Any copyright is dedicated to the Public Domain.
+# https://creativecommons.org/publicdomain/zero/1.0/
+
+---
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+
+all_metrics:
+  valid_metric: &defaults
+    type: counter
+    lifetime: ping
+    description: for testing
+    bugs:
+      - https://bugzilla.mozilla.org/123
+    data_reviews:
+      - http://example.com/
+    notification_emails:
+      - CHANGE-ME@example.com
+    expires: never
+    send_in_pings:
+      - metrics
+      - custom-ping
+
+  only_builtins:
+    <<: *defaults
+    send_in_pings:
+      - metrics
+      - events
+
+  non_existent_ping:
+    <<: *defaults
+    send_in_pings:
+      - does-not-exist
+
+  non_existent_ping_no_lint:
+    <<: *defaults
+    send_in_pings:
+      - does-not-exist
+    no_lint:
+      - UNKNOWN_PING_REFERENCED

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -461,3 +461,18 @@ def test_old_event_api():
     assert nits[0].check_name == "OLD_EVENT_API"
     assert nits[0].name == "old_event.name"
     assert "Extra keys require a type" in nits[0].msg
+
+
+def test_unknown_pings_lint():
+    """Test that the 'glinter' reports issues with unknown pings in send_in_pings."""
+    input = [ROOT / "data" / "unknown_ping_used.yaml", ROOT / "data" / "pings.yaml"]
+    all_objects = parser.parse_objects(input)
+
+    errs = list(all_objects)
+    assert len(errs) == 0
+
+    nits = lint.lint_metrics(all_objects.value, parser_config={})
+    assert len(nits) == 1
+    assert nits[0].check_name == "UNKNOWN_PING_REFERENCED"
+    assert nits[0].name == "all_metrics.non_existent_ping"
+    assert "does-not-exist" in nits[0].msg


### PR DESCRIPTION
This introduces a new category of checks: those that run across both pings and metrics and can thus apply cross-checks.

Todo:

* [x] Fix the types