### PR TITLE
Bug 1848902 - Drop MarkupSafe dependency version restriction

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ requirements = [
     "Click>=7",
     "diskcache>=4",
     "Jinja2>=2.10.1",
-    "MarkupSafe>=1.1.1,<=2.0.1",
     "jsonschema>=3.0.2",
     "PyYAML>=5.3.1",
 ]


### PR DESCRIPTION
We added that a while ago because MarkupSafe 2.1 dropped Python 3.6 support and m-c required <2.
Therefore this restriction gaves us a range of versions to work with.

Since then we dropped Python 3.6 support anyway. And hopefully this should work in m-c too.
