### PR TITLE
Bug 1855046 - Allow unit only for the quantity metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - BREAKING CHANE: `ping` lifetime metrics on the events ping are now disallowed ([#625](https://github.com/mozilla/glean_parser/pull/625))
+- Disallow `unit` field for anything but quantity ([#630](https://github.com/mozilla/glean_parser/pull/630)).
+  Note that this was already considered the case, now the code enforces it.
 
 ## 9.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- BREAKING CHANE: `ping` lifetime metrics on the events ping are now disallowed ([#625](https://github.com/mozilla/glean_parser/pull/625))
+
 ## 9.0.0
 
 - BREAKING CHANGE: Dropped support for Python 3.6 ([#615](https://github.com/mozilla/glean_parser/issues/615))

--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -55,7 +55,6 @@ class Metric:
         disabled: bool = False,
         lifetime: str = "ping",
         send_in_pings: Optional[List[str]] = None,
-        unit: Optional[str] = None,
         gecko_datapoint: str = "",
         no_lint: Optional[List[str]] = None,
         data_sensitivity: Optional[List[str]] = None,
@@ -86,8 +85,6 @@ class Metric:
         if send_in_pings is None:
             send_in_pings = ["default"]
         self.send_in_pings = send_in_pings
-        if unit is not None:
-            self.unit = unit
         self.gecko_datapoint = gecko_datapoint
         if no_lint is None:
             no_lint = []
@@ -236,6 +233,10 @@ class Counter(Metric):
 
 class Quantity(Metric):
     typename = "quantity"
+
+    def __init__(self, *args, **kwargs):
+        self.unit = kwargs.pop("unit")
+        Metric.__init__(self, *args, **kwargs)
 
 
 class TimeUnit(enum.Enum):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1039,3 +1039,18 @@ def test_no_internal_fields_exposed():
         indent=2,
     )
     assert expected_json == out_json
+
+
+def test_unit_not_accepted_on_nonquantity():
+    results = parser.parse_objects(
+        [
+            util.add_required(
+                {
+                    "category": {"metric": {"type": "counter", "unit": "quantillions"}},
+                }
+            ),
+        ]
+    )
+    errs = list(results)
+    assert len(errs) == 1
+    assert "got an unexpected keyword argument 'unit'" in str(errs[0])


### PR DESCRIPTION
This is implemented the same way time_unit is implemented for others: The specific metric class takes the argument, not the generic one.

Because the schema enforces `unit` to be required for `quantity` we can just `pop` it with the guarantee it's there.

The error message for other metrics if they do set `unit` is less nice:

    Metric.__init__() got an unexpected keyword argument 'unit'

But that's in line with what `time_unit` also does.

---

~~10 minute explore of what it takes.~~
~~Needs a changelog entry and probably an additional test to cover it. I'd appreciate if someone is taking this off my hands.~~