### PR TITLE
Bug 1922086 - Remove now-unused keyword argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Bugfix: Remove unused keyword argument from exception ([#755](https://github.com/mozilla/glean_parser/pull/755))
+
 ## 15.0.1
 
 - Rust codegen: use correctly named parameter for events without extras ([#750](https://github.com/mozilla/glean_parser/pull/750))

--- a/glean_parser/translate.py
+++ b/glean_parser/translate.py
@@ -11,7 +11,6 @@ High-level interface for translating `metrics.yaml` into other formats.
 from pathlib import Path
 import os
 import shutil
-import sys
 import tempfile
 from typing import Any, Callable, Dict, Iterable, List, Optional
 
@@ -98,7 +97,6 @@ def transform_metrics(objects):
             raise ValueError(
                 f"No `counter` named {denominator_name} found to be used as"
                 "denominator for {numerators}",
-                file=sys.stderr,
             )
         counters[denominator_name].__class__ = metrics.Denominator
         counters[denominator_name].type = "denominator"


### PR DESCRIPTION
When we switched from just printing the error to raising it as an exception, we accidentally left the `file` argument in. It's not needed and not accepted by ValueError.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
