### PR TITLE
fix javascript server template to include defined metrics in the parameter list for named event record calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix javascript_server template to include non-event metric parameters in #record call for event metrics ([#643](https://github.com/mozilla/glean_parser/pull/643))
+
 ## 11.0.0
 
 - Add updated logging logic for Ruby Server ([#642](https://github.com/mozilla/glean_parser/pull/642))

--- a/glean_parser/templates/javascript_server.jinja2
+++ b/glean_parser/templates/javascript_server.jinja2
@@ -237,7 +237,13 @@ class {{ ping|event_class_name(event_metric_exists) }} {
     this.#record({
       user_agent,
       ip_address,
-      identifiers_fxa_account_id,
+      {% for metric_type, metrics in metrics_by_type.items() %}
+      {% if metric_type != 'event' %}
+      {% for metric in metrics %}
+      {{ metric|metric_argument_name }},
+      {% endfor %}
+      {% endif %}
+      {% endfor %}
       event
     });
   }


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly

In the process of understanding how server implementations worked, I was creating my own metrics.yaml and pings.yaml configurations and noticed that the javascript_server output included "identifiers_fxa_account_id" even though that was not defined in my metrics.yaml.

Digging into the template, I realized that the other metrics that I did define were parameters on the methods for the event type metrics I had defined, but they were not passed into the record call.
