### PR TITLE
Bug 1915744 - Rust codegen: use correctly named parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Rust codegen: use correctly named parameter for events without extras ([#750](https://github.com/mozilla/glean_parser/pull/750))
+
 ## 15.0.0
 
 - **Breaking change:** Updating Kotlin template import statement as part of removing `service-glean` from Android Components. ([bug 1906941](https://bugzilla.mozilla.org/show_bug.cgi?id=1906941))

--- a/glean_parser/rust.py
+++ b/glean_parser/rust.py
@@ -109,7 +109,7 @@ def type_name(obj):
                 generic = util.Camelize(obj.name) + suffix
             else:
                 if isinstance(obj, metrics.Event):
-                    generic = "NoExtra"
+                    generic = "NoExtraKeys"
                 else:
                     generic = "No" + suffix
 

--- a/tests/test_rust.py
+++ b/tests/test_rust.py
@@ -132,7 +132,7 @@ def test_metric_type_name():
         expires="never",
     )
 
-    assert rust.type_name(event) == "EventMetric<NoExtra>"
+    assert rust.type_name(event) == "EventMetric<NoExtraKeys>"
 
     boolean = metrics.Boolean(
         type="boolean",


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
