### PR TITLE
Replace all uses of `tmpdir` in tests with modern `tmp_path`

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,7 +25,7 @@ def test_basic_help():
     assert "Show this message and exit." in help_result.output
 
 
-def test_translate(tmpdir):
+def test_translate(tmp_path):
     """Test the 'translate' command."""
     runner = CliRunner()
     result = runner.invoke(
@@ -34,7 +34,7 @@ def test_translate(tmpdir):
             "translate",
             str(ROOT / "data" / "core.yaml"),
             "-o",
-            str(tmpdir),
+            str(tmp_path),
             "-f",
             "kotlin",
             "-s",
@@ -43,7 +43,7 @@ def test_translate(tmpdir):
         ],
     )
     assert result.exit_code == 0
-    assert set(os.listdir(str(tmpdir))) == set(
+    assert set(os.listdir(str(tmp_path))) == set(
         [
             "CorePing.kt",
             "Telemetry.kt",
@@ -53,14 +53,14 @@ def test_translate(tmpdir):
             "GleanBuildInfo.kt",
         ]
     )
-    for filename in os.listdir(str(tmpdir)):
-        path = Path(str(tmpdir)) / filename
+    for filename in os.listdir(str(tmp_path)):
+        path = tmp_path / filename
         with path.open(encoding="utf-8") as fd:
             content = fd.read()
         assert "package Foo" in content
 
 
-def test_translate_no_buildinfo(tmpdir):
+def test_translate_no_buildinfo(tmp_path):
     """Test the 'translate' command."""
     runner = CliRunner()
     result = runner.invoke(
@@ -69,7 +69,7 @@ def test_translate_no_buildinfo(tmpdir):
             "translate",
             str(ROOT / "data" / "core.yaml"),
             "-o",
-            str(tmpdir),
+            str(tmp_path),
             "-f",
             "kotlin",
             "-s",
@@ -80,7 +80,7 @@ def test_translate_no_buildinfo(tmpdir):
         ],
     )
     assert result.exit_code == 0
-    assert set(os.listdir(str(tmpdir))) == set(
+    assert set(os.listdir(str(tmp_path))) == set(
         [
             "CorePing.kt",
             "Telemetry.kt",
@@ -89,14 +89,14 @@ def test_translate_no_buildinfo(tmpdir):
             "GleanInternalMetrics.kt",
         ]
     )
-    for filename in os.listdir(str(tmpdir)):
-        path = Path(str(tmpdir)) / filename
+    for filename in os.listdir(str(tmp_path)):
+        path = tmp_path / filename
         with path.open(encoding="utf-8") as fd:
             content = fd.read()
         assert "package Foo" in content
 
 
-def test_translate_build_date(tmpdir):
+def test_translate_build_date(tmp_path):
     """Test with a custom build date."""
     runner = CliRunner()
     result = runner.invoke(
@@ -105,7 +105,7 @@ def test_translate_build_date(tmpdir):
             "translate",
             str(ROOT / "data" / "core.yaml"),
             "-o",
-            str(tmpdir),
+            str(tmp_path),
             "-f",
             "kotlin",
             "-s",
@@ -117,14 +117,14 @@ def test_translate_build_date(tmpdir):
     )
     assert result.exit_code == 0
 
-    path = Path(str(tmpdir)) / "GleanBuildInfo.kt"
+    path = tmp_path / "GleanBuildInfo.kt"
     with path.open(encoding="utf-8") as fd:
         content = fd.read()
     assert "buildDate = Calendar.getInstance" in content
     assert "cal.set(2020, 0, 1, 17, 30" in content
 
 
-def test_translate_fixed_build_date(tmpdir):
+def test_translate_fixed_build_date(tmp_path):
     """Test with a custom build date."""
     runner = CliRunner()
     result = runner.invoke(
@@ -133,7 +133,7 @@ def test_translate_fixed_build_date(tmpdir):
             "translate",
             str(ROOT / "data" / "core.yaml"),
             "-o",
-            str(tmpdir),
+            str(tmp_path),
             "-f",
             "kotlin",
             "-s",
@@ -145,14 +145,14 @@ def test_translate_fixed_build_date(tmpdir):
     )
     assert result.exit_code == 0
 
-    path = Path(str(tmpdir)) / "GleanBuildInfo.kt"
+    path = tmp_path / "GleanBuildInfo.kt"
     with path.open(encoding="utf-8") as fd:
         content = fd.read()
     assert "buildDate = Calendar.getInstance" in content
     assert "cal.set(1970" in content
 
 
-def test_translate_borked_build_date(tmpdir):
+def test_translate_borked_build_date(tmp_path):
     """Test with a custom build date."""
     runner = CliRunner()
     result = runner.invoke(
@@ -161,7 +161,7 @@ def test_translate_borked_build_date(tmpdir):
             "translate",
             str(ROOT / "data" / "core.yaml"),
             "-o",
-            str(tmpdir),
+            str(tmp_path),
             "-f",
             "kotlin",
             "-s",
@@ -174,7 +174,7 @@ def test_translate_borked_build_date(tmpdir):
     assert result.exit_code == 1
 
 
-def test_translate_errors(tmpdir):
+def test_translate_errors(tmp_path):
     """Test the 'translate' command."""
     runner = CliRunner()
     result = runner.invoke(
@@ -183,16 +183,16 @@ def test_translate_errors(tmpdir):
             "translate",
             str(ROOT / "data" / "invalid.yamlx"),
             "-o",
-            str(tmpdir),
+            str(tmp_path),
             "-f",
             "kotlin",
         ],
     )
     assert result.exit_code == 1
-    assert len(os.listdir(str(tmpdir))) == 0
+    assert len(os.listdir(str(tmp_path))) == 0
 
 
-def test_glinter_errors(tmpdir):
+def test_glinter_errors(tmp_path):
     """Test that the 'glinter' command reports all errors."""
     runner = CliRunner()
     result = runner.invoke(
@@ -206,18 +206,25 @@ def test_glinter_errors(tmpdir):
     assert "Found 1 errors" in result.output
 
 
-def test_translate_invalid_format(tmpdir):
+def test_translate_invalid_format(tmp_path):
     """Test passing an invalid format to the 'translate' command."""
     runner = CliRunner()
     result = runner.invoke(
         __main__.main,
-        ["translate", str(ROOT / "data" / "core.yaml"), "-o", str(tmpdir), "-f", "foo"],
+        [
+            "translate",
+            str(ROOT / "data" / "core.yaml"),
+            "-o",
+            str(tmp_path),
+            "-f",
+            "foo",
+        ],
     )
     assert result.exit_code == 2
     assert re.search("Invalid value for ['\"]--format['\"]", result.output)
 
 
-def test_reject_jwe(tmpdir):
+def test_reject_jwe(tmp_path):
     """Test that the JWE type is rejected"""
     runner = CliRunner()
     result = runner.invoke(
@@ -226,16 +233,16 @@ def test_reject_jwe(tmpdir):
             "translate",
             str(ROOT / "data" / "jwe.yaml"),
             "-o",
-            str(tmpdir),
+            str(tmp_path),
             "-f",
             "kotlin",
         ],
     )
     assert result.exit_code == 1
-    assert len(os.listdir(str(tmpdir))) == 0
+    assert len(os.listdir(str(tmp_path))) == 0
 
 
-def test_wrong_key_lint(tmpdir):
+def test_wrong_key_lint(tmp_path):
     """Test that the 'glinter' reports a wrong key used."""
     runner = CliRunner()
     result = runner.invoke(
@@ -251,7 +258,7 @@ def test_wrong_key_lint(tmpdir):
     assert "Found 3 errors" in result.output
 
 
-def test_no_file_is_an_error(tmpdir):
+def test_no_file_is_an_error(tmp_path):
     """Test that 'translate' fails when no files are passed."""
     runner = CliRunner()
     result = runner.invoke(
@@ -259,7 +266,7 @@ def test_no_file_is_an_error(tmpdir):
         [
             "translate",
             "-o",
-            str(tmpdir),
+            str(tmp_path),
             "-f",
             "kotlin",
         ],
@@ -267,11 +274,11 @@ def test_no_file_is_an_error(tmpdir):
     assert result.exit_code == 1
 
 
-def test_no_file_can_be_skipped(tmpdir):
+def test_no_file_can_be_skipped(tmp_path):
     """Test that 'translate' works when no files are passed but flag is set."""
     runner = CliRunner()
     result = runner.invoke(
         __main__.main,
-        ["translate", "-o", str(tmpdir), "-f", "kotlin", "--allow-missing-files"],
+        ["translate", "-o", str(tmp_path), "-f", "kotlin", "--allow-missing-files"],
     )
     assert result.exit_code == 0

--- a/tests/test_go_server.py
+++ b/tests/test_go_server.py
@@ -16,63 +16,55 @@ from glean_parser import validate_ping
 ROOT = Path(__file__).parent
 
 
-def test_parser_go_server_ping_no_metrics(tmpdir, capsys):
+def test_parser_go_server_ping_no_metrics(tmp_path, capsys):
     """Test that no files are generated if only ping definitions
     are provided without any metrics."""
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         ROOT / "data" / "server_pings.yaml",
         "go_server",
-        tmpdir,
+        tmp_path,
     )
-    assert all(False for _ in tmpdir.iterdir())
+    assert all(False for _ in tmp_path.iterdir())
 
 
-def test_parser_go_server_ping_file(tmpdir, capsys):
+def test_parser_go_server_ping_file(tmp_path, capsys):
     """Test that no files are generated if ping definitions
     are provided."""
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         [
             ROOT / "data" / "server_metrics_with_event.yaml",
             ROOT / "data" / "server_pings.yaml",
         ],
         "go_server",
-        tmpdir,
+        tmp_path,
     )
-    assert all(False for _ in tmpdir.iterdir())
+    assert all(False for _ in tmp_path.iterdir())
 
 
-def test_parser_go_server_metrics_no_ping(tmpdir, capsys):
+def test_parser_go_server_metrics_no_ping(tmp_path, capsys):
     """Test that no files are generated if only metric definitions
     are provided without any events metrics."""
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         ROOT / "data" / "server_metrics_no_events_no_pings.yaml",
         "go_server",
-        tmpdir,
+        tmp_path,
     )
 
     captured = capsys.readouterr()
-    assert all(False for _ in tmpdir.iterdir())
+    assert all(False for _ in tmp_path.iterdir())
     assert (
         "No event metrics found...at least one event metric is required" in captured.out
     )
 
 
-def test_parser_go_server_metrics_unsupported_type(tmpdir, capsys):
+def test_parser_go_server_metrics_unsupported_type(tmp_path, capsys):
     """Test that no files are generated with unsupported metric types."""
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         [
             ROOT / "data" / "go_server_metrics_unsupported.yaml",
         ],
         "go_server",
-        tmpdir,
+        tmp_path,
     )
     captured = capsys.readouterr()
     assert "Ignoring unsupported metric type" in captured.out
@@ -90,20 +82,18 @@ def test_parser_go_server_metrics_unsupported_type(tmpdir, capsys):
         assert t in captured.out
 
 
-def test_parser_go_server(tmpdir):
+def test_parser_go_server(tmp_path):
     """Test that parser works"""
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         ROOT / "data" / "go_server_metrics.yaml",
         "go_server",
-        tmpdir,
+        tmp_path,
     )
 
-    assert set(x.name for x in tmpdir.iterdir()) == set(["server_events.go"])
+    assert set(x.name for x in tmp_path.iterdir()) == set(["server_events.go"])
 
     # Make sure generated file matches expected
-    with (tmpdir / "server_events.go").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "server_events.go").open("r", encoding="utf-8") as fd:
         content = fd.read()
         with (ROOT / "data" / "server_events_compare.go").open(
             "r", encoding="utf-8"
@@ -139,9 +129,8 @@ def run_logger(code_dir, code):
 
 
 @pytest.mark.go_dependency
-def test_run_logging(tmpdir):
-    tmpdir = Path(str(tmpdir))
-    glean_module_path = tmpdir / "glean"
+def test_run_logging(tmp_path):
+    glean_module_path = tmp_path / "glean"
 
     translate.translate(
         [
@@ -165,7 +154,7 @@ def test_run_logging(tmpdir):
     )
     """
 
-    logged_output = run_logger(tmpdir, code)
+    logged_output = run_logger(tmp_path, code)
     logged_output = json.loads(logged_output)
     fields = logged_output["Fields"]
     payload = fields["payload"]

--- a/tests/test_javascript.py
+++ b/tests/test_javascript.py
@@ -14,19 +14,17 @@ from glean_parser import translate
 ROOT = Path(__file__).parent
 
 
-def test_parser_js(tmpdir):
+def test_parser_js(tmp_path):
     """Test translating metrics to Javascript files."""
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         ROOT / "data" / "core.yaml",
         "javascript",
-        tmpdir,
+        tmp_path,
         None,
         {"allow_reserved": True},
     )
 
-    assert set(x.name for x in tmpdir.iterdir()) == set(
+    assert set(x.name for x in tmp_path.iterdir()) == set(
         [
             "corePing.js",
             "telemetry.js",
@@ -37,47 +35,43 @@ def test_parser_js(tmpdir):
     )
 
     # Make sure descriptions made it in
-    with (tmpdir / "corePing.js").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "corePing.js").open("r", encoding="utf-8") as fd:
         content = fd.read()
         assert "True if the user has set Firefox as the default browser." in content
 
-    with (tmpdir / "telemetry.js").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "telemetry.js").open("r", encoding="utf-8") as fd:
         content = fd.read()
         assert "جمع 搜集" in content
 
-    with (tmpdir / "gleanInternalMetrics.js").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "gleanInternalMetrics.js").open("r", encoding="utf-8") as fd:
         content = fd.read()
         assert 'category: ""' in content
 
 
-def test_parser_js_all_metrics(tmpdir):
+def test_parser_js_all_metrics(tmp_path):
     """Test translating metrics to Javascript files."""
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         ROOT / "data" / "all_metrics.yaml",
         "javascript",
-        tmpdir,
+        tmp_path,
         None,
         {"allow_reserved": True},
     )
 
-    assert set(x.name for x in tmpdir.iterdir()) == set(["allMetrics.js"])
+    assert set(x.name for x in tmp_path.iterdir()) == set(["allMetrics.js"])
 
 
-def test_parser_ts(tmpdir):
+def test_parser_ts(tmp_path):
     """Test translating metrics to Typescript files."""
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         ROOT / "data" / "core.yaml",
         "typescript",
-        tmpdir,
+        tmp_path,
         None,
         {"allow_reserved": True},
     )
 
-    assert set(x.name for x in tmpdir.iterdir()) == set(
+    assert set(x.name for x in tmp_path.iterdir()) == set(
         [
             "corePing.ts",
             "telemetry.ts",
@@ -88,38 +82,36 @@ def test_parser_ts(tmpdir):
     )
 
     # Make sure descriptions made it in
-    with (tmpdir / "corePing.ts").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "corePing.ts").open("r", encoding="utf-8") as fd:
         content = fd.read()
         assert "use strict" not in content
         assert "True if the user has set Firefox as the default browser." in content
 
-    with (tmpdir / "telemetry.ts").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "telemetry.ts").open("r", encoding="utf-8") as fd:
         content = fd.read()
         assert "use strict" not in content
         assert "جمع 搜集" in content
 
-    with (tmpdir / "gleanInternalMetrics.ts").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "gleanInternalMetrics.ts").open("r", encoding="utf-8") as fd:
         content = fd.read()
         assert "use strict" not in content
         assert 'category: ""' in content
 
 
-def test_ping_parser(tmpdir):
+def test_ping_parser(tmp_path):
     """Test translating pings to Javascript files."""
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         ROOT / "data" / "pings.yaml",
         "javascript",
-        tmpdir,
+        tmp_path,
         None,
         {"allow_reserved": True},
     )
 
-    assert set(x.name for x in tmpdir.iterdir()) == set(["pings.js"])
+    assert set(x.name for x in tmp_path.iterdir()) == set(["pings.js"])
 
     # Make sure descriptions made it in
-    with (tmpdir / "pings.js").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "pings.js").open("r", encoding="utf-8") as fd:
         content = fd.read()
         assert "This is a custom ping" in content
 
@@ -205,20 +197,17 @@ def test_import_path():
     assert javascript.import_path(ping.type) == "ping"
 
 
-def test_labeled_subtype_is_imported(tmpdir):
+def test_labeled_subtype_is_imported(tmp_path):
     """
     Test that both the LabeledMetricType and its subtype are imported
     """
-
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
-        ROOT / "data" / "single_labeled.yaml", "javascript", tmpdir, None
+        ROOT / "data" / "single_labeled.yaml", "javascript", tmp_path, None
     )
 
-    assert set(x.name for x in tmpdir.iterdir()) == set(["category.js"])
+    assert set(x.name for x in tmp_path.iterdir()) == set(["category.js"])
 
-    with (tmpdir / "category.js").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "category.js").open("r", encoding="utf-8") as fd:
         content = fd.read()
         assert (
             content.count(
@@ -234,23 +223,20 @@ def test_labeled_subtype_is_imported(tmpdir):
         )
 
 
-def test_duplicate(tmpdir):
+def test_duplicate(tmp_path):
     """
     Test that there aren't duplicate imports when using a labeled and
     non-labeled version of the same metric.
 
     https://github.com/mozilla-mobile/android-components/issues/2793
     """
-
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
-        ROOT / "data" / "duplicate_labeled.yaml", "javascript", tmpdir, None
+        ROOT / "data" / "duplicate_labeled.yaml", "javascript", tmp_path, None
     )
 
-    assert set(x.name for x in tmpdir.iterdir()) == set(["category.js"])
+    assert set(x.name for x in tmp_path.iterdir()) == set(["category.js"])
 
-    with (tmpdir / "category.js").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "category.js").open("r", encoding="utf-8") as fd:
         content = fd.read()
         assert (
             content.count(
@@ -260,116 +246,102 @@ def test_duplicate(tmpdir):
         )
 
 
-def test_reasons(tmpdir):
-    tmpdir = Path(str(tmpdir))
+def test_reasons(tmp_path):
+    translate.translate(ROOT / "data" / "pings.yaml", "javascript", tmp_path, None)
 
-    translate.translate(ROOT / "data" / "pings.yaml", "javascript", tmpdir, None)
+    translate.translate(ROOT / "data" / "pings.yaml", "typescript", tmp_path, None)
 
-    translate.translate(ROOT / "data" / "pings.yaml", "typescript", tmpdir, None)
+    assert set(x.name for x in tmp_path.iterdir()) == set(["pings.js", "pings.ts"])
 
-    assert set(x.name for x in tmpdir.iterdir()) == set(["pings.js", "pings.ts"])
-
-    with (tmpdir / "pings.js").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "pings.js").open("r", encoding="utf-8") as fd:
         content = fd.read()
         assert "export const CustomPingMightBeEmptyReasonCodes" in content
         assert "export const RealPingMightBeEmptyReasonCodes" not in content
 
-    with (tmpdir / "pings.ts").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "pings.ts").open("r", encoding="utf-8") as fd:
         content = fd.read()
         assert "export enum CustomPingMightBeEmptyReasonCodes" in content
         assert "export enum RealPingMightBeEmptyReasonCodes" not in content
 
 
-def test_event_extra_keys_in_correct_order(tmpdir):
+def test_event_extra_keys_in_correct_order(tmp_path):
     """
     Assert that the extra keys appear in the parameter and the enumeration in
     the same order.
 
     https://bugzilla.mozilla.org/show_bug.cgi?id=1648768
     """
-
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         ROOT / "data" / "event_key_ordering.yaml",
         "javascript",
-        tmpdir,
+        tmp_path,
         None,
     )
 
-    assert set(x.name for x in tmpdir.iterdir()) == set(["event.js"])
+    assert set(x.name for x in tmp_path.iterdir()) == set(["event.js"])
 
-    with (tmpdir / "event.js").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "event.js").open("r", encoding="utf-8") as fd:
         content = fd.read()
         content = " ".join(content.split())
         assert '["alice", "bob", "charlie"]' in content
 
 
-def test_arguments_are_generated_in_deterministic_order(tmpdir):
+def test_arguments_are_generated_in_deterministic_order(tmp_path):
     """
     Assert that arguments on generated code are always in the same order.
 
     https://bugzilla.mozilla.org/show_bug.cgi?id=1666192
     """
-
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         ROOT / "data" / "event_key_ordering.yaml",
         "javascript",
-        tmpdir,
+        tmp_path,
         None,
     )
 
-    assert set(x.name for x in tmpdir.iterdir()) == set(["event.js"])
+    assert set(x.name for x in tmp_path.iterdir()) == set(["event.js"])
 
-    with (tmpdir / "event.js").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "event.js").open("r", encoding="utf-8") as fd:
         content = fd.read()
         content = " ".join(content.split())
         expected = 'export const example = new EventMetricType({ category: "event", name: "example", sendInPings: ["events"], lifetime: "ping", disabled: false, }, ["alice", "bob", "charlie"]);'  # noqa
         assert expected in content
 
 
-def test_qt_platform_template_includes_expected_imports(tmpdir):
+def test_qt_platform_template_includes_expected_imports(tmp_path):
     """
     Assert that when the platform is Qt, the template does not contain
     import/export statements.
     """
-
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         ROOT / "data" / "single_labeled.yaml",
         "javascript",
-        tmpdir,
+        tmp_path,
         {"platform": "qt", "version": "0.14"},
     )
 
-    assert set(x.name for x in tmpdir.iterdir()) == set(["category.js", "qmldir"])
+    assert set(x.name for x in tmp_path.iterdir()) == set(["category.js", "qmldir"])
 
-    with (tmpdir / "category.js").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "category.js").open("r", encoding="utf-8") as fd:
         content = fd.read()
         assert content.count(".import org.mozilla.Glean 0.14") == 1
         assert content.count("export") == 0
 
 
-def test_qt_platform_generated_correct_qmldir_file(tmpdir):
+def test_qt_platform_generated_correct_qmldir_file(tmp_path):
     """
     Assert that when the platform is Qt, a qmldir is also generated
     with the expected files listed in it.
     """
-
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         ROOT / "data" / "core.yaml",
         "javascript",
-        tmpdir,
+        tmp_path,
         {"platform": "qt", "version": "0.14"},
         {"allow_reserved": True},
     )
 
-    assert set(x.name for x in tmpdir.iterdir()) == set(
+    assert set(x.name for x in tmp_path.iterdir()) == set(
         [
             "corePing.js",
             "telemetry.js",
@@ -380,7 +352,7 @@ def test_qt_platform_generated_correct_qmldir_file(tmpdir):
         ]
     )
 
-    with (tmpdir / "qmldir").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "qmldir").open("r", encoding="utf-8") as fd:
         content = fd.read()
         assert content.count("CorePing 0.14 corePing.js") == 1
         assert content.count("Telemetry 0.14 telemetry.js") == 1
@@ -390,22 +362,19 @@ def test_qt_platform_generated_correct_qmldir_file(tmpdir):
         assert content.count("depends org.mozilla.Glean 0.14") == 1
 
 
-def test_event_extra_keys_with_types(tmpdir):
+def test_event_extra_keys_with_types(tmp_path):
     """
     Assert that the extra keys with types appear with their corresponding types.
     """
-
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         ROOT / "data" / "events_with_types.yaml",
         "typescript",
-        tmpdir,
+        tmp_path,
     )
 
-    assert set(x.name for x in tmpdir.iterdir()) == set(["core.ts"])
+    assert set(x.name for x in tmp_path.iterdir()) == set(["core.ts"])
 
-    with (tmpdir / "core.ts").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "core.ts").open("r", encoding="utf-8") as fd:
         content = fd.read()
         content = " ".join(content.split())
         assert (
@@ -421,44 +390,41 @@ def test_event_extra_keys_with_types(tmpdir):
     translate.translate(
         ROOT / "data" / "events_with_types.yaml",
         "javascript",
-        tmpdir,
+        tmp_path,
     )
 
-    assert set(x.name for x in tmpdir.iterdir()) == set(["core.js", "core.ts"])
+    assert set(x.name for x in tmp_path.iterdir()) == set(["core.js", "core.ts"])
 
-    with (tmpdir / "core.js").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "core.js").open("r", encoding="utf-8") as fd:
         content = fd.read()
         content = " ".join(content.split())
         assert "new EventMetricType({" in content
         assert '"enabled", "preference", "swapped"' in content
 
 
-def test_build_info_is_generated_when_option_is_present(tmpdir):
+def test_build_info_is_generated_when_option_is_present(tmp_path):
     """
     Assert that build info is generated
     """
-
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         ROOT / "data" / "single_labeled.yaml",
         "typescript",
-        tmpdir,
+        tmp_path,
         {"with_buildinfo": "true"},
     )
-    assert set(x.name for x in tmpdir.iterdir()) == set(
+    assert set(x.name for x in tmp_path.iterdir()) == set(
         ["gleanBuildInfo.ts", "category.ts"]
     )
 
     translate.translate(
         ROOT / "data" / "single_labeled.yaml",
         "typescript",
-        tmpdir,
+        tmp_path,
         {"with_buildinfo": "true", "build_date": "2022-03-01T14:10+01:00"},
     )
-    assert set(x.name for x in tmpdir.iterdir()) == set(
+    assert set(x.name for x in tmp_path.iterdir()) == set(
         ["gleanBuildInfo.ts", "category.ts"]
     )
-    with (tmpdir / "gleanBuildInfo.ts").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "gleanBuildInfo.ts").open("r", encoding="utf-8") as fd:
         content = fd.read()
         assert "new Date(2022, 2, 1, 14, 10, 0)" in content

--- a/tests/test_javascript_server.py
+++ b/tests/test_javascript_server.py
@@ -18,52 +18,46 @@ from glean_parser import validate_ping
 ROOT = Path(__file__).parent
 
 
-def test_parser_js_server_ping_no_metrics(tmpdir):
+def test_parser_js_server_ping_no_metrics(tmp_path):
     """Test that no files are generated if only ping definitions
     are provided without any metrics."""
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         ROOT / "data" / "fxa-server-pings.yaml",
         "javascript_server",
-        tmpdir,
+        tmp_path,
     )
 
-    assert all(False for _ in tmpdir.iterdir())
+    assert all(False for _ in tmp_path.iterdir())
 
 
-def test_parser_js_server_metrics_no_ping(tmpdir):
+def test_parser_js_server_metrics_no_ping(tmp_path):
     """Test that no files are generated if only metric definitions
     are provided without pings."""
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         ROOT / "data" / "fxa-server-metrics.yaml",
         "javascript_server",
-        tmpdir,
+        tmp_path,
     )
 
-    assert all(False for _ in tmpdir.iterdir())
+    assert all(False for _ in tmp_path.iterdir())
 
 
-def test_parser_js_server(tmpdir):
+def test_parser_js_server(tmp_path):
     """Test that no files are generated if only metric definitions
     are provided without pings."""
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         [
             ROOT / "data" / "fxa-server-pings.yaml",
             ROOT / "data" / "fxa-server-metrics.yaml",
         ],
         "javascript_server",
-        tmpdir,
+        tmp_path,
     )
 
-    assert set(x.name for x in tmpdir.iterdir()) == set(["server_events.js"])
+    assert set(x.name for x in tmp_path.iterdir()) == set(["server_events.js"])
 
     # Make sure string metric made it in
-    with (tmpdir / "server_events.js").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "server_events.js").open("r", encoding="utf-8") as fd:
         content = fd.read()
         assert "'event.name': event_name" in content
 
@@ -110,16 +104,14 @@ def run_logger(code_dir, import_file, factory, code):
 
 
 @pytest.mark.node_dependency
-def test_logging_custom_ping_as_events(tmpdir):
-    tmpdir = Path(str(tmpdir))
-
+def test_logging_custom_ping_as_events(tmp_path):
     translate.translate(
         [
             ROOT / "data" / "fxa-server-pings.yaml",
             ROOT / "data" / "fxa-server-metrics.yaml",
         ],
         "javascript_server",
-        tmpdir,
+        tmp_path,
     )
 
     factory = "createAccountsEventsEvent"
@@ -127,7 +119,7 @@ def test_logging_custom_ping_as_events(tmpdir):
 eventLogger.record({ user_agent: "glean-test/1.0", event_name: "testing" });
     """
 
-    logged_output = run_logger(tmpdir, "server_events.js", factory, code)
+    logged_output = run_logger(tmp_path, "server_events.js", factory, code)
     logged_output = json.loads(logged_output)
     fields = logged_output["Fields"]
     payload = fields["payload"]
@@ -152,16 +144,13 @@ eventLogger.record({ user_agent: "glean-test/1.0", event_name: "testing" });
 
 
 @pytest.mark.node_dependency
-def test_logging_events_ping_with_event_metrics(tmpdir):
-    tmpdir = "/tmp/glean-js-server"
-    tmpdir = Path(str(tmpdir))
-
+def test_logging_events_ping_with_event_metrics(tmp_path):
     translate.translate(
         [
             ROOT / "data" / "server_metrics_with_event.yaml",
         ],
         "javascript_server",
-        tmpdir,
+        tmp_path,
     )
 
     factory = "createEventsServerEventLogger"
@@ -175,7 +164,7 @@ eventLogger.recordBackendObjectUpdate({
 });
     """
 
-    logged_output = run_logger(tmpdir, "server_events.js", factory, code)
+    logged_output = run_logger(tmp_path, "server_events.js", factory, code)
     logged_output = json.loads(logged_output)
     fields = logged_output["Fields"]
     payload = fields["payload"]

--- a/tests/test_kotlin.py
+++ b/tests/test_kotlin.py
@@ -50,19 +50,17 @@ def run_linters(files):
     run_detekt(files)
 
 
-def test_parser(tmpdir):
+def test_parser(tmp_path):
     """Test translating metrics to Kotlin files."""
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         ROOT / "data" / "core.yaml",
         "kotlin",
-        tmpdir,
+        tmp_path,
         {"namespace": "Foo"},
         {"allow_reserved": True},
     )
 
-    assert set(x.name for x in tmpdir.iterdir()) == set(
+    assert set(x.name for x in tmp_path.iterdir()) == set(
         [
             "CorePing.kt",
             "Telemetry.kt",
@@ -74,68 +72,64 @@ def test_parser(tmpdir):
     )
 
     # Make sure descriptions made it in
-    with (tmpdir / "CorePing.kt").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "CorePing.kt").open("r", encoding="utf-8") as fd:
         content = fd.read()
         assert "True if the user has set Firefox as the default browser." in content
         # Make sure the namespace option is in effect
         assert "package Foo" in content
 
-    with (tmpdir / "Telemetry.kt").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "Telemetry.kt").open("r", encoding="utf-8") as fd:
         content = fd.read()
         assert "جمع 搜集" in content
 
-    with (tmpdir / "GleanInternalMetrics.kt").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "GleanInternalMetrics.kt").open("r", encoding="utf-8") as fd:
         content = fd.read()
         assert 'category = ""' in content
 
-    with (tmpdir / "GleanBuildInfo.kt").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "GleanBuildInfo.kt").open("r", encoding="utf-8") as fd:
         content = fd.read()
         assert "buildDate = Calendar.getInstance" in content
 
-    run_linters(tmpdir.glob("*.kt"))
+    run_linters(tmp_path.glob("*.kt"))
 
 
-def test_parser_all_metrics(tmpdir):
+def test_parser_all_metrics(tmp_path):
     """Test translating ALL metric types to Kotlin files."""
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         ROOT / "data" / "all_metrics.yaml",
         "kotlin",
-        tmpdir,
+        tmp_path,
         {"namespace": "Foo", "with_buildinfo": "false"},
         {"allow_reserved": False},
     )
 
-    assert set(x.name for x in tmpdir.iterdir()) == set(["AllMetrics.kt"])
+    assert set(x.name for x in tmp_path.iterdir()) == set(["AllMetrics.kt"])
 
-    run_linters(tmpdir.glob("*.kt"))
+    run_linters(tmp_path.glob("*.kt"))
 
 
-def test_ping_parser(tmpdir):
+def test_ping_parser(tmp_path):
     """Test translating pings to Kotlin files."""
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         ROOT / "data" / "pings.yaml",
         "kotlin",
-        tmpdir,
+        tmp_path,
         {"namespace": "Foo"},
         {"allow_reserved": True},
     )
 
-    assert set(x.name for x in tmpdir.iterdir()) == set(
+    assert set(x.name for x in tmp_path.iterdir()) == set(
         ["Pings.kt", "GleanBuildInfo.kt"]
     )
 
     # Make sure descriptions made it in
-    with (tmpdir / "Pings.kt").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "Pings.kt").open("r", encoding="utf-8") as fd:
         content = fd.read()
         assert "This is a custom ping" in content
         # Make sure the namespace option is in effect
         assert "package Foo" in content
 
-    run_linters(tmpdir.glob("*.kt"))
+    run_linters(tmp_path.glob("*.kt"))
 
 
 def test_kotlin_generator():
@@ -207,25 +201,25 @@ def test_metric_type_name():
     assert kotlin.type_name(ping) == "PingType<customReasonCodes>"
 
 
-def test_duplicate(tmpdir):
+def test_duplicate(tmp_path):
     """
     Test that there aren't duplicate imports when using a labeled and
     non-labeled version of the same metric.
 
     https://github.com/mozilla-mobile/android-components/issues/2793
     """
-
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
-        ROOT / "data" / "duplicate_labeled.yaml", "kotlin", tmpdir, {"namespace": "Foo"}
+        ROOT / "data" / "duplicate_labeled.yaml",
+        "kotlin",
+        tmp_path,
+        {"namespace": "Foo"},
     )
 
-    assert set(x.name for x in tmpdir.iterdir()) == set(
+    assert set(x.name for x in tmp_path.iterdir()) == set(
         ["Category.kt", "GleanBuildInfo.kt"]
     )
 
-    with (tmpdir / "Category.kt").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "Category.kt").open("r", encoding="utf-8") as fd:
         content = fd.read()
         assert (
             content.count(
@@ -235,36 +229,32 @@ def test_duplicate(tmpdir):
         )
 
 
-def test_glean_namespace(tmpdir):
+def test_glean_namespace(tmp_path):
     """
     Test that setting the glean namespace works.
     """
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         ROOT / "data" / "duplicate_labeled.yaml",
         "kotlin",
-        tmpdir,
+        tmp_path,
         {"namespace": "Foo", "glean_namespace": "Bar"},
     )
 
-    assert set(x.name for x in tmpdir.iterdir()) == set(
+    assert set(x.name for x in tmp_path.iterdir()) == set(
         ["Category.kt", "GleanBuildInfo.kt"]
     )
 
-    with (tmpdir / "Category.kt").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "Category.kt").open("r", encoding="utf-8") as fd:
         content = fd.read()
         assert content.count("import Bar.private.CounterMetricType") == 1
 
 
-def test_gecko_datapoints(tmpdir):
+def test_gecko_datapoints(tmp_path):
     """Test translating metrics to Kotlin files."""
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         ROOT / "data" / "gecko.yaml",
         "kotlin",
-        tmpdir,
+        tmp_path,
         {"glean_namespace": "Bar"},
         {"allow_reserved": True},
     )
@@ -276,12 +266,12 @@ def test_gecko_datapoints(tmpdir):
         "NonGeckoMetrics.kt",
         "GleanBuildInfo.kt",
     ]
-    assert set(x.name for x in tmpdir.iterdir()) == set(
+    assert set(x.name for x in tmp_path.iterdir()) == set(
         ["GleanGeckoMetricsMapping.kt"] + metrics_files
     )
 
     # Make sure descriptions made it in
-    with (tmpdir / "GleanGeckoMetricsMapping.kt").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "GleanGeckoMetricsMapping.kt").open("r", encoding="utf-8") as fd:
         content = fd.read()
         # Make sure we're adding the relevant Glean SDK import, once.
         assert content.count("import Bar.private.HistogramMetricBase") == 1
@@ -346,35 +336,32 @@ def test_gecko_datapoints(tmpdir):
         assert expected_func in content
 
     for file_name in metrics_files:
-        with (tmpdir / file_name).open("r", encoding="utf-8") as fd:
+        with (tmp_path / file_name).open("r", encoding="utf-8") as fd:
             content = fd.read()
             assert "HistogramMetricBase" not in content
 
-    run_linters(tmpdir.glob("*.kt"))
+    run_linters(tmp_path.glob("*.kt"))
 
 
-def test_event_extra_keys_in_correct_order(tmpdir):
+def test_event_extra_keys_in_correct_order(tmp_path):
     """
     Assert that the extra keys appear in the parameter and the enumeration in
     the same order.
 
     https://bugzilla.mozilla.org/show_bug.cgi?id=1648768
     """
-
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         ROOT / "data" / "event_key_ordering.yaml",
         "kotlin",
-        tmpdir,
+        tmp_path,
         {"namespace": "Foo"},
     )
 
-    assert set(x.name for x in tmpdir.iterdir()) == set(
+    assert set(x.name for x in tmp_path.iterdir()) == set(
         ["Event.kt", "GleanBuildInfo.kt"]
     )
 
-    with (tmpdir / "Event.kt").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "Event.kt").open("r", encoding="utf-8") as fd:
         content = fd.read()
         content = " ".join(content.split())
         assert "ExampleExtra(" in content
@@ -385,52 +372,46 @@ def test_event_extra_keys_in_correct_order(tmpdir):
         assert 'allowedExtraKeys = listOf("alice", "bob", "charlie")' in content
 
 
-def test_arguments_are_generated_in_deterministic_order(tmpdir):
+def test_arguments_are_generated_in_deterministic_order(tmp_path):
     """
     Assert that arguments on generated code are always in the same order.
 
     https://bugzilla.mozilla.org/show_bug.cgi?id=1666192
     """
-
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         ROOT / "data" / "event_key_ordering.yaml",
         "kotlin",
-        tmpdir,
+        tmp_path,
         {"namespace": "Foo"},
     )
 
-    assert set(x.name for x in tmpdir.iterdir()) == set(
+    assert set(x.name for x in tmp_path.iterdir()) == set(
         ["Event.kt", "GleanBuildInfo.kt"]
     )
 
-    with (tmpdir / "Event.kt").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "Event.kt").open("r", encoding="utf-8") as fd:
         content = fd.read()
         content = " ".join(content.split())
         expected = 'EventMetricType<ExampleExtra> by lazy { // generated from event.example EventMetricType<ExampleExtra>( CommonMetricData( category = "event", name = "example", sendInPings = listOf("events"), lifetime = Lifetime.PING, disabled = false ), allowedExtraKeys = listOf("alice", "bob", "charlie")) } }'  # noqa
         assert expected in content
 
 
-def test_event_extra_keys_with_types(tmpdir):
+def test_event_extra_keys_with_types(tmp_path):
     """
     Assert that the extra keys with types appear with their corresponding types.
     """
-
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         ROOT / "data" / "events_with_types.yaml",
         "kotlin",
-        tmpdir,
+        tmp_path,
         {"namespace": "Foo"},
     )
 
-    assert set(x.name for x in tmpdir.iterdir()) == set(
+    assert set(x.name for x in tmp_path.iterdir()) == set(
         ["Core.kt", "GleanBuildInfo.kt"]
     )
 
-    with (tmpdir / "Core.kt").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "Core.kt").open("r", encoding="utf-8") as fd:
         content = fd.read()
         content = " ".join(content.split())
         assert (
@@ -445,27 +426,24 @@ def test_event_extra_keys_with_types(tmpdir):
         )
 
 
-def test_reasons(tmpdir):
+def test_reasons(tmp_path):
     """
     Assert that we generate the reason codes as a plain enum.
 
     https://bugzilla.mozilla.org/show_bug.cgi?id=1811888
     """
-
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         ROOT / "data" / "pings.yaml",
         "kotlin",
-        tmpdir,
+        tmp_path,
         {"namespace": "Foo"},
     )
 
-    assert set(x.name for x in tmpdir.iterdir()) == set(
+    assert set(x.name for x in tmp_path.iterdir()) == set(
         ["Pings.kt", "GleanBuildInfo.kt"]
     )
 
-    with (tmpdir / "Pings.kt").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "Pings.kt").open("r", encoding="utf-8") as fd:
         content = fd.read()
         content = " ".join(content.split())
 

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -309,7 +309,7 @@ def test_invalid_lifetime_for_metric_on_events_ping():
     assert len(errs) == 1
 
 
-def test_translate_missing_input_files(tmpdir):
+def test_translate_missing_input_files(tmp_path):
     with pytest.raises(FileNotFoundError):
         lint.glinter(
             [ROOT / "data" / "missing.yaml"],

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -14,22 +14,20 @@ from glean_parser import translate
 ROOT = Path(__file__).parent
 
 
-def test_parser(tmpdir):
+def test_parser(tmp_path):
     """Test translating metrics to Markdown files."""
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         ROOT / "data" / "core.yaml",
         "markdown",
-        tmpdir,
+        tmp_path,
         {"namespace": "Foo", "introduction_extra": "Extra Intro Text Bar"},
         {"allow_reserved": True},
     )
 
-    assert set(x.name for x in tmpdir.iterdir()) == set(["metrics.md"])
+    assert set(x.name for x in tmp_path.iterdir()) == set(["metrics.md"])
 
     # Make sure descriptions made it in
-    with (tmpdir / "metrics.md").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "metrics.md").open("r", encoding="utf-8") as fd:
         content = fd.read()
         assert "is assembled out of the box by the Glean SDK." in content
         # Make sure the table structure is in place
@@ -159,44 +157,39 @@ def test_review_title():
     assert markdown.ping_review_title("http://example.com/reviews", index) == "Review 1"
 
 
-def test_reasons(tmpdir):
-    tmpdir = Path(str(tmpdir))
-
+def test_reasons(tmp_path):
     translate.translate(
         ROOT / "data" / "pings.yaml",
         "markdown",
-        tmpdir,
+        tmp_path,
         {"namespace": "Foo"},
     )
 
-    assert set(x.name for x in tmpdir.iterdir()) == set(["metrics.md"])
+    assert set(x.name for x in tmp_path.iterdir()) == set(["metrics.md"])
 
     # Make sure descriptions made it in
-    with (tmpdir / "metrics.md").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "metrics.md").open("r", encoding="utf-8") as fd:
         content = fd.read()
         assert "- `serious`: A serious reason for sending a ping." in content
 
 
-def test_event_extra_keys_in_correct_order(tmpdir):
+def test_event_extra_keys_in_correct_order(tmp_path):
     """
     Assert that the extra keys appear in the parameter and the enumeration in
     the same order.
 
     https://bugzilla.mozilla.org/show_bug.cgi?id=1648768
     """
-
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         ROOT / "data" / "event_key_ordering.yaml",
         "markdown",
-        tmpdir,
+        tmp_path,
         {"namespace": "Foo"},
     )
 
-    assert set(x.name for x in tmpdir.iterdir()) == set(["metrics.md"])
+    assert set(x.name for x in tmp_path.iterdir()) == set(["metrics.md"])
 
-    with (tmpdir / "metrics.md").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "metrics.md").open("r", encoding="utf-8") as fd:
         content = fd.read()
         print(content)
         content = " ".join(content.split())
@@ -207,23 +200,21 @@ def test_event_extra_keys_in_correct_order(tmpdir):
         )
 
 
-def test_send_if_empty_metrics(tmpdir):
-    tmpdir = Path(str(tmpdir))
-
+def test_send_if_empty_metrics(tmp_path):
     translate.translate(
         [
             ROOT / "data" / "send_if_empty_with_metrics.yaml",
             ROOT / "data" / "pings.yaml",
         ],
         "markdown",
-        tmpdir,
+        tmp_path,
         {"namespace": "Foo"},
     )
 
-    assert set(x.name for x in tmpdir.iterdir()) == set(["metrics.md"])
+    assert set(x.name for x in tmp_path.iterdir()) == set(["metrics.md"])
 
     # Make sure descriptions made it in
-    with (tmpdir / "metrics.md").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "metrics.md").open("r", encoding="utf-8") as fd:
         content = fd.read()
         assert "Lorem ipsum dolor sit amet, consectetur adipiscing elit." in content
 

--- a/tests/test_ruby_server.py
+++ b/tests/test_ruby_server.py
@@ -16,88 +16,78 @@ from glean_parser import validate_ping
 ROOT = Path(__file__).parent
 
 
-def test_parser_rb_server_ping_file(tmpdir, capsys):
+def test_parser_rb_server_ping_file(tmp_path, capsys):
     """Test that no files are generated if ping definition
     is provided."""
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         [
             ROOT / "data" / "server_metrics_with_event.yaml",
             ROOT / "data" / "server_pings.yaml",
         ],
         "ruby_server",
-        tmpdir,
+        tmp_path,
     )
     captured = capsys.readouterr()
-    assert all(False for _ in tmpdir.iterdir())
+    assert all(False for _ in tmp_path.iterdir())
     assert (
         "Ping definition found. Server-side environment is simplified" in captured.out
     )
 
 
-def test_parser_rb_server_no_event_metrics(tmpdir, capsys):
+def test_parser_rb_server_no_event_metrics(tmp_path, capsys):
     """Test that no files are generated if no event metrics."""
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         [ROOT / "data" / "server_metrics_no_events_no_pings.yaml"],
         "ruby_server",
-        tmpdir,
+        tmp_path,
     )
     captured = capsys.readouterr()
-    assert all(False for _ in tmpdir.iterdir())
+    assert all(False for _ in tmp_path.iterdir())
     assert (
         "No event metrics found...at least one event metric is required" in captured.out
     )
 
 
-def test_parser_rb_server_metrics_unsupported_type(tmpdir, capsys):
+def test_parser_rb_server_metrics_unsupported_type(tmp_path, capsys):
     """Test that no files are generated with unsupported metric types."""
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         [
             ROOT / "data" / "ruby_server_metrics_unsupported.yaml",
         ],
         "ruby_server",
-        tmpdir,
+        tmp_path,
     )
     captured = capsys.readouterr()
     assert "Ignoring unsupported metric type" in captured.out
     assert "boolean" in captured.out
 
 
-def test_parser_rb_server_pings_unsupported_type(tmpdir, capsys):
+def test_parser_rb_server_pings_unsupported_type(tmp_path, capsys):
     """Test that no files are generated with ping types that are not `events`."""
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         [
             ROOT / "data" / "ruby_server_pings_unsupported.yaml",
         ],
         "ruby_server",
-        tmpdir,
+        tmp_path,
     )
     captured = capsys.readouterr()
     assert "Non-events ping reference found" in captured.out
     assert "Ignoring the tests ping type" in captured.out
 
 
-def test_parser_rb_server(tmpdir):
+def test_parser_rb_server(tmp_path):
     """Test that parser works"""
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         [ROOT / "data" / "server_metrics_with_event.yaml"],
         "ruby_server",
-        tmpdir,
+        tmp_path,
     )
 
-    assert set(x.name for x in tmpdir.iterdir()) == set(["server_events.rb"])
+    assert set(x.name for x in tmp_path.iterdir()) == set(["server_events.rb"])
 
     # Make sure string metric made it in
-    with (tmpdir / "server_events.rb").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "server_events.rb").open("r", encoding="utf-8") as fd:
         content = fd.read()
         with (ROOT / "data" / "server_events_compare.rb").open(
             "r", encoding="utf-8"
@@ -130,15 +120,13 @@ def run_logger(code_dir, import_file, code):
 
 
 @pytest.mark.ruby_dependency
-def test_run_logging(tmpdir):
-    tmpdir = Path(str(tmpdir))
-
+def test_run_logging(tmp_path):
     translate.translate(
         [
             ROOT / "data" / "server_metrics_with_event.yaml",
         ],
         "ruby_server",
-        tmpdir,
+        tmp_path,
     )
 
     code = """
@@ -151,7 +139,7 @@ events.backend_object_update.record(
 )
     """
 
-    logged_output = run_logger(tmpdir, "server_events.rb", code)
+    logged_output = run_logger(tmp_path, "server_events.rb", code)
     logged_output = json.loads(logged_output)
     fields = logged_output["Fields"]
     payload = fields["payload"]

--- a/tests/test_rust.py
+++ b/tests/test_rust.py
@@ -44,18 +44,16 @@ def run_linters(files):
             )
 
 
-def test_parser(tmpdir):
+def test_parser(tmp_path):
     """Test translating metrics to Rust files."""
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
-        ROOT / "data" / "core.yaml", "rust", tmpdir, {}, {"allow_reserved": True}
+        ROOT / "data" / "core.yaml", "rust", tmp_path, {}, {"allow_reserved": True}
     )
 
-    assert set(x.name for x in tmpdir.iterdir()) == set(["glean_metrics.rs"])
+    assert set(x.name for x in tmp_path.iterdir()) == set(["glean_metrics.rs"])
 
     # Make sure descriptions made it in
-    with (tmpdir / "glean_metrics.rs").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "glean_metrics.rs").open("r", encoding="utf-8") as fd:
         content = fd.read()
 
         assert "True if the user has set Firefox as the default browser." in content
@@ -64,25 +62,23 @@ def test_parser(tmpdir):
 
     # We don't have a cargo.toml, not sure what to do here aside from creating a fake
     # one for the purpose of running cargo fmt and cargo clippy
-    # run_linters(tmpdir.glob("*.rs"))
+    # run_linters(tmp_path.glob("*.rs"))
 
 
-def test_ping_parser(tmpdir):
+def test_ping_parser(tmp_path):
     """Test translating pings to Rust files."""
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         ROOT / "data" / "pings.yaml",
         "rust",
-        tmpdir,
+        tmp_path,
         {"namespace": "Foo"},
         {"allow_reserved": True},
     )
 
-    assert set(x.name for x in tmpdir.iterdir()) == set(["glean_metrics.rs"])
+    assert set(x.name for x in tmp_path.iterdir()) == set(["glean_metrics.rs"])
 
     # Make sure descriptions made it in
-    with (tmpdir / "glean_metrics.rs").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "glean_metrics.rs").open("r", encoding="utf-8") as fd:
         content = fd.read()
 
         assert "This is a custom ping" in content
@@ -100,7 +96,7 @@ def test_ping_parser(tmpdir):
     # TODO we need a cargo.toml to run `cargo fmt` and `cargo clippy`
     # and I'm not quite sure how to do that in a non-Rust project for
     # the purpose of testing
-    run_linters(tmpdir.glob("*.rs"))
+    run_linters(tmp_path.glob("*.rs"))
 
 
 def test_rust_generator():
@@ -168,16 +164,14 @@ def test_metric_type_name():
     assert rust.type_name(ping) == "Ping<CustomReasonCodes>"
 
 
-def test_order_of_fields(tmpdir):
+def test_order_of_fields(tmp_path):
     """Test that translating metrics to Rust files keeps a stable order of fields."""
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
-        ROOT / "data" / "core.yaml", "rust", tmpdir, {}, {"allow_reserved": True}
+        ROOT / "data" / "core.yaml", "rust", tmp_path, {}, {"allow_reserved": True}
     )
 
     # Make sure descriptions made it in
-    fd = (tmpdir / "glean_metrics.rs").open("r", encoding="utf-8")
+    fd = (tmp_path / "glean_metrics.rs").open("r", encoding="utf-8")
     content = fd.read()
     fd.close()
 
@@ -205,26 +199,23 @@ def test_order_of_fields(tmpdir):
     assert expected_fields == first_metric_fields[:size]
 
 
-def test_event_extra_keys_in_correct_order(tmpdir):
+def test_event_extra_keys_in_correct_order(tmp_path):
     """
     Assert that the extra keys appear in the parameter and the enumeration in
     the same order.
 
     https://bugzilla.mozilla.org/show_bug.cgi?id=1648768
     """
-
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         ROOT / "data" / "events_with_types.yaml",
         "rust",
-        tmpdir,
+        tmp_path,
         {"namespace": "Foo"},
     )
 
-    assert set(x.name for x in tmpdir.iterdir()) == set(["glean_metrics.rs"])
+    assert set(x.name for x in tmp_path.iterdir()) == set(["glean_metrics.rs"])
 
-    with (tmpdir / "glean_metrics.rs").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "glean_metrics.rs").open("r", encoding="utf-8") as fd:
         content = fd.read()
         content = " ".join(content.split())
         assert (
@@ -238,23 +229,20 @@ def test_event_extra_keys_in_correct_order(tmpdir):
         )
 
 
-def test_event_extra_keys_with_types(tmpdir):
+def test_event_extra_keys_with_types(tmp_path):
     """
     Assert that the extra keys with types appear with their corresponding types.
     """
-
-    tmpdir = Path(str(tmpdir))
-
     translate.translate(
         ROOT / "data" / "events_with_types.yaml",
         "rust",
-        tmpdir,
+        tmp_path,
         {"namespace": "Foo"},
     )
 
-    assert set(x.name for x in tmpdir.iterdir()) == set(["glean_metrics.rs"])
+    assert set(x.name for x in tmp_path.iterdir()) == set(["glean_metrics.rs"])
 
-    with (tmpdir / "glean_metrics.rs").open("r", encoding="utf-8") as fd:
+    with (tmp_path / "glean_metrics.rs").open("r", encoding="utf-8") as fd:
         content = fd.read()
         content = " ".join(content.split())
         assert (

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -25,8 +25,8 @@ def test_translate_unknown_format():
     assert "Unknown output format" in str(e)
 
 
-def test_all_metrics(tmpdir):
-    output = Path(str(tmpdir)) / "tags_test"
+def test_all_metrics(tmp_path):
+    output = tmp_path / "tags_test"
 
     translate.translate(
         [ROOT / "data" / "all_metrics.yaml"],
@@ -40,8 +40,8 @@ def test_all_metrics(tmpdir):
     assert len(list(output.iterdir())) == 1
 
 
-def test_translate_missing_directory(tmpdir):
-    output = Path(str(tmpdir)) / "foo"
+def test_translate_missing_directory(tmp_path):
+    output = tmp_path / "foo"
 
     translate.translate(
         ROOT / "data" / "core.yaml",
@@ -53,8 +53,8 @@ def test_translate_missing_directory(tmpdir):
     assert len(list(output.iterdir())) == 6
 
 
-def test_translate_missing_input_files(tmpdir):
-    output = Path(str(tmpdir))
+def test_translate_missing_input_files(tmp_path):
+    output = tmp_path
 
     with pytest.raises(FileNotFoundError):
         translate.translate(
@@ -72,8 +72,8 @@ def test_translate_missing_input_files(tmpdir):
     )
 
 
-def test_translate_remove_obsolete_kotlin_files(tmpdir):
-    output = Path(str(tmpdir)) / "foo"
+def test_translate_remove_obsolete_kotlin_files(tmp_path):
+    output = tmp_path / "foo"
 
     translate.translate(
         ROOT / "data" / "core.yaml",
@@ -89,8 +89,8 @@ def test_translate_remove_obsolete_kotlin_files(tmpdir):
     assert len(list(output.iterdir())) == 2
 
 
-def test_translate_retains_existing_markdown_files(tmpdir):
-    output = Path(str(tmpdir)) / "foo"
+def test_translate_retains_existing_markdown_files(tmp_path):
+    output = tmp_path / "foo"
 
     translate.translate(
         ROOT / "data" / "core.yaml",
@@ -133,7 +133,7 @@ def test_translate_expires():
     assert objs["metrics"]["d"].disabled is False
 
 
-def test_translate_send_in_pings(tmpdir):
+def test_translate_send_in_pings(tmp_path):
     contents = [
         {
             "baseline": {
@@ -154,8 +154,8 @@ def test_translate_send_in_pings(tmpdir):
     assert objs["baseline"]["c"].send_in_pings == ["custom", "metrics"]
 
 
-def test_translate_dont_remove_extra_files(tmpdir):
-    output = Path(str(tmpdir)) / "foo"
+def test_translate_dont_remove_extra_files(tmp_path):
+    output = tmp_path / "foo"
     output.mkdir()
 
     with (output / "extra.txt").open("w") as fd:
@@ -172,20 +172,18 @@ def test_translate_dont_remove_extra_files(tmpdir):
     assert "extra.txt" in [str(x.name) for x in output.iterdir()]
 
 
-def test_external_translator(tmpdir):
-    tmpdir = Path(str(tmpdir))
-
+def test_external_translator(tmp_path):
     def external_translator(all_objects, output_dir, options):
         assert {"foo": "bar", "allow_reserved": True} == options
 
         for category in all_objects:
-            with (tmpdir / category).open("w") as fd:
+            with (tmp_path / category).open("w") as fd:
                 for metric in category:
                     fd.write(f"{metric}\n")
 
     translate.translate_metrics(
         ROOT / "data" / "core.yaml",
-        Path(str(tmpdir)),
+        tmp_path,
         external_translator,
         [],
         options={"foo": "bar"},
@@ -196,7 +194,7 @@ def test_external_translator(tmpdir):
 
     expected_keys = set(content.keys()) - set(["$schema"])
 
-    assert set(x.name for x in tmpdir.iterdir()) == expected_keys
+    assert set(x.name for x in tmp_path.iterdir()) == expected_keys
 
 
 def test_getting_line_number():
@@ -207,7 +205,7 @@ def test_getting_line_number():
     assert metrics["core_ping"]["seq"].defined_in["line"] == 69
 
 
-def test_rates(tmpdir):
+def test_rates(tmp_path):
     def external_translator(all_objects, output_dir, options):
         category = all_objects["testing.rates"]
         assert category["has_internal_denominator"].type == "rate"
@@ -236,7 +234,7 @@ def test_rates(tmpdir):
 
     translate.translate_metrics(
         ROOT / "data" / "rate.yaml",
-        Path(str(tmpdir)),
+        tmp_path,
         external_translator,
         [],
         options={"foo": "bar"},
@@ -244,8 +242,8 @@ def test_rates(tmpdir):
     )
 
 
-def test_with_tags(tmpdir):
-    output = Path(str(tmpdir)) / "tags_test"
+def test_with_tags(tmp_path):
+    output = tmp_path / "tags_test"
 
     translate.translate(
         [


### PR DESCRIPTION
See https://docs.pytest.org/en/7.4.x/how-to/tmp_path.html#tmpdir-and-tmpdir-factory

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
