### PR TITLE
bug 1921089 - Forbid redefinition of metrics in definitions files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Forbid redefinition of metrics, categories, or pings within the same YAML document ([bug 1921089](https://bugzilla.mozilla.org/show_bug.cgi?id=1921089))
+
 ## 17.1.0
 
 - Permit object metrics named 'glean.attribution.ext' or 'glean.distribution.ext' even if allow_reserved is false ([bug 1955428](https://bugzilla.mozilla.org/show_bug.cgi?id=1955428))

--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -416,17 +416,22 @@ class LabeledString(Labeled, String):
 class LabeledCounter(Labeled, Counter):
     typename = "labeled_counter"
 
+
 class LabeledCustomDistribution(Labeled, CustomDistribution):
     typename = "labeled_custom_distribution"
+
 
 class LabeledMemoryDistribution(Labeled, MemoryDistribution):
     typename = "labeled_memory_distribution"
 
+
 class LabeledTimingDistribution(Labeled, TimingDistribution):
     typename = "labeled_timing_distribution"
 
+
 class LabeledQuantity(Labeled, Quantity):
     typename = "labeled_quantity"
+
 
 class Rate(Metric):
     typename = "rate"

--- a/glean_parser/parser.py
+++ b/glean_parser/parser.py
@@ -182,6 +182,10 @@ def _instantiate_metrics(
     global_tags = content.get("$tags", [])
     assert isinstance(global_tags, list)
 
+    # Duplicate category names end up on the root content.
+    if not hasattr(all_objects, "duplicate"):
+        setattr(all_objects, "duplicate", getattr(content, "duplicate", None))
+
     for category_key, category_val in sorted(content.items()):
         if category_key.startswith("$"):
             continue
@@ -273,6 +277,12 @@ def _instantiate_metrics(
                     metric_obj.defined_in["line"],
                 )
             else:
+                if not hasattr(all_objects[category_key], "duplicate"):
+                    setattr(
+                        all_objects[category_key],
+                        "duplicate",
+                        getattr(content[category_key], "duplicate", None),
+                    )
                 all_objects[category_key][metric_key] = metric_obj
                 sources[(category_key, metric_key)] = filepath
 
@@ -291,6 +301,15 @@ def _instantiate_pings(
     global_no_lint = content.get("no_lint", [])
     assert isinstance(global_no_lint, list)
     ping_schedule_reverse_map: Dict[str, Set[str]] = dict()
+
+    # Duplicate ping names end up on the root content.
+    duplicate_ping = getattr(content, "duplicate", None)
+    if duplicate_ping:
+        yield util.format_error(
+            filepath,
+            "",
+            f"Duplicate ping named '{duplicate_ping}'.",
+        )
 
     for ping_key, ping_val in sorted(content.items()):
         if ping_key.startswith("$"):

--- a/glean_parser/util.py
+++ b/glean_parser/util.py
@@ -88,7 +88,15 @@ def yaml_load(stream):
 
     def _construct_mapping_adding_line(loader, node):
         loader.flatten_mapping(node)
-        mapping = DictWrapper(loader.construct_pairs(node))
+        pairs = loader.construct_pairs(node)
+
+        # Redefinition of a key might be a mistake if that key is a metric name.
+        mapping = DictWrapper()
+        for pair in pairs:
+            if pair[0] in mapping:
+                mapping.duplicate = pair[0]
+            mapping[pair[0]] = pair[1]
+
         mapping.defined_in = {"line": node.start_mark.line}
         return mapping
 

--- a/tests/data/redefined_category.yamlx
+++ b/tests/data/redefined_category.yamlx
@@ -1,0 +1,32 @@
+# Any copyright is dedicated to the Public Domain.
+# https://creativecommons.org/publicdomain/zero/1.0/
+
+# Note: we're using YAML anchors to re-use the values
+# defined in the first metric.
+# Saves us some typing.
+---
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+
+redefined.category:
+  metric_name:
+    type: counter
+    description: for testing
+    bugs:
+      - https://bugzilla.mozilla.org/1921089
+    data_reviews:
+      - http://example.com/
+    notification_emails:
+      - CHANGE-ME@example.com
+    expires: never
+
+redefined.category:
+  some_other_metric:
+    type: event
+    description: for testing
+    bugs:
+      - https://bugzilla.mozilla.org/1921089
+    data_reviews:
+      - http://example.com/
+    notification_emails:
+      - CHANGE-ME@example.com
+    expires: never

--- a/tests/data/redefined_metric.yamlx
+++ b/tests/data/redefined_metric.yamlx
@@ -1,0 +1,31 @@
+# Any copyright is dedicated to the Public Domain.
+# https://creativecommons.org/publicdomain/zero/1.0/
+
+# Note: we're using YAML anchors to re-use the values
+# defined in the first metric.
+# Saves us some typing.
+---
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+
+redefined.metric:
+  metric_name:
+    type: counter
+    description: for testing
+    bugs:
+      - https://bugzilla.mozilla.org/1921089
+    data_reviews:
+      - http://example.com/
+    notification_emails:
+      - CHANGE-ME@example.com
+    expires: never
+
+  metric_name:
+    type: event
+    description: for testing
+    bugs:
+      - https://bugzilla.mozilla.org/1921089
+    data_reviews:
+      - http://example.com/
+    notification_emails:
+      - CHANGE-ME@example.com
+    expires: never

--- a/tests/data/redefined_ping.yamlx
+++ b/tests/data/redefined_ping.yamlx
@@ -1,0 +1,30 @@
+# Any copyright is dedicated to the Public Domain.
+# https://creativecommons.org/publicdomain/zero/1.0/
+
+---
+$schema: moz://mozilla.org/schemas/glean/pings/2-0-0
+
+some-ping:
+  description:
+    This is some custom ping
+  include_client_id: false
+  bugs:
+    - http://bugzilla.mozilla.com/1921089
+  data_reviews:
+    - http://nowhere.com/reviews
+  notification_emails:
+    - CHANGE-ME@test-only.com
+  no_lint: [REDUNDANT_PING]
+
+
+some-ping:
+  description:
+    This is some other custom ping
+  include_client_id: false
+  bugs:
+    - http://bugzilla.mozilla.com/1921089
+  data_reviews:
+    - http://nowhere.com/reviews
+  notification_emails:
+    - CHANGE-ME@test-only.com
+  no_lint: [REDUNDANT_PING]

--- a/tests/data/same_name_different_category.yaml
+++ b/tests/data/same_name_different_category.yaml
@@ -1,0 +1,32 @@
+# Any copyright is dedicated to the Public Domain.
+# https://creativecommons.org/publicdomain/zero/1.0/
+
+# Note: we're using YAML anchors to re-use the values
+# defined in the first metric.
+# Saves us some typing.
+---
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+
+some.category:
+  metric_name:
+    type: counter
+    description: for testing
+    bugs:
+      - https://bugzilla.mozilla.org/1921089
+    data_reviews:
+      - http://example.com/
+    notification_emails:
+      - CHANGE-ME@example.com
+    expires: never
+
+some.other.category:
+  metric_name:
+    type: event
+    description: for testing
+    bugs:
+      - https://bugzilla.mozilla.org/1921089
+    data_reviews:
+      - http://example.com/
+    notification_emails:
+      - CHANGE-ME@example.com
+    expires: never

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -136,7 +136,7 @@ def test_combined():
                 "m_width_pixels": {
                     "type": "quantity",
                     "gecko_datapoint": "WIDTH_PIXELS",
-                    "unit": "pixels", # not a lint issue
+                    "unit": "pixels",  # not a lint issue
                 },
             }
         }
@@ -523,6 +523,53 @@ def test_name_too_similar_lint():
     assert nits[0].check_name == "NAME_TOO_SIMILAR"
     assert nits[0].name == "all_metrics.validmetric"
     assert "all_metrics.valid_metric" in nits[0].msg
+
+
+def test_redefined_metric():
+    """Ensure we fail when folks redefine a metric with the same category+name."""
+    input = [
+        ROOT / "data" / "redefined_metric.yamlx",
+        ROOT / "data" / "same_name_different_category.yaml",
+    ]
+    all_objects = parser.parse_objects(input)
+
+    errs = list(all_objects)
+    assert len(errs) == 0
+
+    nits = lint.lint_metrics(all_objects.value, parser_config={})
+    assert len(nits) == 1
+    assert nits[0].check_name == "REDEFINED_METRIC"
+    assert nits[0].name == "redefined.metric"
+    assert "metric_name" in nits[0].msg
+
+
+def test_redefined_category():
+    """Ensure we fail when folks redefine a category."""
+    input = [
+        ROOT / "data" / "redefined_category.yamlx",
+        ROOT / "data" / "same_name_different_category.yaml",
+    ]
+    all_objects = parser.parse_objects(input)
+
+    errs = list(all_objects)
+    assert len(errs) == 0
+
+    nits = lint.lint_metrics(all_objects.value, parser_config={})
+    assert len(nits) == 1
+    assert nits[0].check_name == "REDEFINED_CATEGORY"
+
+
+def test_redefined_ping():
+    """Ensure we fail when folks redefine a ping."""
+    input = [
+        ROOT / "data" / "redefined_ping.yamlx",
+        ROOT / "data" / "pings.yaml",
+    ]
+    all_objects = parser.parse_objects(input)
+
+    errs = list(all_objects)
+    assert len(errs) == 1
+    assert "Duplicate ping named 'some-ping'" in errs[0]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
We don't want to forbid the redefinition of every YAML property, as we use that to save typing out similar definitions over and over again with YAML's spread operator `<<: *`

I got it far enough to catch the redefinition of a metric within the same category, which hopefully will be enough to get started with.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
