### PR TITLE
Bug 1827852 - Allow metadata to configure precise timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - BREAKING CHANGE: Dropped support for Python 3.6 ([#615](https://github.com/mozilla/glean_parser/issues/615))
+- Allow metadata to configure precise timestamps in pings ([#592](https://github.com/mozilla/glean_parser/pull/592))
 
 ## 8.1.1
 

--- a/glean_parser/pings.py
+++ b/glean_parser/pings.py
@@ -44,6 +44,7 @@ class Ping:
         if metadata is None:
             metadata = {}
         self.metadata = metadata
+        self.precise_timestamps = self.metadata.get("precise_timestamps", True)
         if data_reviews is None:
             data_reviews = []
         self.data_reviews = data_reviews
@@ -88,6 +89,7 @@ class Ping:
     def _serialize_input(self) -> Dict[str, util.JSONType]:
         d = self.serialize()
         modified_dict = util.remove_output_params(d, "defined_in")
+        modified_dict = util.remove_output_params(modified_dict, "precise_timestamps")
         return modified_dict
 
     def identifier(self) -> str:

--- a/glean_parser/schemas/pings.2-0-0.schema.yaml
+++ b/glean_parser/schemas/pings.2-0-0.schema.yaml
@@ -76,6 +76,15 @@ additionalProperties:
           items:
             type: string
             maxLength: 80
+        precise_timestamps:
+          title: Precise Timestamps
+          description: |
+            When `true` Glean uses millisecond-precise timestamps for
+            the ping's start/end time (the default).
+            When `false` Glean uses minute-precise timestamps for
+            the ping's start/end time.
+          type: boolean
+
       default: {}
 
     include_client_id:

--- a/glean_parser/templates/rust.jinja2
+++ b/glean_parser/templates/rust.jinja2
@@ -44,7 +44,7 @@ impl ExtraKeys for {{ obj.name|Camelize }}{{ suffix }} {
 /// {{ obj.description|wordwrap() | replace('\n', '\n/// ') }}
 #[rustfmt::skip]
 pub static {{ obj.name|snake_case }}: ::glean::private::__export::Lazy<::glean::private::PingType> =
-    ::glean::private::__export::Lazy::new(|| ::glean::private::PingType::new("{{ obj.name }}", {{ obj.include_client_id|rust }}, {{ obj.send_if_empty|rust }}, {{ obj.reason_codes|rust }}));
+    ::glean::private::__export::Lazy::new(|| ::glean::private::PingType::new("{{ obj.name }}", {{ obj.include_client_id|rust }}, {{ obj.send_if_empty|rust }}, {{ obj.precise_timestamps|rust }}, {{ obj.reason_codes|rust }}));
 {% endfor %}
 {% else %}
 pub mod {{ category.name|snake_case }} {

--- a/glean_parser/templates/swift.jinja2
+++ b/glean_parser/templates/swift.jinja2
@@ -95,6 +95,7 @@ extension {{ namespace }} {
             name: {{ obj.name|swift }},
             includeClientId: {{obj.include_client_id|swift}},
             sendIfEmpty: {{obj.send_if_empty|swift}},
+            preciseTimestamps: {{obj.precise_timestamps|swift}},
             reasonCodes: {{obj.reason_codes|swift}}
         )
 

--- a/glean_parser/util.py
+++ b/glean_parser/util.py
@@ -524,6 +524,7 @@ ping_args = [
     "name",
     "include_client_id",
     "send_if_empty",
+    "precise_timestamps",
     "reason_codes",
 ]
 


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
