### PR TITLE
Bug 1950669 - Allow custom-defined units as a name suffix too

### DIFF
--- a/glean_parser/lint.py
+++ b/glean_parser/lint.py
@@ -134,7 +134,6 @@ def check_unit_in_name(
 
     time_unit = getattr(metric, "time_unit", None)
     memory_unit = getattr(metric, "memory_unit", None)
-    unit = getattr(metric, "unit", None)
 
     if time_unit is not None:
         if (
@@ -173,14 +172,6 @@ def check_unit_in_name(
                 f"Suffix '{unit_in_name}' doesn't match memory_unit "
                 f"{memory_unit.name}'. "
                 "Confirm the unit is correct and only include memory_unit."
-            )
-
-    elif unit is not None:
-        if unit_in_name == unit:
-            yield (
-                f"Suffix '{unit_in_name}' is redundant with unit param "
-                f"'{unit}'. "
-                "Only include unit."
             )
 
 

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -67,6 +67,7 @@ def test_unit_in_name():
                     "type": "memory_distribution",
                     "memory_unit": "megabyte",
                 },
+                # This should be allowed.
                 "width_pixels": {
                     "type": "quantity",
                     "gecko_datapoint": "WIDTH_PIXELS",
@@ -83,7 +84,7 @@ def test_unit_in_name():
 
     nits = lint.lint_metrics(all_metrics.value)
 
-    assert len(nits) == 3
+    assert len(nits) == 2
     assert all(nit.check_name == "UNIT_IN_NAME" for nit in nits)
 
     # Now make sure the override works
@@ -94,7 +95,7 @@ def test_unit_in_name():
 
     nits = lint.lint_metrics(all_metrics.value)
 
-    assert len(nits) == 2
+    assert len(nits) == 1
 
 
 def test_category_generic():
@@ -135,7 +136,7 @@ def test_combined():
                 "m_width_pixels": {
                     "type": "quantity",
                     "gecko_datapoint": "WIDTH_PIXELS",
-                    "unit": "pixels",
+                    "unit": "pixels", # not a lint issue
                 },
             }
         }
@@ -148,7 +149,7 @@ def test_combined():
 
     nits = lint.lint_metrics(all_metrics.value)
 
-    assert len(nits) == 5
+    assert len(nits) == 4
     assert set(["COMMON_PREFIX", "CATEGORY_GENERIC", "UNIT_IN_NAME"]) == set(
         v.check_name for v in nits
     )


### PR DESCRIPTION
For custom units it's ok if they match t he name's suffix. The alternative encourages awkwardly naming things or omitting units entirely -- either action reduces the richness of information in the metric definition.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
