### PR TITLE
[go server] enable configurable writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Enable configurable Writer for log output (`go_server`) ([#](https://github.com/mozilla/glean_parser/pull/))
+
 ## 15.2.1
 
 - Allow earlier versions of platformdirs ([#769](https://github.com/mozilla/glean_parser/pull/769))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Enable configurable Writer for log output (`go_server`) ([#](https://github.com/mozilla/glean_parser/pull/))
+- Enable configurable Writer for log output (`go_server`) ([#775](https://github.com/mozilla/glean_parser/pull/775))
 
 ## 15.2.1
 

--- a/glean_parser/templates/go_server.jinja2
+++ b/glean_parser/templates/go_server.jinja2
@@ -11,6 +11,7 @@ package glean
 import (
 	"encoding/json"
     "fmt"
+	"io"
 	"strconv"
 	"time"
 
@@ -24,6 +25,7 @@ type GleanEventsLogger struct {
 	AppID             string // Application Id to identify application per Glean standards
 	AppDisplayVersion string // Version of application emitting the event
 	AppChannel        string // Channel to differentiate logs from prod/beta/staging/devel
+	Writer            io.Writer // Writer to output to. Normal operation expects os.Stdout
 }
 
 // exported type for public method parameters
@@ -157,7 +159,9 @@ func (g GleanEventsLogger) record(
 	if envelopeErr != nil {
 		panic("Unable to marshal log envelope to json")
 	}
-	fmt.Println(string(envelopeJson))
+	if g.Writer != nil {
+		fmt.Fprintln(g.Writer, string(envelopeJson))
+	}
 }
 {# if any ping has an event metric, create methods and types for them #}
 {% if events %}

--- a/glean_parser/templates/go_server.jinja2
+++ b/glean_parser/templates/go_server.jinja2
@@ -21,6 +21,10 @@ import (
 // log type string used to identify logs to process in the Moz Data Pipeline
 var gleanEventMozlogType string = "glean-server-event"
 
+// A GleanEventsLogger produces output in the required format for Glean to ingest.
+// Glean ingestion requires the output to be written to os.Stdout. Writing to a different
+// output will require the consumer to handle any closing as appropriate for the Writer.
+// e.g. if writing to a file.
 type GleanEventsLogger struct {
 	AppID             string // Application Id to identify application per Glean standards
 	AppDisplayVersion string // Version of application emitting the event

--- a/tests/data/server_custom_ping_only_compare.go
+++ b/tests/data/server_custom_ping_only_compare.go
@@ -20,6 +20,10 @@ import (
 // log type string used to identify logs to process in the Moz Data Pipeline
 var gleanEventMozlogType string = "glean-server-event"
 
+// A GleanEventsLogger produces output in the required format for Glean to ingest.
+// Glean ingestion requires the output to be written to os.Stdout. Writing to a different
+// output will require the consumer to handle any closing as appropriate for the Writer.
+// e.g. if writing to a file.
 type GleanEventsLogger struct {
 	AppID             string // Application Id to identify application per Glean standards
 	AppDisplayVersion string // Version of application emitting the event

--- a/tests/data/server_custom_ping_only_compare.go
+++ b/tests/data/server_custom_ping_only_compare.go
@@ -10,6 +10,7 @@ package glean
 import (
 	"encoding/json"
     "fmt"
+	"io"
 	"strconv"
 	"time"
 
@@ -23,6 +24,7 @@ type GleanEventsLogger struct {
 	AppID             string // Application Id to identify application per Glean standards
 	AppDisplayVersion string // Version of application emitting the event
 	AppChannel        string // Channel to differentiate logs from prod/beta/staging/devel
+	Writer            io.Writer // Writer to output to. Normal operation expects os.Stdout
 }
 
 // exported type for public method parameters
@@ -155,7 +157,9 @@ func (g GleanEventsLogger) record(
 	if envelopeErr != nil {
 		panic("Unable to marshal log envelope to json")
 	}
-	fmt.Println(string(envelopeJson))
+	if g.Writer != nil {
+		fmt.Fprintln(g.Writer, string(envelopeJson))
+	}
 }
 
 func newGleanEvent(category, name string, extra map[string]string) gleanEvent {

--- a/tests/data/server_events_and_custom_ping_compare.go
+++ b/tests/data/server_events_and_custom_ping_compare.go
@@ -20,6 +20,10 @@ import (
 // log type string used to identify logs to process in the Moz Data Pipeline
 var gleanEventMozlogType string = "glean-server-event"
 
+// A GleanEventsLogger produces output in the required format for Glean to ingest.
+// Glean ingestion requires the output to be written to os.Stdout. Writing to a different
+// output will require the consumer to handle any closing as appropriate for the Writer.
+// e.g. if writing to a file.
 type GleanEventsLogger struct {
 	AppID             string // Application Id to identify application per Glean standards
 	AppDisplayVersion string // Version of application emitting the event

--- a/tests/data/server_events_and_custom_ping_compare.go
+++ b/tests/data/server_events_and_custom_ping_compare.go
@@ -10,6 +10,7 @@ package glean
 import (
 	"encoding/json"
     "fmt"
+	"io"
 	"strconv"
 	"time"
 
@@ -23,6 +24,7 @@ type GleanEventsLogger struct {
 	AppID             string // Application Id to identify application per Glean standards
 	AppDisplayVersion string // Version of application emitting the event
 	AppChannel        string // Channel to differentiate logs from prod/beta/staging/devel
+	Writer            io.Writer // Writer to output to. Normal operation expects os.Stdout
 }
 
 // exported type for public method parameters
@@ -155,7 +157,9 @@ func (g GleanEventsLogger) record(
 	if envelopeErr != nil {
 		panic("Unable to marshal log envelope to json")
 	}
-	fmt.Println(string(envelopeJson))
+	if g.Writer != nil {
+		fmt.Fprintln(g.Writer, string(envelopeJson))
+	}
 }
 
 func newGleanEvent(category, name string, extra map[string]string) gleanEvent {

--- a/tests/data/server_events_only_compare.go
+++ b/tests/data/server_events_only_compare.go
@@ -20,6 +20,10 @@ import (
 // log type string used to identify logs to process in the Moz Data Pipeline
 var gleanEventMozlogType string = "glean-server-event"
 
+// A GleanEventsLogger produces output in the required format for Glean to ingest.
+// Glean ingestion requires the output to be written to os.Stdout. Writing to a different
+// output will require the consumer to handle any closing as appropriate for the Writer.
+// e.g. if writing to a file.
 type GleanEventsLogger struct {
 	AppID             string // Application Id to identify application per Glean standards
 	AppDisplayVersion string // Version of application emitting the event

--- a/tests/data/server_events_only_compare.go
+++ b/tests/data/server_events_only_compare.go
@@ -10,6 +10,7 @@ package glean
 import (
 	"encoding/json"
     "fmt"
+	"io"
 	"strconv"
 	"time"
 
@@ -23,6 +24,7 @@ type GleanEventsLogger struct {
 	AppID             string // Application Id to identify application per Glean standards
 	AppDisplayVersion string // Version of application emitting the event
 	AppChannel        string // Channel to differentiate logs from prod/beta/staging/devel
+	Writer            io.Writer // Writer to output to. Normal operation expects os.Stdout
 }
 
 // exported type for public method parameters
@@ -155,7 +157,9 @@ func (g GleanEventsLogger) record(
 	if envelopeErr != nil {
 		panic("Unable to marshal log envelope to json")
 	}
-	fmt.Println(string(envelopeJson))
+	if g.Writer != nil {
+		fmt.Fprintln(g.Writer, string(envelopeJson))
+	}
 }
 
 func newGleanEvent(category, name string, extra map[string]string) gleanEvent {

--- a/tests/test-go/test.go.tmpl
+++ b/tests/test-go/test.go.tmpl
@@ -2,6 +2,7 @@ package main
 
 import (
   "glean/glean"
+  "os"
   "time"
 )
 
@@ -10,6 +11,7 @@ func main() {
     AppID:             "glean.test",
     AppDisplayVersion: "0.0.1",
     AppChannel:        "nightly",
+    Writer:            os.Stdout,
   }
 
   /* CODE */


### PR DESCRIPTION
### problem
The go server implementation is hardcoded to use stdout. As we add more server glean logs, this will make the output have more entries and be harder to read while developing.

### solution
Adjust the go server implementation to allow for a configurable writer. This will enable users of the go server implementation to choose where the logs are written to. When running in production it will have to supply stdout since that is where the ingestion side of things expects to find the logs.

### testing
made similar modifications to the server output locally and confirmed these different scenarios are all valid:
a Writer of `io.Discard` will produce no output
a Writer of a file will write logs to a file
a Writer of `os.Stdout` matches existing behavior

ran `make test-full`

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
