### PR TITLE
Bug 1894270 - ping_schedule: Gracefully handle missing ping

### DIFF
--- a/glean_parser/parser.py
+++ b/glean_parser/parser.py
@@ -299,8 +299,6 @@ def _instantiate_pings(
                     ping_schedule_reverse_map[ping_schedule] = set()
                 ping_schedule_reverse_map[ping_schedule].add(ping_key)
 
-            del ping_val["metadata"]["ping_schedule"]
-
         try:
             ping_obj = Ping(
                 defined_in=getattr(ping_val, "defined_in", None),
@@ -331,7 +329,9 @@ def _instantiate_pings(
             sources[ping_key] = filepath
 
     for scheduler, scheduled in ping_schedule_reverse_map.items():
-        if isinstance(all_objects["pings"][scheduler], Ping):
+        if scheduler in all_objects["pings"] and isinstance(
+            all_objects["pings"][scheduler], Ping
+        ):
             scheduler_obj: Ping = cast(Ping, all_objects["pings"][scheduler])
             scheduler_obj.schedules_pings = sorted(list(scheduled))
 


### PR DESCRIPTION
This is for those cases where the referenced ping is not part of the same ping definition, e.g. builtin pings.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
