### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,13 +95,6 @@ commands:
             pip-licenses --fail-on 'GNU General Public License v3 (GPLv3)'
 
 jobs:
-  build-37:
-    docker:
-      - image: cimg/python:3.7-node
-    steps:
-      - test-start
-      - test-python-version
-
   build-38:
     docker:
       - image: cimg/python:3.8-node
@@ -176,7 +169,7 @@ jobs:
 
   pypi-deploy:
     docker:
-      - image: cimg/python:3.7
+      - image: cimg/python:3.8
     steps:
       - checkout
       - run:
@@ -210,10 +203,6 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - build-37:
-          filters:
-            tags:
-              only: /.*/
       - build-38:
           filters:
             tags:
@@ -238,7 +227,7 @@ workflows:
               only: main
       - pypi-deploy:
           requires:
-            - build-37
+            - build-38
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,16 +132,30 @@ jobs:
           root: docs/_build
           paths: html
 
+  build-311:
+    docker:
+      - image: cimg/python:3.11-node
+    steps:
+      - test-start
+      - test-python-version
+
+  build-312:
+    docker:
+      - image: cimg/python:3.12-node
+    steps:
+      - test-start
+      - test-python-version
+
   lint:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.12
     steps:
       - test-start
       - lint
 
   license-check:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.12
     steps:
       - test-start
       - license-check
@@ -216,6 +230,14 @@ workflows:
             tags:
               only: /.*/
       - build-310:
+          filters:
+            tags:
+              only: /.*/
+      - build-311:
+          filters:
+            tags:
+              only: /.*/
+      - build-312:
           filters:
             tags:
               only: /.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add updated logging logic for Ruby Server ([#642](https://github.com/mozilla/glean_parser/pull/642))
 - Add support for event metric type in server-side JavaScript outputter ([DENG-1736](https://mozilla-hub.atlassian.net/browse/DENG-1736))
+- BREAKING CHANGE: Dropped support for Python 3.7 ([#638](https://github.com/mozilla/glean_parser/pull/638))
 
 ## 10.0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add updated logging logic for Ruby Server ([#642](https://github.com/mozilla/glean_parser/pull/642))
 - Add support for event metric type in server-side JavaScript outputter ([DENG-1736](https://mozilla-hub.atlassian.net/browse/DENG-1736))
 - BREAKING CHANGE: Dropped support for Python 3.7 ([#638](https://github.com/mozilla/glean_parser/pull/638))
+- Add official support for Python 3.11+ ([#638](https://github.com/mozilla/glean_parser/pull/638))
 
 ## 10.0.3
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put your
    new functionality into a function with a docstring, and describe
    public-facing features in the docs.
-3. The pull request should work for Python 3.7+ (The CI system
+3. The pull request should work for Python 3.8+ (The CI system
    will take care of testing all of these Python versions).
 4. The pull request should update the changelog in `CHANGELOG.md`.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ code for various integrations, linting and coverage testing.
 
 ## Requirements
 
--   Python 3.7 (or later)
+-   Python 3.8 (or later)
 
 The following library requirements are installed automatically when
 `glean_parser` is installed by `pip`.

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,7 @@
 black==23.3.0
 coverage==7.2.7
-flake8==6.1.0; python_version >= '3.8'
-flake8-bugbear==23.12.2; python_version >= '3.8'
+flake8==6.1.0
+flake8-bugbear==23.12.2
 mypy==1.4.1
 pip
 pytest-runner==5.3.2

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
     description="Parser tools for Mozilla's Glean telemetry",
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ import sys
 from setuptools import setup, find_packages
 
 
-if sys.version_info < (3, 7):
-    print("glean_parser requires at least Python 3.7", file=sys.stderr)
+if sys.version_info < (3, 8):
+    print("glean_parser requires at least Python 3.8", file=sys.stderr)
     sys.exit(1)
 
 
@@ -49,7 +49,6 @@ setup(
         "Intended Audience :: Developers",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
mach is dropping it too: https://bugzilla.mozilla.org/show_bug.cgi?id=1843209

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
