### PR TITLE
Use importlib.metadata instead of deprecated pkg_resources

### DIFF
--- a/glean_parser/__init__.py
+++ b/glean_parser/__init__.py
@@ -6,11 +6,11 @@
 
 """Top-level package for Glean parser."""
 
-from pkg_resources import get_distribution, DistributionNotFound
+import importlib.metadata
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    __version__ = importlib.metadata.version(__name__)
+except importlib.metadata.PackageNotFoundError:
     # package is not installed
     pass
 

--- a/glean_parser/util.py
+++ b/glean_parser/util.py
@@ -406,7 +406,7 @@ def is_expired(expires: str, major_version: Optional[int] = None) -> bool:
         return parse_expiration_version(expires) <= major_version
     else:
         date = parse_expiration_date(expires)
-        return date <= datetime.datetime.utcnow().date()
+        return date <= datetime.datetime.now(datetime.timezone.utc).date()
 
 
 def validate_expires(expires: str, major_version: Optional[int] = None) -> None:
@@ -458,7 +458,7 @@ def build_date(date: Optional[str]) -> datetime.datetime:
         else:
             ts = datetime_fromisoformat(date).replace(tzinfo=datetime.timezone.utc)
     else:
-        ts = datetime.datetime.utcnow()
+        ts = datetime.datetime.now(datetime.timezone.utc)
 
     return ts
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,7 +8,6 @@ ruff==0.4.2
 Sphinx==7.3.7; python_version > '3.8'
 twine==5.0.0
 types-Jinja2==2.11.9
-types-pkg_resources==0.1.3
 types-PyYAML==6.0.12.20240311
 wheel
 yamllint==1.28.0

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -52,7 +52,7 @@ def test_expires():
     """
     for date, expired in [
         ("2018-06-10", True),
-        (datetime.datetime.utcnow().date().isoformat(), True),
+        (datetime.datetime.now(datetime.timezone.utc).date().isoformat(), True),
         ("3000-01-01", False),
     ]:
         m = metrics.Boolean(


### PR DESCRIPTION
importlib.metadata is available since Python 3.8, the minimum Python we support.### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
