### PR TITLE
DENG-2407 Update javascript server outputter to support mixed-style collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - BREAKING CHANGE: Expose the optional `enabled` property on pings, defaulting to `enabled: true` ([#681](https://github.com/mozilla/glean_parser/pull/681))
 - BREAKING CHANGE: Support metadata field `ping_schedule` for pings ([bug 1804711](https://bugzilla.mozilla.org/show_bug.cgi?id=1804711))
+- Add support for event metric type in server JavaScript outputter ([DENG-2407](https://mozilla-hub.atlassian.net/browse/DENG-2407))
 
 ## 13.0.1
 

--- a/glean_parser/templates/javascript_server.jinja2
+++ b/glean_parser/templates/javascript_server.jinja2
@@ -21,7 +21,7 @@ type LoggerOptions = { app: string; fmt?: 'heka' };
 type Event = {
   category: string;
   name: string;
-  extra: Record<string, any>;
+  extra?: Record<string, any>;
   timestamp?: number;
 };
 {% endif %}
@@ -30,14 +30,14 @@ type Event = {
 let _logger{% if lang == "typescript" %}: Logger{% endif %};
 
 {% for ping, metrics_by_type in pings.items() %}
-class {{ ping|event_class_name(event_metric_exists) }} {
+class {{ ping|event_class_name(metrics_by_type) }} {
   {% if lang == "typescript" %}
   _applicationId: string;
   _appDisplayVersion: string;
   _channel: string;
   {% endif %}
   /**
-   * Create {{ ping|event_class_name(event_metric_exists) }} instance.
+   * Create {{ ping|event_class_name(metrics_by_type) }} instance.
    *
    * @param {string} applicationId - The application ID.
    * @param {string} appDisplayVersion - The application display version.
@@ -72,7 +72,7 @@ class {{ ping|event_class_name(event_metric_exists) }} {
       {% endif %}
     }
   }
-  {% if event_metric_exists %}
+  {% if 'event' in metrics_by_type %}
   #record({
   {% else %}
   /**
@@ -99,28 +99,28 @@ class {{ ping|event_class_name(event_metric_exists) }} {
     {% endfor %}
     {% endif %}
     {% endfor %}
-    {% if event_metric_exists %}
+    {% if 'event' in metrics_by_type %}
     event,
     {% endif %}
   {% if lang == "typescript" %}
   }: {
-    user_agent: string,
-    ip_address: string,
+    user_agent: string;
+    ip_address: string;
     {% for metric_type, metrics in metrics_by_type.items() %}
     {% if metric_type != 'event' %}
     {% for metric in metrics %}
-    {{ metric|metric_argument_name }}: {{ metric|js_metric_type }},
+    {{ metric|metric_argument_name }}: {{ metric|js_metric_type }};
     {% endfor %}
     {% endif %}
     {% endfor %}
-    {% if event_metric_exists %}
-    event: Event
+    {% if 'event' in metrics_by_type %}
+    event: Event;
     {% endif %}
   {% endif %}
   }) {
     const now = new Date();
     const timestamp = now.toISOString();
-    {% if event_metric_exists %}
+    {% if 'event' in metrics_by_type %}
     event.timestamp = now.getTime();
     {% endif %}
     const eventPayload = {
@@ -135,7 +135,7 @@ class {{ ping|event_class_name(event_metric_exists) }} {
         {% endif %}
         {% endfor %}
       },
-      {% if event_metric_exists %}
+      {% if 'event' in metrics_by_type %}
       events: [event],
       {% endif %}
       ping_info: {
@@ -171,7 +171,7 @@ class {{ ping|event_class_name(event_metric_exists) }} {
     // this is similar to how FxA currently logs with mozlog: https://github.com/mozilla/fxa/blob/4c5c702a7fcbf6f8c6b1f175e9172cdd21471eac/packages/fxa-auth-server/lib/log.js#L289
     _logger.info(GLEAN_EVENT_MOZLOG_TYPE, ping);
   }
-  {% if event_metric_exists %}
+  {% if 'event' in metrics_by_type %}
   {% for event in metrics_by_type["event"] %}
   /**
    * Record and submit a {{ event.category }}_{{ event.name }} event:
@@ -209,27 +209,27 @@ class {{ ping|event_class_name(event_metric_exists) }} {
     {% endfor %}
   {% if lang == "typescript" %}
   }: {
-    user_agent: string,
-    ip_address: string,
+    user_agent: string;
+    ip_address: string;
     {% for metric_type, metrics in metrics_by_type.items() %}
     {% if metric_type != 'event' %}
     {% for metric in metrics %}
-    {{ metric|metric_argument_name }}: {{ metric|js_metric_type }},
+    {{ metric|metric_argument_name }}: {{ metric|js_metric_type }};
     {% endfor %}
     {% endif %}
     {% endfor %}
     {% for extra, metadata in event.extra_keys.items() %}
-    {{ extra }}: {{metadata.type}},
+    {{ extra }}: {{metadata.type}};
     {% endfor %}
   {% endif %}
   }) {
-    let event = {
-      'category': '{{ event.category }}',
-      'name': '{{ event.name }}',
+    const event = {
+      category: '{{ event.category }}',
+      name: '{{ event.name }}',
       {% if event.extra_keys %}
-      'extra': {
+      extra: {
         {% for extra, metadata in event.extra_keys.items() %}
-        '{{ extra }}': {{ extra }},
+        {{ extra }}: {{ extra }},
         {% endfor %}
       },
       {% endif %}
@@ -244,14 +244,14 @@ class {{ ping|event_class_name(event_metric_exists) }} {
       {% endfor %}
       {% endif %}
       {% endfor %}
-      event
+      event,
     });
   }
   {% endfor %}
   {% endif %}
 }
 {% endfor %}
-{% for ping in pings %}
+{% for ping, metrics_by_type in pings.items() %}
 
 /**
  * Factory function that creates an instance of Glean Server Event Logger to
@@ -262,11 +262,11 @@ class {{ ping|event_class_name(event_metric_exists) }} {
  * @param {Object} logger_options - The logger options.
  * @returns {EventsServerEventLogger} An instance of EventsServerEventLogger.
  */
-export const {{ ping|factory_method(event_metric_exists) }} = function ({
+export const {{ ping|factory_method(metrics_by_type) }} = function ({
   applicationId,
   appDisplayVersion,
   channel,
-  logger_options
+  logger_options,
 {% if lang == "typescript" %}
 }: {
   applicationId: string;
@@ -275,7 +275,7 @@ export const {{ ping|factory_method(event_metric_exists) }} = function ({
   logger_options: LoggerOptions;
 {% endif %}
 }) {
-  return new {{ ping|event_class_name(event_metric_exists) }}(
+  return new {{ ping|event_class_name(metrics_by_type) }}(
     applicationId,
     appDisplayVersion,
     channel,

--- a/tests/test_javascript_server.py
+++ b/tests/test_javascript_server.py
@@ -13,6 +13,8 @@ import subprocess
 from glean_parser import javascript_server
 from glean_parser import translate
 from glean_parser import validate_ping
+from glean_parser.metrics import Metric
+from unittest.mock import Mock
 
 
 ROOT = Path(__file__).parent
@@ -65,15 +67,13 @@ def test_parser_js_server(tmp_path):
 def test_generate_ping_factory_method():
     ping = "accounts_events"
     expected_result = "createAccountsEventsEvent"
-    result = javascript_server.generate_ping_factory_method(
-        ping, event_metric_exists=False
-    )
+    result = javascript_server.generate_ping_factory_method(ping, metrics_by_type={})
     assert result == expected_result
 
     ping = "accounts_events"
     expected_result = "createAccountsEventsServerEventLogger"
     result = javascript_server.generate_ping_factory_method(
-        ping, event_metric_exists=True
+        ping, metrics_by_type={"event": [Mock(spec=Metric)]}
     )
     assert result == expected_result
 


### PR DESCRIPTION
This allows JS outputter to support pings-as-events and event metric types in a single run.
We need this to switch FxA to the latter approach.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
