### PR TITLE
Bug 1886479 - Eventually use CSafeLoader as yaml loader

### DIFF
--- a/glean_parser/util.py
+++ b/glean_parser/util.py
@@ -20,6 +20,11 @@ import jsonschema  # type: ignore
 from jsonschema import _utils  # type: ignore
 import yaml
 
+try:
+    from yaml import CSafeLoader as SafeLoader
+except ImportError:
+    from yaml import SafeLoader  # type: ignore
+
 
 def date_fromisoformat(datestr: str) -> datetime.date:
     return datetime.date.fromisoformat(datestr)
@@ -44,7 +49,7 @@ class DictWrapper(dict):
     pass
 
 
-class _NoDatesSafeLoader(yaml.SafeLoader):
+class _NoDatesSafeLoader(SafeLoader):
     @classmethod
     def remove_implicit_resolver(cls, tag_to_remove):
         """


### PR DESCRIPTION
It is significantly faster than the Python parser. It saves more than 25% of the execution time when running the `run_glean_parser.py gifft_map` script in the Firefox codebase.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
