### PR TITLE
Bug 1874935 - Add definition of the `events` ping for server-side Glean

### DIFF
--- a/server-side-pings.yaml
+++ b/server-side-pings.yaml
@@ -1,0 +1,23 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This file defines the pings that are recorded by server-side Glean.
+# Their code APIs is automatically generated, at build time using,
+# the `glean_parser` PyPI package.
+
+---
+$schema: moz://mozilla.org/schemas/glean/pings/2-0-0
+
+events:
+  description: |
+    The events ping's purpose is to transport all of the event metric
+    information. The `events` ping is automatically sent when the application
+    becomes inactive.
+  include_client_id: true
+  bugs:
+    - https://bugzilla.mozilla.org/1512938
+  data_reviews:
+    - https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3
+  notification_emails:
+    - glean-team@mozilla.com


### PR DESCRIPTION
will be included in https://github.com/mozilla/probe-scraper/pull/717 then