### PR TITLE
Bug 1960034 - Object metric: Allow a description in the definition

### DIFF
--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -462,7 +462,7 @@ class Object(Metric):
         self._generate_structure = self.validate_structure(structure)
         super().__init__(*args, **kwargs)
 
-    ALLOWED_TOPLEVEL = {"type", "properties", "items"}
+    ALLOWED_TOPLEVEL = {"type", "properties", "items", "description"}
     ALLOWED_TYPES = ["object", "array", "number", "string", "boolean"]
 
     @staticmethod

--- a/tests/data/object.yaml
+++ b/tests/data/object.yaml
@@ -16,8 +16,10 @@ complex.types:
       - CHANGE-ME@example.com
     expires: never
     structure:
+      description: An array of numbers
       type: array
       items:
+        description: Every number counts
         type: number
 
   array_in_array:


### PR DESCRIPTION
The file is parsed by tests, so without the metrics.py change tests would fail, thus no new test required for this.