### PR TITLE
Bug 1834596 - Add `stored_content` as an alias for Cat 3 data

### DIFF
--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -29,7 +29,8 @@ class Lifetime(enum.Enum):
 class DataSensitivity(enum.Enum):
     technical = 1
     interaction = 2
-    web_activity = 3
+    stored_content = 3
+    web_activity = 3  # Old, deprecated name
     highly_sensitive = 4
 
 

--- a/glean_parser/schemas/metrics.2-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.2-0-0.schema.yaml
@@ -483,27 +483,60 @@ definitions:
             tabs, addons, or windows a user has open; uses of specific Firefox
             features; session length, scrolls and clicks; and the status of
             discrete user preferences.
+            It also includes information about the user's in-product journeys
+            and product choices helpful to understand engagement (attitudes).
+            For example, selections of add-ons or tiles to determine
+            potential interest categories etc.
 
-          - **Category 3: Web activity data:** (`web_activity`) Information
-            about user web browsing that could be considered sensitive. Examples
-            include users’ specific web browsing history; general information
-            about their web browsing history (such as TLDs or categories of
-            webpages visited over time); and potentially certain types of
-            interaction data about specific webpages visited.
+          - **Category 3: Stored Content & Communications:**
+            (`stored_content`, formerly Web activity data, `web_activity`)
+            Information about what people store, sync, communicate or connect to
+            where the information is generally considered to be more sensitive
+            and personal in nature.
+            Examples include users' saved URLs or URL history,
+            specific web browsing history, general information
+            about their web browsing history
+            (such as TLDs or categories of webpages visited over time)
+            and potentially certain types of interaction data
+            about specific web pages or stories visited
+            (such as highlighted portions of a story).
+            It also includes information such as content saved by users to
+            an individual account like saved URLs, tags, notes, passwords
+            and files as well as communications that users have with one another
+            through a Mozilla service.
 
-          - **Category 4: Highly sensitive data:** (`highly_sensitive`)
+          - **Category 4: Highly sensitive data
+            or clearly identifiable personal data:** (`highly_sensitive`)
+
             Information that directly identifies a person, or if combined with
-            other data could identify a person. Examples include e-mail,
-            usernames, identifiers such as google ad id, apple id, fxaccount,
-            city or country (unless small ones are explicitly filtered out), or
-            certain cookies. It may be embedded within specific website content,
-            such as memory contents, dumps, captures of screen data, or DOM
-            data.
+            other data could identify a person.
+            This data may be embedded within specific website content,
+            such as memory contents, dumps, captures of screen data,
+            or DOM data.
+            Examples include account registration data like name, password,
+            and email address associated with an account,
+            payment data in connection with subscriptions or donations,
+            contact information such as phone numbers or mailing addresses,
+            email addresses associated with surveys, promotions
+            and customer support contacts.
+            It also includes any data from different categories that,
+            when combined, can identify a person, device, household or account.
+            For example Category 1 log data combined with Category 3 saved URLs.
+            Additional examples are: voice audio commands
+            (including a voice audio file), speech-to-text or text-to-speech
+            (including transcripts), biometric data, demographic information,
+            and precise location data associated with a persistent identifier,
+            individual or small population cohorts.
+            This is location inferred or determined from mechanisms
+            other than IP such as wi-fi access points, Bluetooth beacons,
+            cell phone towers or provided directly to us,
+            such as in a survey or a profile.
         type: array
         items:
           enum:
             - technical
             - interaction
+            - stored_content
             - web_activity
             - highly_sensitive
           type: string
@@ -687,11 +720,13 @@ additionalProperties:
 
             data_sensitivity:
               description: >
-                Text metrics require Category 3 (`web_activity`)
+                Text metrics require Category 3
+                (`stored_content` / `web_activity`)
                 or Category 4 (`highly_sensitive`).
               type: array
               items:
                 enum:
+                  - stored_content
                   - web_activity
                   - highly_sensitive
 

--- a/tests/data/text.yaml
+++ b/tests/data/text.yaml
@@ -39,6 +39,6 @@ valid.text:
       - CHANGE-ME@example.com
     expires: 2100-01-01
     data_sensitivity:
-      - web_activity
+      - stored_content
     no_lint:
       - EXPIRATION_DATE_TOO_FAR

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -905,7 +905,7 @@ def test_text_valid():
     assert all_metrics.value["valid.text"]["lifetime"].lifetime == metrics.Lifetime.ping
 
     assert all_metrics.value["valid.text"]["sensitivity"].data_sensitivity == [
-        metrics.DataSensitivity.web_activity
+        metrics.DataSensitivity.stored_content
     ]
 
 

--- a/tools/extract_data_categories.py
+++ b/tools/extract_data_categories.py
@@ -48,7 +48,7 @@ QUESTION = "what collection type of data do the requested measurements fall unde
 CATEGORY_MAP = {
     1: "technical",
     2: "interaction",
-    3: "web_activity",
+    3: "stored_content",
     4: "highly_sensitive",
 }
 


### PR DESCRIPTION
This is the newer name. Adjusted the text as well.

---

`stored_content` is short, but is missing the `& Communications` part of the category.
but `stored_content_communications` felt so wordy.

:chutten, wdyt?
