### PR TITLE
Bug 1933542 - Require `array` or `object` as the root type in object metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - New lint: error when there are metrics whose names are too similar ([bug 1934099](https://bugzilla.mozilla.org/show_bug.cgi?id=1934099))
+- Require `array` or `object` as the root type in object metrics ([#780](https://github.com/mozilla/glean_parser/pull/780))
 
 ## 16.1.0
 

--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -509,6 +509,20 @@ class Object(Metric):
         if None:
             raise ValueError("`structure` needed for object metric.")
 
+        # Different from `ALLOWED_TYPES`:
+        # We _require_ the root type to be an object or array.
+        allowed_types = ["object", "array"]
+        if "type" not in structure:
+            raise ValueError(
+                f"missing `type` in object structure. Allowed: {allowed_types}"
+            )
+        if structure["type"] not in allowed_types:
+            raise ValueError(
+                "invalid `type` in object structure. found: {}, allowed: {}".format(
+                    structure["type"], allowed_types
+                )
+            )
+
         structure = Object._validate_substructure(structure)
         return structure
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1273,3 +1273,11 @@ def test_object_invalid():
     errors = list(all_metrics)
     assert len(errors) == 1
     assert "`items` not allowed in object structure" in errors[0]
+
+    structure = {"type": "string"}
+    contents = [{"category": {"metric": {"type": "object", "structure": structure}}}]
+    contents = [util.add_required(x) for x in contents]
+    all_metrics = parser.parse_objects(contents)
+    errors = list(all_metrics)
+    assert len(errors) == 1
+    assert "invalid `type` in object structure." in errors[0]


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
