### PR TITLE
Remove use of deprecated `RefResolver`

### DIFF
--- a/glean_parser/parser.py
+++ b/glean_parser/parser.py
@@ -111,11 +111,10 @@ def _load_schemas() -> Dict[str, Tuple[Any, Any]]:
     schemas = {}
     for schema_path in SCHEMAS_DIR.glob("*.yaml"):
         schema = util.load_yaml_or_json(schema_path)
-        resolver = util.get_null_resolver(schema)
         validator_class = jsonschema.validators.validator_for(schema)
         _update_validator(validator_class)
         validator_class.check_schema(schema)
-        validator = validator_class(schema, resolver=resolver)
+        validator = validator_class(schema)
         schemas[schema["$id"]] = (schema, validator)
     return schemas
 

--- a/glean_parser/util.py
+++ b/glean_parser/util.py
@@ -16,7 +16,6 @@ import urllib.request
 import appdirs  # type: ignore
 import diskcache  # type: ignore
 import jinja2
-import jsonschema  # type: ignore
 from jsonschema import _utils  # type: ignore
 import yaml
 
@@ -238,23 +237,6 @@ def keep_value(f):
         return ValueKeepingGenerator(f(*args, **kwargs))
 
     return g
-
-
-def get_null_resolver(schema):
-    """
-    Returns a JSON Pointer resolver that does nothing.
-
-    This lets us handle the moz: URLs in our schemas.
-    """
-
-    class NullResolver(jsonschema.RefResolver):
-        def resolve_remote(self, uri):
-            if uri in self.store:
-                return self.store[uri]
-            if uri == "":
-                return self.referrer
-
-    return NullResolver.from_schema(schema)
 
 
 def fetch_remote_url(url: str, cache: bool = True):

--- a/glean_parser/validate_ping.py
+++ b/glean_parser/validate_ping.py
@@ -32,12 +32,10 @@ def _get_ping_schema(schema_url):
 def _validate_ping(ins, outs, schema_url):
     schema = _get_ping_schema(schema_url)
 
-    resolver = util.get_null_resolver(schema)
-
     document = json.load(ins)
 
     validator_class = jsonschema.validators.validator_for(schema)
-    validator = validator_class(schema, resolver=resolver)
+    validator = validator_class(schema)
 
     has_error = 0
     for error in validator.iter_errors(document):


### PR DESCRIPTION
`jsonschema.RefResolver` is deprecated in recent versions and replaced by a whole new package called `referencing`.
However it seems nothing is blowing up if we just leave out that resolver. Let's go with that.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
