### PR TITLE
Add the `commonjs_server` option to the javascript_server outputter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add the `module_spec` option to the javascript_server outputter ([#726](https://github.com/mozilla/glean_parser/pull/726))
+
 ## 14.2.0
 
 - New Metric Types: `labeled_{custom|memory|timing}_distribution` ([bug 1657947](https://bugzilla.mozilla.org/show_bug.cgi?id=1657947))

--- a/glean_parser/javascript_server.py
+++ b/glean_parser/javascript_server.py
@@ -87,6 +87,7 @@ def output(
     lang: str,
     objs: metrics.ObjectTree,
     output_dir: Path,
+    options: Optional[Dict[str, Any]] = None,
 ) -> None:
     """
     Given a tree of objects, output Javascript or Typescript code to `output_dir`.
@@ -99,6 +100,16 @@ def output(
         `parser.parse_objects`.
     :param output_dir: Path to an output directory to write to.
     """
+
+    if options is None:
+        options = {}
+
+    module_spec = options.get("module_spec", "es")
+    accepted_module_specs = ["es", "commonjs"]
+    if module_spec not in accepted_module_specs:
+        raise ValueError(
+            f"Unknown module_spec: {module_spec}. Accepted specs are: {accepted_module_specs}."  # noqa
+        )
 
     template = util.get_jinja2_template(
         "javascript_server.jinja2",
@@ -184,6 +195,7 @@ def output(
                 parser_version=__version__,
                 pings=ping_to_metrics,
                 event_metric_exists=event_metric_exists,
+                module_spec=module_spec,
                 lang=lang,
             )
         )
@@ -198,9 +210,13 @@ def output_javascript(
     :param objects: A tree of objects (metrics and pings) as returned from
         `parser.parse_objects`.
     :param output_dir: Path to an output directory to write to.
+    :param options: options dictionary, with the following optional keys:
+
+        - `module_spec`: Module specification to use. Options are `es`, `commonjs`.
+                        Default is `es`.
     """
 
-    output("javascript", objs, output_dir)
+    output("javascript", objs, output_dir, options)
 
 
 def output_typescript(
@@ -214,4 +230,4 @@ def output_typescript(
     :param output_dir: Path to an output directory to write to.
     """
 
-    output("typescript", objs, output_dir)
+    output("typescript", objs, output_dir, options)

--- a/glean_parser/templates/javascript_server.jinja2
+++ b/glean_parser/templates/javascript_server.jinja2
@@ -11,8 +11,13 @@ Jinja2 template is not. Please file bugs! #}
 // @types/uuid and mozlog types definitions are required in devDependencies
 // for the latter see https://github.com/mozilla/fxa/blob/85bda71cda376c417b8c850ba82aa14252208c3c/types/mozlog/index.d.ts
 {% endif %}
+{% if module_spec == "commonjs" %}
+const uuidv4 = require('uuid').v4;
+const mozlog = require('mozlog');
+{% else %}
 import { v4 as uuidv4 } from 'uuid';
 import mozlog{% if lang == "typescript" %}, { Logger }{% endif %} from 'mozlog';
+{% endif %}
 
 const GLEAN_EVENT_MOZLOG_TYPE = 'glean-server-event';
 {% if lang == "typescript" %}
@@ -262,7 +267,11 @@ class {{ ping|event_class_name(metrics_by_type) }} {
  * @param {Object} logger_options - The logger options.
  * @returns {EventsServerEventLogger} An instance of EventsServerEventLogger.
  */
+{% if module_spec == "commonjs" %}
+module.exports.{{ ping|factory_method(metrics_by_type) }} = function ({
+{% else %}
 export const {{ ping|factory_method(metrics_by_type) }} = function ({
+{% endif %}
   applicationId,
   appDisplayVersion,
   channel,


### PR DESCRIPTION
Unfortunately some nodejs services still need to use CommonJS.  This patch adds an `-f` option to generate JS in the CommonJS module format.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
  - I didn't see any existing tests for the javascript_server outputter that tests individual -f options...?
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
