### PR TITLE
Turn a `unit` field on metrics into a warning for most metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Warn about empty or TODO-tagged data reviews in the list ([#634](https://github.com/mozilla/glean_parser/pull/634))
+- Allow `unit` field on all metrics, but warn for all but quantity and custom distribution ([#636](https://github.com/mozilla/glean_parser/pull/636))
 
 ## 10.0.2
 

--- a/glean_parser/lint.py
+++ b/glean_parser/lint.py
@@ -303,13 +303,19 @@ def check_metric_on_events_lifetime(
         )
 
 
-def check_unit_on_string(
+def check_unexpected_unit(
     metric: metrics.Metric, parser_config: Dict[str, Any]
 ) -> LintGenerator:
-    """`unit` was allowed on all metrics and recently disallowed.
-    To unbreak things we had to add it back to `string` metrics, but now warn"""
-    if isinstance(metric, metrics.String) and metric.unit:
-        yield "The `unit` property is not allowed for string metrics."
+    """
+    `unit` was allowed on all metrics and recently disallowed.
+    We now warn about its use on all but quantity metrics.
+    """
+    allowed_types = [metrics.Quantity, metrics.CustomDistribution]
+    if not any([isinstance(metric, ty) for ty in allowed_types]) and metric.unit:
+        yield (
+            "The `unit` property is only allowed for quantity "
+            + "and custom distribution metrics."
+        )
 
 
 def check_empty_datareview(
@@ -403,7 +409,7 @@ METRIC_CHECKS: Dict[
     "EXPIRED": (check_expired_metric, CheckType.warning),
     "OLD_EVENT_API": (check_old_event_api, CheckType.warning),
     "METRIC_ON_EVENTS_LIFETIME": (check_metric_on_events_lifetime, CheckType.error),
-    "UNIT_ON_STRING": (check_unit_on_string, CheckType.warning),
+    "UNEXPECTED_UNIT": (check_unexpected_unit, CheckType.warning),
     "EMPTY_DATAREVIEW": (check_empty_datareview, CheckType.warning),
 }
 

--- a/glean_parser/lint.py
+++ b/glean_parser/lint.py
@@ -308,7 +308,8 @@ def check_unexpected_unit(
 ) -> LintGenerator:
     """
     `unit` was allowed on all metrics and recently disallowed.
-    We now warn about its use on all but quantity metrics.
+    We now warn about its use on all but quantity and custom distribution
+    metrics.
     """
     allowed_types = [metrics.Quantity, metrics.CustomDistribution]
     if not any([isinstance(metric, ty) for ty in allowed_types]) and metric.unit:

--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -55,6 +55,7 @@ class Metric:
         disabled: bool = False,
         lifetime: str = "ping",
         send_in_pings: Optional[List[str]] = None,
+        unit: Optional[str] = None,
         gecko_datapoint: str = "",
         no_lint: Optional[List[str]] = None,
         data_sensitivity: Optional[List[str]] = None,
@@ -85,6 +86,7 @@ class Metric:
         if send_in_pings is None:
             send_in_pings = ["default"]
         self.send_in_pings = send_in_pings
+        self.unit = unit
         self.gecko_datapoint = gecko_datapoint
         if no_lint is None:
             no_lint = []
@@ -175,6 +177,8 @@ class Metric:
                 d[key] = [x.name for x in val]
         del d["name"]
         del d["category"]
+        if not d["unit"]:
+            d.pop("unit")
         d.pop("_config", None)
         d.pop("_generate_enums", None)
         return d
@@ -222,11 +226,6 @@ class Boolean(Metric):
 class String(Metric):
     typename = "string"
 
-    def __init__(self, *args, **kwargs):
-        # Deprecated. Kept here to unbreak stuff.
-        self.unit = kwargs.pop("unit", None)
-        Metric.__init__(self, *args, **kwargs)
-
 
 class StringList(Metric):
     typename = "string_list"
@@ -238,10 +237,6 @@ class Counter(Metric):
 
 class Quantity(Metric):
     typename = "quantity"
-
-    def __init__(self, *args, **kwargs):
-        self.unit = kwargs.pop("unit")
-        Metric.__init__(self, *args, **kwargs)
 
 
 class TimeUnit(enum.Enum):
@@ -302,7 +297,6 @@ class CustomDistribution(Metric):
         self.histogram_type = getattr(
             HistogramType, kwargs.pop("histogram_type", "exponential")
         )
-        self.unit = kwargs.pop("unit", None)
         super().__init__(*args, **kwargs)
 
 

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -535,3 +535,48 @@ def test_empty_datareviews(metric, num_nits):
     assert len(nits) == num_nits
     if num_nits > 0:
         assert set(["EMPTY_DATAREVIEW"]) == set(v.check_name for v in nits)
+
+
+@pytest.mark.parametrize(
+    "metric, num_nits",
+    [
+        ({"metric": {"type": "quantity", "unit": "sheep"}}, 0),
+        (
+            {
+                "metric": {
+                    "type": "custom_distribution",
+                    "unit": "quantillions",
+                    "range_max": 100,
+                    "bucket_count": 100,
+                    "histogram_type": "linear",
+                }
+            },
+            0,
+        ),
+        ({"metric": {"type": "string", "unit": "quantillions"}}, 1),
+        ({"metric": {"type": "counter", "unit": "quantillions"}}, 1),
+        (
+            {
+                "metric": {
+                    "type": "string",
+                    "unit": "quantillions",
+                    "no_lint": ["UNEXPECTED_UNIT"],
+                }
+            },
+            0,
+        ),
+    ],
+)
+def test_unit_on_metrics(metric, num_nits):
+    content = {"category": metric}
+    content = util.add_required(content)
+    all_metrics = parser.parse_objects(content)
+
+    errs = list(all_metrics)
+    assert len(errs) == 0
+
+    nits = lint.lint_metrics(all_metrics.value)
+
+    assert len(nits) == num_nits
+    if num_nits > 0:
+        assert set(["UNEXPECTED_UNIT"]) == set(v.check_name for v in nits)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -187,7 +187,7 @@ def test_no_unit():
         _config={"allow_reserved": True},
     )
 
-    assert not hasattr(event, "unit")
+    assert not event.unit
 
 
 def test_jwe_is_rejected():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -10,7 +10,6 @@ import textwrap
 
 import pytest
 
-from glean_parser import lint
 from glean_parser import metrics
 from glean_parser import parser
 
@@ -1040,63 +1039,3 @@ def test_no_internal_fields_exposed():
         indent=2,
     )
     assert expected_json == out_json
-
-
-def test_unit_not_accepted_on_nonquantity():
-    results = parser.parse_objects(
-        [
-            util.add_required(
-                {
-                    "category": {"metric": {"type": "counter", "unit": "quantillions"}},
-                }
-            ),
-        ]
-    )
-    errs = list(results)
-    assert len(errs) == 1
-    assert "got an unexpected keyword argument 'unit'" in str(errs[0])
-
-
-def test_unit_accepted_on_custom_dist():
-    results = parser.parse_objects(
-        [
-            util.add_required(
-                {
-                    "category": {
-                        "metric": {
-                            "type": "custom_distribution",
-                            "unit": "quantillions",
-                            "range_max": 100,
-                            "bucket_count": 100,
-                            "histogram_type": "linear",
-                        }
-                    },
-                }
-            ),
-        ]
-    )
-    errs = list(results)
-    assert len(errs) == 0
-
-
-def test_unit_accepted_on_string_but_warns():
-    results = parser.parse_objects(
-        [
-            util.add_required(
-                {
-                    "category": {
-                        "metric": {
-                            "type": "string",
-                            "unit": "quantillions",
-                        }
-                    },
-                }
-            ),
-        ]
-    )
-    errs = list(results)
-    assert len(errs) == 0
-
-    nits = lint.lint_metrics(results.value)
-    assert len(nits) == 1
-    assert set(["UNIT_ON_STRING"]) == set(v.check_name for v in nits)


### PR DESCRIPTION
This partially reverts #630 (and subsequent fixes) and should unblock all failures in probe-scraper and co.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
