### PR TITLE
bug 1934099 - New lint: metric names that differ only in punctuation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- New lint: error when there are metrics whose names are too similar ([bug 1934099](https://bugzilla.mozilla.org/show_bug.cgi?id=1934099))
+
 ## 16.1.0
 
 - Allow specifying a subset of interesting metrics to actually collect. Other metrics will be built, but marked as disabled ([bug 1931277](https://bugzilla.mozilla.org/show_bug.cgi?id=1911165)).

--- a/tests/data/name_too_similar.yaml
+++ b/tests/data/name_too_similar.yaml
@@ -1,0 +1,31 @@
+# Any copyright is dedicated to the Public Domain.
+# https://creativecommons.org/publicdomain/zero/1.0/
+
+---
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+
+all_metrics:
+  valid_metric: &defaults
+    type: counter
+    lifetime: ping
+    description: for testing
+    bugs:
+      - https://bugzilla.mozilla.org/123
+    data_reviews:
+      - http://example.com/
+    notification_emails:
+      - CHANGE-ME@example.com
+    expires: never
+
+  validmetric:
+    <<: *defaults
+
+  similar_nolint:
+    <<: *defaults
+    no_lint:
+      - NAME_TOO_SIMILAR
+
+  similar_no_lint:
+    <<: *defaults
+    no_lint:
+      - NAME_TOO_SIMILAR

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -508,6 +508,22 @@ def test_unknown_pings_lint():
     assert "does-not-exist" in nits[0].msg
 
 
+def test_name_too_similar_lint():
+    """Ensure the 'glinter' reports metrics whose names are too similar."""
+    # Note: NAME_TOO_SIMILAR is an all-object lint meaning we need pings for it to work.
+    input = [ROOT / "data" / "name_too_similar.yaml", ROOT / "data" / "pings.yaml"]
+    all_objects = parser.parse_objects(input)
+
+    errs = list(all_objects)
+    assert len(errs) == 0
+
+    nits = lint.lint_metrics(all_objects.value, parser_config={})
+    assert len(nits) == 1
+    assert nits[0].check_name == "NAME_TOO_SIMILAR"
+    assert nits[0].name == "all_metrics.validmetric"
+    assert "all_metrics.valid_metric" in nits[0].msg
+
+
 @pytest.mark.parametrize(
     "metric, num_nits",
     [


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
