### PR TITLE
Bug 1889114 - Add 'enabled' property to pings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- BREAKING CHANGE: Expose the optional `enabled` property on pings, defaulting to `enabled: true` ([#681](https://github.com/mozilla/glean_parser/pull/681))
+
 ## 13.0.1
 
 - Use faster C yaml parser if available ([#677](https://github.com/mozilla/glean_parser/pull/677))

--- a/glean_parser/pings.py
+++ b/glean_parser/pings.py
@@ -31,6 +31,7 @@ class Ping:
         reasons: Optional[Dict[str, str]] = None,
         defined_in: Optional[Dict] = None,
         no_lint: Optional[List[str]] = None,
+        enabled: Optional[bool] = True,
         _validated: bool = False,
     ):
         # Avoid cyclical import
@@ -46,6 +47,7 @@ class Ping:
         self.metadata = metadata
         self.precise_timestamps = self.metadata.get("precise_timestamps", True)
         self.include_info_sections = self.metadata.get("include_info_sections", True)
+        self.enabled = enabled
         if data_reviews is None:
             data_reviews = []
         self.data_reviews = data_reviews

--- a/glean_parser/pings.py
+++ b/glean_parser/pings.py
@@ -31,7 +31,7 @@ class Ping:
         reasons: Optional[Dict[str, str]] = None,
         defined_in: Optional[Dict] = None,
         no_lint: Optional[List[str]] = None,
-        enabled: Optional[bool] = True,
+        enabled: Optional[bool] = None,
         _validated: bool = False,
     ):
         # Avoid cyclical import
@@ -47,6 +47,8 @@ class Ping:
         self.metadata = metadata
         self.precise_timestamps = self.metadata.get("precise_timestamps", True)
         self.include_info_sections = self.metadata.get("include_info_sections", True)
+        if enabled is None:
+            enabled = True
         self.enabled = enabled
         if data_reviews is None:
             data_reviews = []

--- a/glean_parser/schemas/pings.2-0-0.schema.yaml
+++ b/glean_parser/schemas/pings.2-0-0.schema.yaml
@@ -175,6 +175,18 @@ additionalProperties:
       additionalProperties:
         type: string
 
+    enabled:
+      title: Whether or not this ping is enabled
+      description: |
+        **Optional.**
+
+        When `true`, the ping will be sent as usual.
+        When `false`, the ping will not be sent, but the data will continue to
+        be collected but will not be cleared when the ping is submitted.
+
+        Defaults to `true` if omitted.
+      type: boolean
+
     no_lint:
       title: Lint checks to skip
       description: |

--- a/glean_parser/templates/rust.jinja2
+++ b/glean_parser/templates/rust.jinja2
@@ -87,7 +87,7 @@ impl ExtraKeys for {{ obj.name|Camelize }}{{ suffix }} {
 /// {{ obj.description|wordwrap() | replace('\n', '\n/// ') }}
 #[rustfmt::skip]
 pub static {{ obj.name|snake_case }}: ::glean::private::__export::Lazy<::glean::private::PingType> =
-    ::glean::private::__export::Lazy::new(|| ::glean::private::PingType::new("{{ obj.name }}", {{ obj.include_client_id|rust }}, {{ obj.send_if_empty|rust }}, {{ obj.precise_timestamps|rust }}, {{ obj.include_info_sections|rust }}, {{ obj.reason_codes|rust }}, {{ obj.enabled|rust}}));
+    ::glean::private::__export::Lazy::new(|| ::glean::private::PingType::new("{{ obj.name }}", {{ obj.include_client_id|rust }}, {{ obj.send_if_empty|rust }}, {{ obj.precise_timestamps|rust }}, {{ obj.include_info_sections|rust }}, {{ obj.enabled|rust}}, {{ obj.reason_codes|rust }}));
 {% endfor %}
 {% else %}
 pub mod {{ category.name|snake_case }} {

--- a/glean_parser/templates/rust.jinja2
+++ b/glean_parser/templates/rust.jinja2
@@ -87,7 +87,7 @@ impl ExtraKeys for {{ obj.name|Camelize }}{{ suffix }} {
 /// {{ obj.description|wordwrap() | replace('\n', '\n/// ') }}
 #[rustfmt::skip]
 pub static {{ obj.name|snake_case }}: ::glean::private::__export::Lazy<::glean::private::PingType> =
-    ::glean::private::__export::Lazy::new(|| ::glean::private::PingType::new("{{ obj.name }}", {{ obj.include_client_id|rust }}, {{ obj.send_if_empty|rust }}, {{ obj.precise_timestamps|rust }}, {{ obj.include_info_sections|rust }}, {{ obj.reason_codes|rust }}));
+    ::glean::private::__export::Lazy::new(|| ::glean::private::PingType::new("{{ obj.name }}", {{ obj.include_client_id|rust }}, {{ obj.send_if_empty|rust }}, {{ obj.precise_timestamps|rust }}, {{ obj.include_info_sections|rust }}, {{ obj.reason_codes|rust }}, {{ obj.enabled|rust}}));
 {% endfor %}
 {% else %}
 pub mod {{ category.name|snake_case }} {

--- a/glean_parser/templates/swift.jinja2
+++ b/glean_parser/templates/swift.jinja2
@@ -97,7 +97,8 @@ extension {{ namespace }} {
             sendIfEmpty: {{obj.send_if_empty|swift}},
             preciseTimestamps: {{obj.precise_timestamps|swift}},
             includeInfoSections: {{obj.include_info_sections|swift}},
-            reasonCodes: {{obj.reason_codes|swift}}
+            reasonCodes: {{obj.reason_codes|swift}},
+            enabled: {{obj.enabled|swift}}
         )
 
       {% endfor %}

--- a/glean_parser/templates/swift.jinja2
+++ b/glean_parser/templates/swift.jinja2
@@ -97,8 +97,8 @@ extension {{ namespace }} {
             sendIfEmpty: {{obj.send_if_empty|swift}},
             preciseTimestamps: {{obj.precise_timestamps|swift}},
             includeInfoSections: {{obj.include_info_sections|swift}},
-            reasonCodes: {{obj.reason_codes|swift}},
-            enabled: {{obj.enabled|swift}}
+            enabled: {{obj.enabled|swift}},
+            reasonCodes: {{obj.reason_codes|swift}}
         )
 
       {% endfor %}

--- a/glean_parser/util.py
+++ b/glean_parser/util.py
@@ -531,6 +531,7 @@ ping_args = [
     "send_if_empty",
     "precise_timestamps",
     "include_info_sections",
+    "enabled",
     "reason_codes",
 ]
 

--- a/tests/data/pings.yaml
+++ b/tests/data/pings.yaml
@@ -66,3 +66,31 @@ custom-ping-no-info:
   metadata:
     include_info_sections: false
   no_lint: [REDUNDANT_PING]
+
+custom-ping-enabled:
+  description:
+    A custom ping with an explicit enabled property set to true
+  include_client_id: false
+  send_if_empty: true
+  bugs:
+    - http://bugzilla.mozilla.com/1866559
+  data_reviews:
+    - http://nowhere.com/reviews
+  notification_emails:
+    - CHANGE-ME@test-only.com
+  enabled: true
+  no_lint: [REDUNDANT_PING]
+
+custom-ping-disabled:
+  description:
+    A custom ping with an explicit enabled property set to false
+  include_client_id: false
+  send_if_empty: true
+  bugs:
+    - http://bugzilla.mozilla.com/1866559
+  data_reviews:
+    - http://nowhere.com/reviews
+  notification_emails:
+    - CHANGE-ME@test-only.com
+  enabled: false
+  no_lint: [REDUNDANT_PING]

--- a/tests/test_pings.py
+++ b/tests/test_pings.py
@@ -74,3 +74,10 @@ def test_send_if_empty():
     util.add_required_ping(content)
     errors = list(parser.parse_objects([content]))
     assert len(errors) == 0
+
+def test_send_if_disabled():
+    content = {"disabled-ping": {"include_client_id": True, "enabled": False}}
+
+    util.add_required_ping(content)
+    errors = list(parser.parse_objects([content]))
+    assert len(errors) == 0


### PR DESCRIPTION
This is enabled initially for Swift, Kotlin, and Rust