### PR TITLE
bug 1910976 - Expand acceptable extra_keys property names to printable ASCII (from dotted.snake_case)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix JS and Ruby server templates to correctly send event extra values as strings ([DENG-4405](https://mozilla-hub.atlassian.net/browse/DENG-4405))
+- ENHANCEMENT: Extra keys in `extra_keys:` fields may now contain any printable ASCII characters ([bug 1910976](https://bugzilla.mozilla.org/show_bug.cgi?id=1910976))
 
 ## 14.3.0
 

--- a/glean_parser/schemas/metrics.2-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.2-0-0.schema.yaml
@@ -28,6 +28,11 @@ definitions:
     pattern: "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})*$"
     maxLength: 40
 
+  event_extra_key:
+    type: string
+    pattern: "^[ -~]+$"
+    maxLength: 40
+
   # Prior to version 2.0.0 of the schema, special ping names with underscores
   # were also supported.
   kebab_case:
@@ -385,7 +390,7 @@ definitions:
           Valid when `type`_ is `event`.
         type: object
         propertyNames:
-          $ref: "#/definitions/dotted_snake_case"
+          $ref: "#/definitions/event_extra_key"
         additionalProperties:
           type: object
           properties:

--- a/tests/data/all_metrics.yaml
+++ b/tests/data/all_metrics.yaml
@@ -96,6 +96,9 @@ all_metrics:
       source:
         description: Source of this event
         type: string
+      extraKeyNOTJUSTdotted.snake:
+        description: An extra key with an expressive name.
+        type: boolean
 
   quantity:
     <<: *defaults

--- a/tests/data/event_key_ordering.yaml
+++ b/tests/data/event_key_ordering.yaml
@@ -27,4 +27,7 @@ event:
       bob:
         description: "three"
         type: string
+      And1WithExtraCasing:
+        description: "four"
+        type: boolean
     expires: 2100-01-01

--- a/tests/test_javascript.py
+++ b/tests/test_javascript.py
@@ -283,7 +283,7 @@ def test_event_extra_keys_in_correct_order(tmp_path):
     with (tmp_path / "event.js").open("r", encoding="utf-8") as fd:
         content = fd.read()
         content = " ".join(content.split())
-        assert '["alice", "bob", "charlie"]' in content
+        assert '["And1WithExtraCasing", "alice", "bob", "charlie"]' in content
 
 
 def test_arguments_are_generated_in_deterministic_order(tmp_path):
@@ -304,7 +304,7 @@ def test_arguments_are_generated_in_deterministic_order(tmp_path):
     with (tmp_path / "event.js").open("r", encoding="utf-8") as fd:
         content = fd.read()
         content = " ".join(content.split())
-        expected = 'export const example = new EventMetricType({ category: "event", name: "example", sendInPings: ["events"], lifetime: "ping", disabled: false, }, ["alice", "bob", "charlie"]);'  # noqa
+        expected = 'export const example = new EventMetricType({ category: "event", name: "example", sendInPings: ["events"], lifetime: "ping", disabled: false, }, ["And1WithExtraCasing", "alice", "bob", "charlie"]);'  # noqa
         assert expected in content
 
 

--- a/tests/test_kotlin.py
+++ b/tests/test_kotlin.py
@@ -365,11 +365,12 @@ def test_event_extra_keys_in_correct_order(tmp_path):
         content = fd.read()
         content = " ".join(content.split())
         assert "ExampleExtra(" in content
+        assert "and1withextracasing:" in content
         assert "alice:" in content
         assert "bob:" in content
         assert "charlie:" in content
         assert ": EventExtras" in content
-        assert 'allowedExtraKeys = listOf("alice", "bob", "charlie")' in content
+        assert 'allowedExtraKeys = listOf("And1WithExtraCasing", "alice", "bob", "charlie")' in content
 
 
 def test_arguments_are_generated_in_deterministic_order(tmp_path):
@@ -392,7 +393,7 @@ def test_arguments_are_generated_in_deterministic_order(tmp_path):
     with (tmp_path / "Event.kt").open("r", encoding="utf-8") as fd:
         content = fd.read()
         content = " ".join(content.split())
-        expected = 'EventMetricType<ExampleExtra> by lazy { // generated from event.example EventMetricType<ExampleExtra>( CommonMetricData( category = "event", name = "example", sendInPings = listOf("events"), lifetime = Lifetime.PING, disabled = false ), allowedExtraKeys = listOf("alice", "bob", "charlie")) } }'  # noqa
+        expected = 'EventMetricType<ExampleExtra> by lazy { // generated from event.example EventMetricType<ExampleExtra>( CommonMetricData( category = "event", name = "example", sendInPings = listOf("events"), lifetime = Lifetime.PING, disabled = false ), allowedExtraKeys = listOf("And1WithExtraCasing", "alice", "bob", "charlie")) } }'  # noqa
         assert expected in content
 
 

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -194,7 +194,8 @@ def test_event_extra_keys_in_correct_order(tmp_path):
         print(content)
         content = " ".join(content.split())
         assert (
-            r"<ul><li>alice: two</li>"
+            r"<ul><li>And1WithExtraCasing: four</li>"
+            r"<li>alice: two</li>"
             r"<li>bob: three</li>"
             r"<li>charlie: one</li></ul>" in content
         )

--- a/tests/test_swift.py
+++ b/tests/test_swift.py
@@ -288,9 +288,9 @@ def test_event_extra_keys_in_correct_order(tmp_path):
         content = " ".join(content.split())
         assert (
             "struct ExampleExtra: EventExtras "
-            "{ var alice: String? var bob: String? var charlie: String?" in content
+            "{ var and1withextracasing: Bool? var alice: String? var bob: String? var charlie: String?" in content
         )
-        assert ', ["alice", "bob", "charlie"]' in content
+        assert ', ["And1WithExtraCasing", "alice", "bob", "charlie"]' in content
 
 
 def test_event_extra_keys_with_types(tmp_path):


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly


I do not believe this to be a breaking change as it is backwards-compatible.