### PR TITLE
bug 1866559 - Support a no-info configuration for pings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- BREAKING CHANGE: Support metadata field `include_info_sections` ([bug 1866559](https://bugzilla.mozilla.org/show_bug.cgi?id=1866559))
+
 ## 12.0.1
 
 - Fix Rust codegen for object metric type ([#662](https://github.com/mozilla/glean_parser/pull/662))

--- a/glean_parser/pings.py
+++ b/glean_parser/pings.py
@@ -45,6 +45,7 @@ class Ping:
             metadata = {}
         self.metadata = metadata
         self.precise_timestamps = self.metadata.get("precise_timestamps", True)
+        self.include_info_sections = self.metadata.get("include_info_sections", True)
         if data_reviews is None:
             data_reviews = []
         self.data_reviews = data_reviews
@@ -90,6 +91,9 @@ class Ping:
         d = self.serialize()
         modified_dict = util.remove_output_params(d, "defined_in")
         modified_dict = util.remove_output_params(modified_dict, "precise_timestamps")
+        modified_dict = util.remove_output_params(
+            modified_dict, "include_info_sections"
+        )
         return modified_dict
 
     def identifier(self) -> str:

--- a/glean_parser/schemas/pings.2-0-0.schema.yaml
+++ b/glean_parser/schemas/pings.2-0-0.schema.yaml
@@ -84,6 +84,18 @@ additionalProperties:
             When `false` Glean uses minute-precise timestamps for
             the ping's start/end time.
           type: boolean
+        include_info_sections:
+          title: Include Info Sections
+          description: |
+            When `true`, assemble and include the `client_info` and `ping_info`
+            sections in the ping on submission.
+            When `false`, omit the `client_info` and `ping_info` sections when
+            assembling the ping on submission.
+            Defaults to `true`.
+
+            Interaction with `include_client_id`: `include_client_id` only takes
+            effect when `metadata.include_info_sections` is `true`.
+          type: boolean
 
       default: {}
 
@@ -93,6 +105,9 @@ additionalProperties:
         **Required.**
 
         When `true`, include the `client_id` value in the ping.
+
+        Interaction with `metadata.include_info_sections`: `include_client_id`
+        only takes effect when `metadata.include_info_sections` is `true`.
       type: boolean
 
     send_if_empty:

--- a/glean_parser/templates/rust.jinja2
+++ b/glean_parser/templates/rust.jinja2
@@ -92,7 +92,7 @@ impl ExtraKeys for {{ obj.name|Camelize }}{{ suffix }} {
 /// {{ obj.description|wordwrap() | replace('\n', '\n/// ') }}
 #[rustfmt::skip]
 pub static {{ obj.name|snake_case }}: ::glean::private::__export::Lazy<::glean::private::PingType> =
-    ::glean::private::__export::Lazy::new(|| ::glean::private::PingType::new("{{ obj.name }}", {{ obj.include_client_id|rust }}, {{ obj.send_if_empty|rust }}, {{ obj.precise_timestamps|rust }}, {{ obj.reason_codes|rust }}));
+    ::glean::private::__export::Lazy::new(|| ::glean::private::PingType::new("{{ obj.name }}", {{ obj.include_client_id|rust }}, {{ obj.send_if_empty|rust }}, {{ obj.precise_timestamps|rust }}, {{ obj.include_info_sections|rust }}, {{ obj.reason_codes|rust }}));
 {% endfor %}
 {% else %}
 pub mod {{ category.name|snake_case }} {

--- a/glean_parser/templates/swift.jinja2
+++ b/glean_parser/templates/swift.jinja2
@@ -96,6 +96,7 @@ extension {{ namespace }} {
             includeClientId: {{obj.include_client_id|swift}},
             sendIfEmpty: {{obj.send_if_empty|swift}},
             preciseTimestamps: {{obj.precise_timestamps|swift}},
+            includeInfoSections: {{obj.include_info_sections|swift}},
             reasonCodes: {{obj.reason_codes|swift}}
         )
 

--- a/glean_parser/util.py
+++ b/glean_parser/util.py
@@ -525,6 +525,7 @@ ping_args = [
     "include_client_id",
     "send_if_empty",
     "precise_timestamps",
+    "include_info_sections",
     "reason_codes",
 ]
 

--- a/tests/data/pings.yaml
+++ b/tests/data/pings.yaml
@@ -51,3 +51,18 @@ custom-ping-might-be-empty:
     serious:
       A serious reason for sending a ping.
   no_lint: [REDUNDANT_PING]
+
+custom-ping-no-info:
+  description:
+    A custom ping with no info sections
+  include_client_id: false
+  send_if_empty: true
+  bugs:
+    - http://bugzilla.mozilla.com/1866559
+  data_reviews:
+    - http://nowhere.com/reviews
+  notification_emails:
+    - CHANGE-ME@test-only.com
+  metadata:
+    include_info_sections: false
+  no_lint: [REDUNDANT_PING]


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly

----

I basically followed the pattern of `precise_timestamps`.

This _is_ different from [the proposed fields](https://docs.google.com/document/d/1iVvOpFj2gHxNjr2vv03E2rSDueA0hPurokoESG7VX6k/edit#heading=h.7jzekifnekju) (which were `metadata.ping_metadata.{client|ping}_info.enabled`) for the following reasons:
* We don't have a current or future case where we would want users to exclude an info section independently
* Aligns naming better with the similar `include_client_id`
* We can evolve the naming and structure later if/when needed (e.g. if we intend to allow including/excluding only certain fields in certain info sections)
* It was easier to implement