### PR TITLE
bug 1911165 - Fix rust codegen for typed extras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- BUGFIX: Fix Rust codegen to properly handle events with multiple types of extras ([bug 1911165](https://bugzilla.mozilla.org/show_bug.cgi?id=1911165))
+
 ## 14.4.0
 
 - Fix JS and Ruby server templates to correctly send event extra values as strings ([DENG-4405](https://mozilla-hub.atlassian.net/browse/DENG-4405))

--- a/glean_parser/templates/rust.jinja2
+++ b/glean_parser/templates/rust.jinja2
@@ -74,7 +74,7 @@ impl ExtraKeys for {{ obj.name|Camelize }}{{ suffix }} {
     fn into_ffi_extra(self) -> ::std::collections::HashMap<::std::string::String, ::std::string::String> {
         let mut map = ::std::collections::HashMap::new();
         {% for key, _ in obj|attr(name) %}
-        self.{{key|snake_case}}.and_then(|val| map.insert("{{key}}".to_string(), val));
+        self.{{key|snake_case}}.and_then(|val| map.insert("{{key}}".to_string(), val.to_string()));
         {% endfor %}
         map
     }


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
