### PR TITLE
Object metric: Generate typealias for top-level items

### DIFF
--- a/glean_parser/templates/kotlin.jinja2
+++ b/glean_parser/templates/kotlin.jinja2
@@ -121,6 +121,24 @@ data class {{ obj.name|Camelize }}{{ suffix }}(
 
 {% endmacro %}
 
+{%- macro generate_structure_typealias(name, struct) %}
+{%- if struct.type == "array" -%}
+    {{ generate_structure_typealias(name ~ "Item", struct["items"]) }}
+{%- elif struct.type == "object" -%}
+    {% for itemname, val in struct.properties.items() %}
+        {% if val.type == "array" %}
+        {% set nested_name = name ~ "Item" ~ itemname|Camelize %}
+        {{ generate_structure_typealias(nested_name, val) }}
+        {% elif val.type == "object" %}
+        {% set nested_name = name ~ "Item" ~ itemname|Camelize ~ "Object" %}
+        {{ generate_structure_typealias(nested_name, val) }}
+        {% endif %}
+    {% endfor %}
+{%- else -%}
+    typealias {{ name }} = {{ struct.type|structure_type_name }}
+{% endif %}
+{% endmacro %}
+
 /* ktlint-disable no-blank-line-before-rbrace */
 @file:Suppress("PackageNaming", "MaxLineLength")
 package {{ namespace }}
@@ -147,6 +165,13 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 {% endif %}
 
+{# HACK HACK HACK -- typealiases MUST BE top-level #}
+{% for obj in objs.values() %}
+{% if obj|attr("_generate_structure") %}
+{{ generate_structure_typealias(obj.name|Camelize ~ "Object", obj._generate_structure) }}
+{%- endif %}
+{% endfor %}
+{# HACK end #}
 internal object {{ category_name|Camelize }} {
 {% for obj in objs.values() %}
     {% if obj.type == "ping" %}

--- a/glean_parser/templates/swift.jinja2
+++ b/glean_parser/templates/swift.jinja2
@@ -80,7 +80,11 @@ struct {{ obj.name|Camelize }}{{ suffix }}: EventExtras {
         {% endif %}
     {% endfor %}
 
-{%- endif -%}
+{%- else -%}
+
+    typealias {{ name }} = {{ struct.type|structure_type_name }}
+
+{% endif -%}
 
 {% endmacro %}
 

--- a/tests/test_kotlin.py
+++ b/tests/test_kotlin.py
@@ -472,6 +472,13 @@ def test_object_metric(tmp_path):
         ["ActivityStream.kt", "ComplexTypes.kt", "CrashStack.kt", "GleanBuildInfo.kt"]
     )
 
+    with (tmp_path / "ComplexTypes.kt").open("r", encoding="utf-8") as fd:
+        content = fd.read()
+        content = " ".join(content.split())
+
+        assert "typealias ArrayInArrayObjectItemItem = Boolean" in content
+        assert "typealias NumberArrayObjectItem = Int" in content
+
     with (tmp_path / "CrashStack.kt").open("r", encoding="utf-8") as fd:
         content = fd.read()
         content = " ".join(content.split())

--- a/tests/test_swift.py
+++ b/tests/test_swift.py
@@ -363,6 +363,9 @@ def test_object_metric(tmp_path):
         content = fd.read()
         content = " ".join(content.split())
 
+        assert "typealias ArrayInArrayObjectItemItem = Bool" in content
+        assert "typealias NumberArrayObjectItem = Int64" in content
+
         assert "ObjectMetricType<ThreadsObject>" in content
         assert "typealias ThreadsObject = [ThreadsObjectItem]" in content
         assert "struct ThreadsObjectItem: Codable, Equatable, ObjectSerialize {" in content


### PR DESCRIPTION
This is the patch that will make https://github.com/mozilla/glean/pull/2895 work