### PR TITLE
Allow `unit` field for custom distribution again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Allow `unit` field for custom distribution again ([#633](https://github.com/mozilla/glean_parser/pull/633))
+
 ## 10.0.0
 
 - Add Ruby log outputter (`ruby_server`) ([#620](https://github.com/mozilla/glean_parser/pull/620))

--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -297,6 +297,7 @@ class CustomDistribution(Metric):
         self.histogram_type = getattr(
             HistogramType, kwargs.pop("histogram_type", "exponential")
         )
+        self.unit = kwargs.pop("unit", None)
         super().__init__(*args, **kwargs)
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1054,3 +1054,25 @@ def test_unit_not_accepted_on_nonquantity():
     errs = list(results)
     assert len(errs) == 1
     assert "got an unexpected keyword argument 'unit'" in str(errs[0])
+
+
+def test_unit_accepted_on_custom_dist():
+    results = parser.parse_objects(
+        [
+            util.add_required(
+                {
+                    "category": {
+                        "metric": {
+                            "type": "custom_distribution",
+                            "unit": "quantillions",
+                            "range_max": 100,
+                            "bucket_count": 100,
+                            "histogram_type": "linear",
+                        }
+                    },
+                }
+            ),
+        ]
+    )
+    errs = list(results)
+    assert len(errs) == 0


### PR DESCRIPTION
We specifically document that this field should be used for documentation purposes.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
