### PR TITLE
Don't try to remove non-existing key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - New lint: `HIGHER_DATA_SENSITIVITY_REQUIRED` for when an event extra key could potentially contain sensitive data ([bug 1973017](https://bugzilla.mozilla.org/show_bug.cgi?id=1973017))
+- BUGFIX: Don't try to remove non-existent key on dual labeled metrics ([#801](https://github.com/mozilla/glean_parser/pull/801))
 
 ## 17.2.0
 

--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -579,7 +579,6 @@ class DualLabeledCounter(Metric):
         d["categories"] = self.ordered_categories
         del d["ordered_keys"]
         del d["ordered_categories"]
-        del d["dual_labeled"]
         return d
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1153,6 +1153,13 @@ def test_no_internal_fields_exposed():
                             "extra_keys": {
                                 "key_a": {"description": "desc-a", "type": "boolean"}
                             },
+                        },
+                        "metric2": {
+                            "type": "dual_labeled_counter",
+                            "dual_labels": {
+                                "key": { "description": "desc-a" },
+                                "category": { "description": "desc-b" },
+                            }
                         }
                     },
                 }
@@ -1185,7 +1192,25 @@ def test_no_internal_fields_exposed():
             "send_in_pings": ["events"],
             "type": "event",
             "version": 0,
-        }
+        },
+        "category.metric2": {
+            "bugs": ["http://bugzilla.mozilla.org/12345678"],
+            "categories": None,
+            "data_reviews": ["https://example.com/review/"],
+            "defined_in": {"line": 17},
+            "description": "DESCRIPTION...",
+            "disabled": False,
+            "expires": "never",
+            "gecko_datapoint": "",
+            "keys": None,
+            "lifetime": "ping",
+            "metadata": {},
+            "no_lint": [],
+            "notification_emails": ["nobody@example.com"],
+            "send_in_pings": ["metrics"],
+            "type": "dual_labeled_counter",
+            "version": 0,
+        },
     }
     expected_json = json.dumps(expected, sort_keys=True, indent=2)
 


### PR DESCRIPTION
`dual_labeled` is a class attribute, so not part of `self`. Trying to access it results in a KeyError, raising an exception and making probe-scraper explode.

This fixes that.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
