### PR TITLE
Add missing whitespace in lint message

### DIFF
--- a/glean_parser/lint.py
+++ b/glean_parser/lint.py
@@ -100,7 +100,7 @@ def check_common_prefix(
         common_prefix = "_".join(first[:i])
         yield (
             f"Within category '{category_name}', all metrics begin with "
-            f"prefix '{common_prefix}'."
+            f"prefix '{common_prefix}'. "
             "Remove the prefixes on the metric names and (possibly) "
             "rename the category."
         )


### PR DESCRIPTION
Before this patch the error message looks like this:

> COMMON_PREFIX: networking: Within category 'networking', all metrics begin with prefix 'captive_portal_banner'.Remove the prefixes on the metric names and (possibly) rename the category.