### PR TITLE
Bug 1762860 - Python: Make arguments more clear in the help text

### DIFF
--- a/glean_parser/__main__.py
+++ b/glean_parser/__main__.py
@@ -303,12 +303,14 @@ def coverage(coverage_file, metrics_files, format, output, allow_reserved):
 )
 def data_review_request(bug, metrics_files):
     """
-    Generate a skeleton Data Review Request for all metrics in metrics_files
-    whose bug_numbers fields contain the provided bug string.
+    Generate a skeleton Data Review Request for all metrics in METRICS_FILES
+    whose bug_numbers fields contain the provided BUG string.
+
     For example, providing "1694739" matches
     "https://bugzilla.mozilla.org/show_bug.cgi?id=1694739".
     To ensure substrings don't match, the provided bug string will match only
     if it is bounded by non-word characters.
+
     Prints to stdout.
     """
     sys.exit(mod_data_review.generate(bug, [Path(x) for x in metrics_files]))


### PR DESCRIPTION
click.argument doesn't have a way to directly document arguments. They refer to using their name directly in the help text instead. See https://click.palletsprojects.com/en/7.x/documentation/#documenting-arguments

[doc only]

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
