### PR TITLE
 Reapply "Bug 1906941 - Update kotlin jinja template import statement (#740)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **Breaking change:** Updating Kotlin template import statement as part of removing `service-glean` from Android Components. ([bug 1906941](https://bugzilla.mozilla.org/show_bug.cgi?id=1906941))
+
 ## 14.5.2
 
 - Revert updating Kotlin template import statement as part of removing `service-glean` from Android Components.

--- a/glean_parser/templates/kotlin.geckoview.jinja2
+++ b/glean_parser/templates/kotlin.geckoview.jinja2
@@ -15,7 +15,7 @@ package {{ namespace }}
 
 import {{ glean_namespace }}.private.BooleanMetricType // ktlint-disable import-ordering no-unused-imports
 import {{ glean_namespace }}.private.CounterMetricType // ktlint-disable import-ordering no-unused-imports
-import {{ glean_namespace }}.private.HistogramMetricBase // ktlint-disable import-ordering no-unused-imports
+import {{ glean_namespace }}.private.HistogramBase // ktlint-disable import-ordering no-unused-imports
 import {{ glean_namespace }}.private.LabeledMetricType // ktlint-disable import-ordering no-unused-imports
 import {{ glean_namespace }}.private.QuantityMetricType // ktlint-disable import-ordering no-unused-imports
 import {{ glean_namespace }}.private.StringMetricType // ktlint-disable import-ordering no-unused-imports
@@ -28,7 +28,7 @@ internal object GleanGeckoMetricsMapping {
     // Support exfiltration of Gecko histograms from products using both the
     // Glean SDK and GeckoView. See bug 1566356 for more context.
     @Suppress("UNUSED_PARAMETER")
-    fun getHistogram(geckoMetricName: String): HistogramMetricBase? {
+    fun getHistogram(geckoMetricName: String): HistogramBase? {
     {% if 'histograms' in gecko_metrics %}
         return when (geckoMetricName) {
         {% for category in gecko_metrics['histograms'].keys()|sort %}

--- a/tests/test_kotlin.py
+++ b/tests/test_kotlin.py
@@ -274,13 +274,13 @@ def test_gecko_datapoints(tmp_path):
     with (tmp_path / "GleanGeckoMetricsMapping.kt").open("r", encoding="utf-8") as fd:
         content = fd.read()
         # Make sure we're adding the relevant Glean SDK import, once.
-        assert content.count("import Bar.private.HistogramMetricBase") == 1
+        assert content.count("import Bar.private.HistogramBase") == 1
 
         # Validate the generated Gecko metric mapper Kotlin functions.
         # NOTE: Indentation, whitespaces  and text formatting of the block
         # below are important. Do not change them unless the file format
         # changes, otherwise validation will fail.
-        expected_func = """    fun getHistogram(geckoMetricName: String): HistogramMetricBase? {
+        expected_func = """    fun getHistogram(geckoMetricName: String): HistogramBase? {
         return when (geckoMetricName) {
             // From GfxContentCheckerboard.kt
             "CHECKERBOARD_DURATION" -> GfxContentCheckerboard.duration
@@ -338,7 +338,7 @@ def test_gecko_datapoints(tmp_path):
     for file_name in metrics_files:
         with (tmp_path / file_name).open("r", encoding="utf-8") as fd:
             content = fd.read()
-            assert "HistogramMetricBase" not in content
+            assert "HistogramBase" not in content
 
     run_linters(tmp_path.glob("*.kt"))
 


### PR DESCRIPTION
This reverts commit 55f5e77.

This needs #744 to land and be released first in a patch release.
This one is then a breaking change to go into a major release.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
