### PR TITLE
Allow but warn on `unit` on a string metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Allow `unit` field for string again, but warn about it in the linter ([#634](https://github.com/mozilla/glean_parser/pull/634))
+
 ## 10.0.1
 
 - Allow `unit` field for custom distribution again ([#633](https://github.com/mozilla/glean_parser/pull/633))

--- a/glean_parser/lint.py
+++ b/glean_parser/lint.py
@@ -303,6 +303,15 @@ def check_metric_on_events_lifetime(
         )
 
 
+def check_unit_on_string(
+    metric: metrics.Metric, parser_config: Dict[str, Any]
+) -> LintGenerator:
+    """`unit` was allowed on all metrics and recently disallowed.
+    To unbreak things we had to add it back to `string` metrics, but now warn"""
+    if isinstance(metric, metrics.String) and metric.unit:
+        yield "`unit` not allwed on string metric"
+
+
 def check_redundant_ping(
     pings: pings.Ping, parser_config: Dict[str, Any]
 ) -> LintGenerator:
@@ -384,6 +393,7 @@ METRIC_CHECKS: Dict[
     "EXPIRED": (check_expired_metric, CheckType.warning),
     "OLD_EVENT_API": (check_old_event_api, CheckType.warning),
     "METRIC_ON_EVENTS_LIFETIME": (check_metric_on_events_lifetime, CheckType.error),
+    "UNIT_ON_STRING": (check_unit_on_string, CheckType.warning),
 }
 
 

--- a/glean_parser/lint.py
+++ b/glean_parser/lint.py
@@ -309,7 +309,7 @@ def check_unit_on_string(
     """`unit` was allowed on all metrics and recently disallowed.
     To unbreak things we had to add it back to `string` metrics, but now warn"""
     if isinstance(metric, metrics.String) and metric.unit:
-        yield "`unit` not allwed on string metric"
+        yield "The `unit` property is not allowed for string metrics."
 
 
 def check_redundant_ping(

--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -222,6 +222,11 @@ class Boolean(Metric):
 class String(Metric):
     typename = "string"
 
+    def __init__(self, *args, **kwargs):
+        # Deprecated. Kept here to unbreak stuff.
+        self.unit = kwargs.pop("unit", None)
+        Metric.__init__(self, *args, **kwargs)
+
 
 class StringList(Metric):
     typename = "string_list"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -10,6 +10,7 @@ import textwrap
 
 import pytest
 
+from glean_parser import lint
 from glean_parser import metrics
 from glean_parser import parser
 
@@ -1076,3 +1077,26 @@ def test_unit_accepted_on_custom_dist():
     )
     errs = list(results)
     assert len(errs) == 0
+
+
+def test_unit_accepted_on_string_but_warns():
+    results = parser.parse_objects(
+        [
+            util.add_required(
+                {
+                    "category": {
+                        "metric": {
+                            "type": "string",
+                            "unit": "quantillions",
+                        }
+                    },
+                }
+            ),
+        ]
+    )
+    errs = list(results)
+    assert len(errs) == 0
+
+    nits = lint.lint_metrics(results.value)
+    assert len(nits) == 1
+    assert set(["UNIT_ON_STRING"]) == set(v.check_name for v in nits)


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
