### PR TITLE
Bug 1839640 - Add new metric type: object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Add new metric type: object ([#587](https://github.com/mozilla/glean_parser/pull/587))
+- Add new metric type object (only Rust codegen support right now) ([#587](https://github.com/mozilla/glean_parser/pull/587))
 
 ## 11.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add new metric type: object ([#587](https://github.com/mozilla/glean_parser/pull/587))
+
 ## 11.1.0
 
 - Add Go log outputter (`go_server`) ([#645](https://github.com/mozilla/glean_parser/pull/645))

--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -181,6 +181,7 @@ class Metric:
             d.pop("unit")
         d.pop("_config", None)
         d.pop("_generate_enums", None)
+        d.pop("_generate_structure", None)
         return d
 
     def _serialize_input(self) -> Dict[str, util.JSONType]:
@@ -432,6 +433,65 @@ class Denominator(Counter):
 
 class Text(Metric):
     typename = "text"
+
+
+class Object(Metric):
+    typename = "object"
+
+    def __init__(self, *args, **kwargs):
+        structure = kwargs.pop("structure", None)
+        if not structure:
+            raise ValueError("`object` is missing required parameter `structure`")
+
+        self._generate_structure = self.validate_structure(structure)
+        super().__init__(*args, **kwargs)
+
+    ALLOWED_TOPLEVEL = {"type", "properties", "items"}
+    ALLOWED_TYPES = ["object", "array", "number", "string", "boolean"]
+
+    @staticmethod
+    def _validate_substructure(structure):
+        extra = set(structure.keys()) - Object.ALLOWED_TOPLEVEL
+        if extra:
+            extra = ", ".join(extra)
+            allowed = ", ".join(Object.ALLOWED_TOPLEVEL)
+            raise ValueError(
+                f"Found additional fields: {extra}. Only allowed: {allowed}"
+            )
+
+        if "type" not in structure or structure["type"] not in Object.ALLOWED_TYPES:
+            raise ValueError("invalid or missing `type` in object structure")
+
+        if structure["type"] == "object":
+            if "items" in structure:
+                raise ValueError("`items` not allowed in object structure")
+
+            if "properties" not in structure:
+                raise ValueError("`properties` missing for type `object`")
+
+            for key in structure["properties"]:
+                value = structure["properties"][key]
+                structure["properties"][key] = Object._validate_substructure(value)
+
+        if structure["type"] == "array":
+            if "properties" in structure:
+                raise ValueError("`properties` not allowed in array structure")
+
+            if "items" not in structure:
+                raise ValueError("`items` missing for type `array`")
+
+            value = structure["items"]
+            structure["items"] = Object._validate_substructure(value)
+
+        return structure
+
+    @staticmethod
+    def validate_structure(structure):
+        if None:
+            raise ValueError("`structure` needed for object metric.")
+
+        structure = Object._validate_substructure(structure)
+        return structure
 
 
 ObjectTree = Dict[str, Dict[str, Union[Metric, pings.Ping, tags.Tag]]]

--- a/glean_parser/rust.py
+++ b/glean_parser/rust.py
@@ -65,7 +65,7 @@ def rust_datatypes_filter(value):
             elif isinstance(value, metrics.CowString):
                 yield f'::std::borrow::Cow::from("{value.inner}")'
             elif isinstance(value, str):
-                yield f'"{value}".into()'
+                yield f"{json.dumps(value)}.into()"
             elif isinstance(value, metrics.Rate):
                 yield "CommonMetricData("
                 first = True

--- a/glean_parser/rust.py
+++ b/glean_parser/rust.py
@@ -115,6 +115,11 @@ def type_name(obj):
 
         return "{}<{}>".format(class_name(obj.type), generic)
 
+    generate_structure = getattr(obj, "_generate_structure", [])
+    if len(generate_structure):
+        generic = util.Camelize(obj.name) + "Object"
+        return "{}<{}>".format(class_name(obj.type), generic)
+
     return class_name(obj.type)
 
 
@@ -129,6 +134,21 @@ def extra_type_name(typ: str) -> str:
         return "String"
     elif typ == "quantity":
         return "u32"
+    else:
+        return "UNSUPPORTED"
+
+
+def structure_type_name(typ: str) -> str:
+    """
+    Returns the corresponding Rust type for structure items.
+    """
+
+    if typ == "boolean":
+        return "bool"
+    elif typ == "string":
+        return "String"
+    elif typ == "number":
+        return "i64"
     else:
         return "UNSUPPORTED"
 
@@ -190,6 +210,7 @@ def output_rust(
             ("camelize", util.camelize),
             ("type_name", type_name),
             ("extra_type_name", extra_type_name),
+            ("structure_type_name", structure_type_name),
             ("ctor", ctor),
             ("extra_keys", extra_keys),
         ),

--- a/glean_parser/schemas/metrics.2-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.2-0-0.schema.yaml
@@ -119,6 +119,9 @@ definitions:
 
             - `text`: Record long text data.
 
+            - `object`: Record structured data based on a pre-defined schema
+              Additional properties: `structure`.
+
         type: string
         enum:
           - event
@@ -140,6 +143,7 @@ definitions:
           - labeled_counter
           - rate
           - text
+          - object
 
       description:
         title: Description
@@ -566,6 +570,15 @@ definitions:
           The named denominator must be defined in this component
           so glean_parser can find it.
         type: string
+
+      structure:
+        title: A subset of a JSON schema definition
+        description: |
+          The expected structure of data, defined in a strict subset of
+          YAML-dialect JSON Schema (Draft 7) supporting keys "type"
+          (only values "object", "array", "number", "string", and "boolean"),
+          "properties", and "items".
+        type: object
 
     required:
       - type

--- a/glean_parser/templates/rust.jinja2
+++ b/glean_parser/templates/rust.jinja2
@@ -25,10 +25,13 @@ Jinja2 template is not. Please file bugs! #}
     pub struct {{ name }} {
         {% for itemname, val in struct.properties.items() %}
           {% if val.type == "object" %}
-          {{itemname|snake_case}}: {{ name ~ "Item" ~ itemname|Camelize ~ "Object" }},
+          #[serde(skip_serializing_if = "Option::is_none")]
+          {{itemname|snake_case}}: Option<{{ name ~ "Item" ~ itemname|Camelize ~ "Object" }}>,
           {% elif val.type == "array" %}
+          #[serde(skip_serializing_if = "Vec::is_empty")]
           {{itemname|snake_case}}: {{ name ~ "Item" ~ itemname|Camelize }},
           {% else %}
+          #[serde(skip_serializing_if = "Option::is_none")]
           {{itemname|snake_case}}: Option<{{val.type|structure_type_name}}>,
           {% endif %}
         {% endfor %}

--- a/glean_parser/templates/rust.jinja2
+++ b/glean_parser/templates/rust.jinja2
@@ -8,6 +8,50 @@ Jinja2 template is not. Please file bugs! #}
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+{%- macro generate_structure(name, struct) %}
+{% if struct.type == "array" %}
+    pub type {{ name }} = Vec<{{ name }}Item>;
+
+    {% if struct["items"].type == "object" %}
+    {{ generate_structure(name ~ "Item", struct["items"]) }}
+    {% elif struct["items"].type == "array" %}
+    {{ generate_structure(name ~ "Item", struct["items"]) }}
+    {% else %}
+    {{ generate_structure(name ~ "Item", struct["items"]) }}
+    {% endif %}
+
+{% elif struct.type == "object" %}
+    #[derive(Debug, Hash, Eq, PartialEq, SerdeSerialize)]
+    pub struct {{ name }} {
+        {% for itemname, val in struct.properties.items() %}
+          {% if val.type == "object" %}
+          {{itemname|snake_case}}: {{ name ~ "Item" ~ itemname|Camelize ~ "Object" }},
+          {% elif val.type == "array" %}
+          {{itemname|snake_case}}: {{ name ~ "Item" ~ itemname|Camelize }},
+          {% else %}
+          {{itemname|snake_case}}: Option<{{val.type|structure_type_name}}>,
+          {% endif %}
+        {% endfor %}
+    }
+
+    {% for itemname, val in struct.properties.items() %}
+        {% if val.type == "array" %}
+        {% set nested_name = name ~ "Item" ~ itemname|Camelize %}
+        {{ generate_structure(nested_name, val) }}
+        {% elif val.type == "object" %}
+        {% set nested_name = name ~ "Item" ~ itemname|Camelize ~ "Object" %}
+        {{ generate_structure(nested_name, val) }}
+        {% endif %}
+    {% endfor %}
+
+{% else %}
+
+pub type {{ name }} = {{ struct.type|structure_type_name }};
+
+{% endif %}
+
+{% endmacro %}
+
 {% macro generate_extra_keys(obj) %}
 {% for name, _ in obj["_generate_enums"] %}
 {# we always use the `extra` suffix, because we only expose the new event API #}
@@ -49,8 +93,12 @@ pub static {{ obj.name|snake_case }}: ::glean::private::__export::Lazy<::glean::
 {% else %}
 pub mod {{ category.name|snake_case }} {
     #[allow(unused_imports)] // HistogramType might be unusued, let's avoid warnings
-    use glean::{private::*, traits::ExtraKeys, traits::NoExtraKeys, CommonMetricData, HistogramType, Lifetime, TimeUnit, MemoryUnit};
+    use glean::{private::*, traits::ExtraKeys, traits::NoExtraKeys, serde::Serialize, serde::Deserialize, CommonMetricData, HistogramType, Lifetime, TimeUnit, MemoryUnit};
     {% for obj in category.objs.values() %}
+
+    {% if obj|attr("_generate_structure") %}
+{{ generate_structure(obj.name|Camelize ~ "Object", obj._generate_structure) }}
+    {%- endif %}
 
     {% if obj|attr("_generate_enums") %}
 {{ generate_extra_keys(obj) }}

--- a/tests/data/object.yaml
+++ b/tests/data/object.yaml
@@ -1,0 +1,28 @@
+# Any copyright is dedicated to the Public Domain.
+# https://creativecommons.org/publicdomain/zero/1.0/
+
+---
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+
+activity.stream:
+  tiles:
+    type: object
+    description: The id, position, and shim for each newtab tile.
+    bugs:
+      - https://bugzilla.mozilla.org/11137353
+    data_reviews:
+      - http://example.com/reviews
+    notification_emails:
+      - CHANGE-ME@example.com
+    expires: never
+    structure:
+      type: array
+      items:
+        type: object
+        properties:
+          id:
+            type: number
+          pos:
+            type: number
+          shim:
+            type: string

--- a/tests/data/object.yaml
+++ b/tests/data/object.yaml
@@ -4,10 +4,46 @@
 ---
 $schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
 
+complex.types:
+  number_array:
+    type: object
+    description: Just a list of nums.
+    bugs:
+      - https://bugzilla.mozilla.org/11137353
+    data_reviews:
+      - http://example.com/reviews
+    notification_emails:
+      - CHANGE-ME@example.com
+    expires: never
+    structure:
+      type: array
+      items:
+        type: number
+
+  array_in_array:
+    type: object
+    description: An array of arrays of bools.
+    bugs:
+      - https://bugzilla.mozilla.org/11137353
+    data_reviews:
+      - http://example.com/reviews
+    notification_emails:
+      - CHANGE-ME@example.com
+    expires: never
+    structure:
+      type: array
+      items:
+        type: array
+        items:
+          type: boolean
+
+# yamllint disable rule:line-length
 activity.stream:
   tiles:
     type: object
-    description: The id, position, and shim for each newtab tile.
+    description: |
+      The id, position, and shim for each newtab tile and any extra nested data,
+      e.g. `[{"id": 1, "pos": 2, "shim": "long-id", "nested": { "count": 17, "info": "more info"}}]`
     bugs:
       - https://bugzilla.mozilla.org/11137353
     data_reviews:
@@ -26,3 +62,40 @@ activity.stream:
             type: number
           shim:
             type: string
+          nested:
+            type: object
+            properties:
+              count:
+                type: number
+              info:
+                type: string
+
+crash.stack:
+  threads:
+    type: object
+    description: |
+      All threads' frame information.
+      e.g. `[{frames: [{module_index: 0, ip: "0xdecafc0ffe", trust: "scan"}]}]`
+    bugs:
+      - https://bugzilla.mozilla.org/11137353
+    data_reviews:
+      - http://example.com/reviews
+    notification_emails:
+      - CHANGE-ME@example.com
+    expires: never
+    structure:
+      type: array
+      items:
+        type: object
+        properties:
+          frames:
+            type: array
+            items:
+              type: object
+              properties:
+                module_index:
+                  type: number
+                ip:
+                  type: string
+                trust:
+                  type: string

--- a/tests/test_rust.py
+++ b/tests/test_rust.py
@@ -275,21 +275,15 @@ def test_object_metric(tmp_path):
         content = " ".join(content.split())
 
         assert "ObjectMetric<ThreadsObject>" in content
-        assert "ObjectMetric<ThreadsObject>" in content
-        assert (
-            "pub struct ThreadsObjectItem { "
-            "frames: ThreadsObjectItemItemFrames, "
-            "}" in content
-        )
+        assert "pub struct ThreadsObjectItem { " in content
+        assert "frames: ThreadsObjectItemItemFrames, }" in content
         assert (
             "pub type ThreadsObjectItemItemFrames = "
             "Vec<ThreadsObjectItemItemFramesItem>;" in content
         )
 
-        assert (
-            "pub struct ThreadsObjectItemItemFramesItem { "
-            "module_index: Option<i64>, "
-            "ip: Option<String>, "
-            "trust: Option<String>, "
-            "}" in content
-        )
+        assert "pub struct ThreadsObjectItemItemFramesItem { " in content
+        assert "module_index: Option<i64>, " in content
+        assert "ip: Option<String>, " in content
+        assert "trust: Option<String>, " in content
+        assert "}" in content

--- a/tests/test_rust.py
+++ b/tests/test_rust.py
@@ -102,8 +102,9 @@ def test_ping_parser(tmp_path):
 def test_rust_generator():
     kdf = rust.rust_datatypes_filter
 
-    assert kdf("\n") == '"\n".into()'
-    assert kdf([42, "\n"]) == 'vec![42, "\n".into()]'
+    # The Rust datatypes filter encodes strings using JSON-escaping
+    assert kdf("\n") == '"\\n".into()'
+    assert kdf([42, "\n"]) == 'vec![42, "\\n".into()]'
     assert kdf(metrics.Lifetime.ping) == "Lifetime::Ping"
 
 

--- a/tests/test_rust.py
+++ b/tests/test_rust.py
@@ -255,3 +255,41 @@ def test_event_extra_keys_with_types(tmp_path):
             "const ALLOWED_KEYS: &'static [&'static str] = "
             '&["enabled", "preference", "swapped"];' in content
         )
+
+
+def test_object_metric(tmp_path):
+    """
+    Assert that an object metric is created.
+    """
+    translate.translate(
+        ROOT / "data" / "object.yaml",
+        "rust",
+        tmp_path,
+        {"namespace": "Foo"},
+    )
+
+    assert set(x.name for x in tmp_path.iterdir()) == set(["glean_metrics.rs"])
+
+    with (tmp_path / "glean_metrics.rs").open("r", encoding="utf-8") as fd:
+        content = fd.read()
+        content = " ".join(content.split())
+
+        assert "ObjectMetric<ThreadsObject>" in content
+        assert "ObjectMetric<ThreadsObject>" in content
+        assert (
+            "pub struct ThreadsObjectItem { "
+            "frames: ThreadsObjectItemItemFrames, "
+            "}" in content
+        )
+        assert (
+            "pub type ThreadsObjectItemItemFrames = "
+            "Vec<ThreadsObjectItemItemFramesItem>;" in content
+        )
+
+        assert (
+            "pub struct ThreadsObjectItemItemFramesItem { "
+            "module_index: Option<i64>, "
+            "ip: Option<String>, "
+            "trust: Option<String>, "
+            "}" in content
+        )


### PR DESCRIPTION
This is the most bare-bones version for now.
It validates the `structure` and then generates the corresponding Rust code.