### PR TITLE
Bug 1874935 - Send internal server metrics only in events ping

### DIFF
--- a/server_telemetry/sdk-metrics-compat.yaml
+++ b/server_telemetry/sdk-metrics-compat.yaml
@@ -16,7 +16,7 @@ glean.client.annotation:
     type: string
     lifetime: application
     send_in_pings:
-      - all-pings
+      - events
     description: |
       An experimentation identifier derived and provided by the application
       for the purpose of experimentation enrollment.
@@ -46,7 +46,7 @@ glean.error:
       - glean-team@mozilla.com
     expires: never
     send_in_pings:
-      - all-pings
+      - events
     no_lint:
       - COMMON_PREFIX
 
@@ -65,7 +65,7 @@ glean.error:
       - glean-team@mozilla.com
     expires: never
     send_in_pings:
-      - all-pings
+      - events
     no_lint:
       - COMMON_PREFIX
 
@@ -84,7 +84,7 @@ glean.error:
       - glean-team@mozilla.com
     expires: never
     send_in_pings:
-      - all-pings
+      - events
     no_lint:
       - COMMON_PREFIX
 
@@ -103,6 +103,6 @@ glean.error:
       - glean-team@mozilla.com
     expires: never
     send_in_pings:
-      - all-pings
+      - events
     no_lint:
       - COMMON_PREFIX


### PR DESCRIPTION
See Option 2 in https://bugzilla.mozilla.org/show_bug.cgi?id=1874935#c16



### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
