### PR TITLE
Add 'uploader_capabilities' to util's ping_args to unbreak Kotlin codegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- BUGFIX: Fix missing `ping_arg` "`uploader_capabilities`" in util.py ([#786](https://github.com/mozilla/glean_parser/pull/786))
+
 ## 17.0.0
 
 - BREAKING CHANGE: Support `uploader_capabilities` for pings ([bug 1920732](https://bugzilla.mozilla.org/show_bug.cgi?id=1920732))

--- a/glean_parser/util.py
+++ b/glean_parser/util.py
@@ -546,6 +546,7 @@ ping_args = [
     "schedules_pings",
     "reason_codes",
     "follows_collection_enabled",
+    "uploader_capabilities",
 ]
 
 


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
  - doesn't include tests because Kotlin codegen will break in mozilla/glean if it's wrong. See also: https://bugzilla.mozilla.org/show_bug.cgi?id=1762858
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
