### PR TITLE
Bug 1857924 - Add an integration-like test for the javascript_server logger

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ commands:
           command: CC=broken_compiler pip install . --user
       - run:
           name: test
-          command: make test
+          command: make test-full
 
   lint:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,21 +94,21 @@ commands:
 jobs:
   build-37:
     docker:
-      - image: cimg/python:3.7
+      - image: cimg/python:3.7-node
     steps:
       - test-start
       - test-python-version
 
   build-38:
     docker:
-      - image: cimg/python:3.8
+      - image: cimg/python:3.8-node
     steps:
       - test-start
       - test-python-version
 
   build-38-min:
     docker:
-      - image: cimg/python:3.8
+      - image: cimg/python:3.8-node
     steps:
       - test-start
       - test-min-requirements
@@ -116,14 +116,14 @@ jobs:
 
   build-39:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.9-node
     steps:
       - test-start
       - test-python-version
 
   build-310:
     docker:
-      - image: cimg/python:3.10
+      - image: cimg/python:3.10-node
     steps:
       - test-start
       - test-python-version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,15 +37,17 @@ commands:
         default: "requirements_dev.txt"
     steps:
       - run:
-          name: install
+          name: Install required native dependencies
           command: |
             pip install --progress-bar off --user -U -r <<parameters.requirements-file>>
             sudo apt update -q
             sudo apt upgrade -q
-            sudo apt install openjdk-11-jdk-headless
+            sudo apt install \
+                --yes --no-install-recommends \
+                openjdk-11-jdk-headless
             make install-kotlin-linters
       - run:
-          name: install
+          name: Install glean_parser
           # Set CC to something that isn't a working compiler so we
           # can detect if any of the dependencies require a compiler
           # to be installed. We can't count on a working compiler
@@ -161,7 +163,7 @@ jobs:
       - attach_workspace:
           at: docs/_build
       - run:
-          name: install
+          name: install gh-pages
           command: |
             npm install -g --silent gh-pages@2.0.1
             git config user.email "glean-ci@nowhere.com"
@@ -185,7 +187,7 @@ jobs:
           command: |
             pip install --upgrade --user pip
       - run:
-          name: install
+          name: install Python dependencies
           command: |
             pip install --user -U -r requirements_dev.txt
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,8 @@ commands:
             sudo apt upgrade -q
             sudo apt install \
                 --yes --no-install-recommends \
-                openjdk-11-jdk-headless
+                openjdk-11-jdk-headless \
+                ruby
             make install-kotlin-linters
       - run:
           name: Install glean_parser

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ test: ## run tests quickly with the default Python
 	py.test
 
 test-full:  ## run tests, including those with additional dependencies
-	py.test --run-web-tests --run-node-tests
+	py.test --run-web-tests --run-node-tests --run-ruby-tests
 
 coverage: ## check code coverage quickly with the default Python
 	coverage run --source glean_parser -m pytest

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,10 @@ fmt: ## autoformat files
 	python3 -m black glean_parser tests setup.py
 
 test: ## run tests quickly with the default Python
-	py.test --run-web-tests
+	py.test
+
+test-full:  ## run tests, including those with additional dependencies
+	py.test --run-web-tests --run-node-tests
 
 coverage: ## check code coverage quickly with the default Python
 	coverage run --source glean_parser -m pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,12 +8,23 @@ def pytest_addoption(parser):
         default=False,
         help="Run tests that require a web connection",
     )
+    parser.addoption(
+        "--run-node-tests",
+        action="store_true",
+        default=False,
+        help="Run tests that require node.js",
+    )
 
 
 def pytest_collection_modifyitems(config, items):
-    if config.getoption("--run-web-tests"):
-        return
-    skip_web = pytest.mark.skip(reason="Need --run-web-tests option to run")
-    for item in items:
-        if "web_dependency" in item.keywords:
-            item.add_marker(skip_web)
+    if not config.getoption("--run-web-tests"):
+        skip_web = pytest.mark.skip(reason="Need --run-web-tests option to run")
+        for item in items:
+            if "web_dependency" in item.keywords:
+                item.add_marker(skip_web)
+
+    if not config.getoption("--run-node-tests"):
+        skip_node = pytest.mark.skip(reason="Need --run-node-tests option to run")
+        for item in items:
+            if "node_dependency" in item.keywords:
+                item.add_marker(skip_node)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,12 @@ def pytest_addoption(parser):
         default=False,
         help="Run tests that require node.js",
     )
+    parser.addoption(
+        "--run-ruby-tests",
+        action="store_true",
+        default=False,
+        help="Run tests that require Ruby",
+    )
 
 
 def pytest_collection_modifyitems(config, items):
@@ -28,3 +34,9 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "node_dependency" in item.keywords:
                 item.add_marker(skip_node)
+
+    if not config.getoption("--run-ruby-tests"):
+        skip_ruby = pytest.mark.skip(reason="Need --run-ruby-tests option to run")
+        for item in items:
+            if "ruby_dependency" in item.keywords:
+                item.add_marker(skip_ruby)

--- a/tests/test-js/package.json
+++ b/tests/test-js/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "glean_test",
+  "type": "module",
+  "version": "1.0.0",
+  "license": "MPL-2.0",
+  "dependencies": {
+    "mozlog": "^3.0.2",
+    "uuid": "^9.0.1"
+  }
+}

--- a/tests/test-js/test.js.tmpl
+++ b/tests/test-js/test.js.tmpl
@@ -1,25 +1,17 @@
 import { createAccountsEventsEvent } from ".//* IMPORT */";
 
-class StringLogger {
-  constructor() {
-    this._buffer = "";
-  }
-
+class PrintLogger {
   write(msg) {
-    this._buffer += msg;
-  }
-
-  get() {
-    return this._buffer;
+    console.log(msg);
   }
 }
 
-let string_logger = new StringLogger;
+let logger = new PrintLogger;
 
 let logger_options = {
   app: "glean-test",
   fmt: 'pretty',
-  stream: string_logger,
+  stream: logger,
 };
 let events = /* FACTORY */({
   applicationId: "glean.test",
@@ -29,7 +21,3 @@ let events = /* FACTORY */({
 });
 
 /* CODE */
-
-let buf = string_logger.get();
-let log = JSON.parse(buf);
-console.log(log.Fields.payload);

--- a/tests/test-js/test.js.tmpl
+++ b/tests/test-js/test.js.tmpl
@@ -1,0 +1,35 @@
+import { createAccountsEventsEvent } from ".//* IMPORT */";
+
+class StringLogger {
+  constructor() {
+    this._buffer = "";
+  }
+
+  write(msg) {
+    this._buffer += msg;
+  }
+
+  get() {
+    return this._buffer;
+  }
+}
+
+let string_logger = new StringLogger;
+
+let logger_options = {
+  app: "glean-test",
+  fmt: 'pretty',
+  stream: string_logger,
+};
+let events = /* FACTORY */({
+  applicationId: "glean.test",
+  appDisplayVersion: "0.0.1",
+  channel: "testing",
+  logger_options
+});
+
+/* CODE */
+
+let buf = string_logger.get();
+let log = JSON.parse(buf);
+console.log(log.Fields.payload);

--- a/tests/test-rb/test.rb.tmpl
+++ b/tests/test-rb/test.rb.tmpl
@@ -1,0 +1,9 @@
+require_relative ".//* IMPORT */"
+
+events = Glean::GleanEventsLogger.new(
+  app_id: "glean.test",
+  app_display_version: "0.0.1",
+  app_channel: "testing",
+  logger_options: $stdout
+)
+/* CODE */

--- a/tests/test_javascript_server.py
+++ b/tests/test_javascript_server.py
@@ -4,9 +4,14 @@
 # http://creativecommons.org/publicdomain/zero/1.0/
 
 from pathlib import Path
+import io
+import pytest
+import shutil
+import subprocess
 
 from glean_parser import javascript_server
 from glean_parser import translate
+from glean_parser import validate_ping
 
 
 ROOT = Path(__file__).parent
@@ -67,3 +72,61 @@ def test_generate_ping_factory_method():
     expected_result = "createAccountsEventsEvent"
     result = javascript_server.generate_ping_factory_method(ping)
     assert result == expected_result
+
+
+def run_logger(code_dir, import_file, factory, code):
+    """
+    Run the JavaScript logger with a mocked logger
+    that just prints the ping payload to STDOUT.
+    """
+
+    shutil.copy(ROOT / "test-js" / "package.json", code_dir)
+    subprocess.check_call(["npm", "install"], cwd=code_dir)
+
+    tmpl_code = ""
+    with open(ROOT / "test-js" / "test.js.tmpl", "r") as fp:
+        tmpl_code = fp.read()
+
+    tmpl_code = (
+        tmpl_code.replace("/* IMPORT */", import_file)
+        .replace("/* FACTORY */", factory)
+        .replace("/* CODE */", code)
+    )
+
+    with open(code_dir / "test.js", "w") as fp:
+        fp.write(tmpl_code)
+
+    return subprocess.check_output(["node", "test.js"], cwd=code_dir).decode("utf-8")
+
+
+@pytest.mark.web_dependency
+def test_run_logging(tmpdir):
+    tmpdir = Path(str(tmpdir))
+
+    translate.translate(
+        [
+            ROOT / "data" / "fxa-server-pings.yaml",
+            ROOT / "data" / "fxa-server-metrics.yaml",
+        ],
+        "javascript_server",
+        tmpdir,
+    )
+
+    factory = "createAccountsEventsEvent"
+    code = """
+events.record({ user_agent: "glean-test/1.0", event_name: "testing" });
+    """
+
+    payload = run_logger(tmpdir, "server_events.js", factory, code)
+
+    schema_url = (
+        "https://raw.githubusercontent.com/mozilla-services/"
+        "mozilla-pipeline-schemas/main/"
+        "schemas/glean/glean/glean.1.schema.json"
+    )
+
+    input = io.StringIO(payload)
+    output = io.StringIO()
+    assert (
+        validate_ping.validate_ping(input, output, schema_url=schema_url) == 0
+    ), output.getvalue()

--- a/tests/test_javascript_server.py
+++ b/tests/test_javascript_server.py
@@ -5,6 +5,7 @@
 
 from pathlib import Path
 import io
+import json
 import pytest
 import shutil
 import subprocess
@@ -117,7 +118,16 @@ def test_run_logging(tmpdir):
 events.record({ user_agent: "glean-test/1.0", event_name: "testing" });
     """
 
-    payload = run_logger(tmpdir, "server_events.js", factory, code)
+    logged_output = run_logger(tmpdir, "server_events.js", factory, code)
+    logged_output = json.loads(logged_output)
+    fields = logged_output["Fields"]
+    payload = fields["payload"]
+
+    assert "glean-server-event" == logged_output["Type"]
+    assert "glean.test" == fields["document_namespace"]
+    assert "accounts-events" == fields["document_type"]
+    assert "1" == fields["document_version"]
+    assert "glean-test/1.0" == fields["user_agent"]
 
     schema_url = (
         "https://raw.githubusercontent.com/mozilla-services/"

--- a/tests/test_javascript_server.py
+++ b/tests/test_javascript_server.py
@@ -99,7 +99,7 @@ def run_logger(code_dir, import_file, factory, code):
     return subprocess.check_output(["node", "test.js"], cwd=code_dir).decode("utf-8")
 
 
-@pytest.mark.web_dependency
+@pytest.mark.node_dependency
 def test_run_logging(tmpdir):
     tmpdir = Path(str(tmpdir))
 

--- a/tests/test_ruby_server.py
+++ b/tests/test_ruby_server.py
@@ -4,9 +4,14 @@
 # http://creativecommons.org/publicdomain/zero/1.0/
 
 from pathlib import Path
+import io
+import json
+import pytest
+import subprocess
 
 import glean_parser
 from glean_parser import translate
+from glean_parser import validate_ping
 
 ROOT = Path(__file__).parent
 
@@ -102,3 +107,69 @@ def test_parser_rb_server(tmpdir):
         current_version=f"glean_parser v{glean_parser.__version__}"
     )
     assert content == compare
+
+
+def run_logger(code_dir, import_file, code):
+    """
+    Run the Ruby logger with a mocked logger
+    that just prints the ping payload to STDOUT.
+    """
+
+    tmpl_code = ""
+    with open(ROOT / "test-rb" / "test.rb.tmpl", "r") as fp:
+        tmpl_code = fp.read()
+
+    tmpl_code = tmpl_code.replace("/* IMPORT */", import_file).replace(
+        "/* CODE */", code
+    )
+
+    with open(code_dir / "test.rb", "w") as fp:
+        fp.write(tmpl_code)
+
+    return subprocess.check_output(["ruby", "test.rb"], cwd=code_dir).decode("utf-8")
+
+
+@pytest.mark.ruby_dependency
+def test_run_logging(tmpdir):
+    tmpdir = Path(str(tmpdir))
+
+    translate.translate(
+        [
+            ROOT / "data" / "ruby_server_metrics.yaml",
+        ],
+        "ruby_server",
+        tmpdir,
+    )
+
+    code = """
+events.backend_object_update.record(
+    object_type: "type",
+    object_state: "state",
+    identifiers_fxa_account_id: nil,
+    user_agent: "glean-test/1.0",
+    ip_address: "127.0.0.1"
+)
+    """
+
+    logged_output = run_logger(tmpdir, "server_events.rb", code)
+    logged_output = json.loads(logged_output)
+    fields = logged_output["Fields"]
+    payload = fields["payload"]
+
+    assert "glean-server-event" == logged_output["Type"]
+    assert "glean.test" == fields["document_namespace"]
+    assert "events" == fields["document_type"]
+    assert "1" == fields["document_version"]
+    assert "glean-test/1.0" == fields["user_agent"]
+
+    schema_url = (
+        "https://raw.githubusercontent.com/mozilla-services/"
+        "mozilla-pipeline-schemas/main/"
+        "schemas/glean/glean/glean.1.schema.json"
+    )
+
+    input = io.StringIO(payload)
+    output = io.StringIO()
+    assert (
+        validate_ping.validate_ping(input, output, schema_url=schema_url) == 0
+    ), output.getvalue()


### PR DESCRIPTION
This is what I had in mind for testing the JavaScript server part behaves as expected.
It runs an actual script using `node`, logging to stdout and checking that output against the schema.