### PR TITLE
chore: Use shasum with algorithm selection instead of sha256sum

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ install: clean ## install the package to the active Python's site-packages
 
 install-kotlin-linters: ## install ktlint and detekt for linting Kotlin output
 	test -f ktlint || curl -sSLO https://github.com/shyiko/ktlint/releases/download/0.29.0/ktlint
-	echo "03c9f9f78f80bcdb44c292d95e4d9abf221daf5e377673c1b6675a8003eab94d *ktlint" | sha256sum -c -
+	echo "03c9f9f78f80bcdb44c292d95e4d9abf221daf5e377673c1b6675a8003eab94d *ktlint" | shasum -a256 -c -
 	chmod a+x ktlint
 	test -f detekt-cli.jar || curl -sSL --output "detekt-cli.jar" https://github.com/detekt/detekt/releases/download/v1.16.0/detekt-cli-1.16.0-all.jar
-	echo "dd63aae60cce4b0516ffc11d31b6280d4010ab481754c7e49b2c9e78db877ca4 *detekt-cli.jar" | sha256sum -c -
+	echo "dd63aae60cce4b0516ffc11d31b6280d4010ab481754c7e49b2c9e78db877ca4 *detekt-cli.jar" | shasum -a256 -c -


### PR DESCRIPTION
sha256sum is not available by default on macOS, but shasum is.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
