### PR TITLE
DENG-9533 - Go server template: support publishing directly to Pub/Sub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,27 @@ commands:
           command: |
             uv sync --resolution lowest-direct
 
+  setup-go:
+    steps:
+      - run:
+          name: Installing Go
+          # The Ubuntu-default Go available via apt in cimg/python is too
+          # old for the cloud.google.com/go/pubsub dependency chain (needs
+          # Go 1.24+). Install a newer release directly.
+          # To update: pick a release from https://go.dev/dl/ and bump
+          # GO_VERSION below.
+          command: |
+            cd /tmp
+            GO_VERSION=1.26.3
+            GO_TARBALL=go${GO_VERSION}.linux-amd64.tar.gz
+            curl -sfSL --retry 5 -o "${GO_TARBALL}" "https://go.dev/dl/${GO_TARBALL}"
+            sudo rm -rf /usr/local/go
+            sudo tar -C /usr/local -xf "${GO_TARBALL}"
+      - run:
+          name: Set Go path
+          command: |
+            echo 'export PATH=/usr/local/go/bin:$PATH' >> $BASH_ENV
+
   test-python-version:
     steps:
       - run:
@@ -62,9 +83,9 @@ commands:
             sudo apt install \
                 --yes --no-install-recommends \
                 openjdk-11-jdk-headless \
-                ruby \
-                golang-go
+                ruby
             make install-kotlin-linters
+      - setup-go
       - setup-rust-toolchain
       - run:
           name: Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Go server template: add `go_server_pubsub` outputter to support direct
+  Pub/Sub delivery ([DENG-9533](https://mozilla-hub.atlassian.net/browse/DENG-9533))
+
 ## 19.1.1
 
 - Use JSON serialization for on-disk caching

--- a/glean_parser/go_server.py
+++ b/glean_parser/go_server.py
@@ -21,7 +21,7 @@ Warning: this outputter supports limited set of metrics,
 see `SUPPORTED_METRIC_TYPES` below.
 
 Generated code creates two methods for each ping (`RecordPingX` and `RecordPingXWithoutUserInfo`)
-that are used for submitting events. 
+that are used for submitting events.
 If pings have `event` metrics assigned, they can be passed to these methods.
 """
 

--- a/glean_parser/go_server.py
+++ b/glean_parser/go_server.py
@@ -21,8 +21,8 @@ Warning: this outputter supports limited set of metrics,
 see `SUPPORTED_METRIC_TYPES` below.
 
 Generated code creates two methods for each ping (`RecordPingX` and `RecordPingXWithoutUserInfo`)
-that are used for submitting events. If pings have `event` metrics assigned, they can be
-passed to these methods.
+that are used for submitting events. 
+If pings have `event` metrics assigned, they can be passed to these methods.
 """
 
 from collections import defaultdict

--- a/glean_parser/go_server.py
+++ b/glean_parser/go_server.py
@@ -11,15 +11,18 @@ This outputter is different from the rest of the outputters in that the code it
 generates does not use the Glean SDK. It is meant to be used to collect events
 in server-side environments. In these environments SDK assumptions to measurement
 window and connectivity don't hold.
+
 Generated code takes care of assembling pings with metrics, and serializing to messages
-conforming to Glean schema.
+conforming to Glean schema. Two transport modes are supported:
+- Cloud Logging (go_server): Logs to stdout in MozLog format for ingestion via GCP log routing
+- Pub/Sub (go_server_pubsub): Publishes directly to GCP Pub/Sub topics
 
 Warning: this outputter supports limited set of metrics,
 see `SUPPORTED_METRIC_TYPES` below.
 
 Generated code creates two methods for each ping (`RecordPingX` and `RecordPingXWithoutUserInfo`)
-that are used for submitting (logging) them.
-If pings have `event` metrics assigned, they can be passed to these methods.
+that are used for submitting events. If pings have `event` metrics assigned, they can be
+passed to these methods.
 """
 
 from collections import defaultdict
@@ -111,7 +114,10 @@ def validate_labeled_boolean(metric: metrics.Metric) -> bool:
 
 
 def output_go(
-    objs: metrics.ObjectTree, output_dir: Path, options: Optional[Dict[str, Any]]
+    objs: metrics.ObjectTree,
+    output_dir: Path,
+    options: Optional[Dict[str, Any]],
+    transport: str = "logging",
 ) -> None:
     """
     Given a tree of objects, output Go code to `output_dir`.
@@ -122,6 +128,8 @@ def output_go(
     :param objects: A tree of objects (metrics and pings) as returned from
         `parser.parse_objects`.
     :param output_dir: Path to an output directory to write to.
+    :param transport: Transport mode - either "logging" (Cloud Logging) or
+        "pubsub" (Pub/Sub direct publishing). Default is "logging".
     """
 
     template = util.get_jinja2_template(
@@ -198,5 +206,34 @@ def output_go(
                 pings=ping_to_metrics,
                 events=event_metrics,
                 labeled_booleans=labeled_boolean_metrics,
+                transport=transport,
             )
         )
+
+
+def output_go_logger(
+    objs: metrics.ObjectTree, output_dir: Path, options: Optional[Dict[str, Any]] = None
+) -> None:
+    """
+    Given a tree of objects, output Go code using Cloud Logging transport.
+
+    :param objects: A tree of objects (metrics and pings) as returned from
+        `parser.parse_objects`.
+    :param output_dir: Path to an output directory to write to.
+    :param options: options dictionary (currently unused for Go).
+    """
+    output_go(objs, output_dir, options, transport="logging")
+
+
+def output_go_pubsub(
+    objs: metrics.ObjectTree, output_dir: Path, options: Optional[Dict[str, Any]] = None
+) -> None:
+    """
+    Given a tree of objects, output Go code using Pub/Sub transport.
+
+    :param objects: A tree of objects (metrics and pings) as returned from
+        `parser.parse_objects`.
+    :param output_dir: Path to an output directory to write to.
+    :param options: options dictionary (currently unused for Go).
+    """
+    output_go(objs, output_dir, options, transport="pubsub")

--- a/glean_parser/templates/go_server.jinja2
+++ b/glean_parser/templates/go_server.jinja2
@@ -32,21 +32,7 @@ import (
 {% endif %}
 )
 
-{% if transport == "logging" %}
-// log type string used to identify logs to process in the Moz Data Pipeline
-var gleanEventMozlogType string = "glean-server-event"
-
-// A GleanEventsLogger produces output in the required format for Glean to ingest.
-// Glean ingestion requires the output to be written to os.Stdout. Writing to a different
-// output will require the consumer to handle any closing as appropriate for the Writer.
-// e.g. if writing to a file.
-type GleanEventsLogger struct {
-    AppID             string // Application Id to identify application per Glean standards
-    AppDisplayVersion string // Version of application emitting the event
-    AppChannel        string // Channel to differentiate logs from prod/beta/staging/devel
-    Writer            io.Writer // Writer to output to. Normal operation expects os.Stdout
-}
-{% else %}
+{% if transport == "pubsub" %}
 // GleanEventsBuilder constructs Pub/Sub messages carrying Glean pings.
 // Builder is stateless beyond its app-identity fields; callers own the
 // pubsub.Client, the pubsub.Publisher, batching settings, retries, shutdown sequencing, and any
@@ -87,6 +73,20 @@ func compressPayload(data []byte) ([]byte, error) {
     }
     gzipPool.Put(gz)
     return buf.Bytes(), nil
+}
+{% else %}
+// log type string used to identify logs to process in the Moz Data Pipeline
+var gleanEventMozlogType string = "glean-server-event"
+
+// A GleanEventsLogger produces output in the required format for Glean to ingest.
+// Glean ingestion requires the output to be written to os.Stdout. Writing to a different
+// output will require the consumer to handle any closing as appropriate for the Writer.
+// e.g. if writing to a file.
+type GleanEventsLogger struct {
+    AppID             string // Application Id to identify application per Glean standards
+    AppDisplayVersion string // Version of application emitting the event
+    AppChannel        string // Channel to differentiate logs from prod/beta/staging/devel
+    Writer            io.Writer // Writer to output to. Normal operation expects os.Stdout
 }
 {% endif %}
 
@@ -207,9 +207,7 @@ func (g GleanEventsLogger) createPing(documentType string, config RequestInfo, p
         Payload:           string(payloadJson),
     }, nil
 }
-{% endif %}
 
-{% if transport == "logging" %}
 // method called by each ping-specific record method.
 // construct the ping, wrap it in the envelope, and print to stdout
 func (g GleanEventsLogger) record(

--- a/glean_parser/templates/go_server.jinja2
+++ b/glean_parser/templates/go_server.jinja2
@@ -9,6 +9,18 @@ package glean
 
 // required imports
 import (
+{% if transport == "pubsub" %}
+    "bytes"
+    "compress/gzip"
+    "encoding/json"
+    "fmt"
+    "io"
+    "sync"
+    "time"
+
+    pubsub "cloud.google.com/go/pubsub/v2"
+    "github.com/google/uuid"
+{% else %}
     "encoding/json"
     "errors"
     "fmt"
@@ -17,8 +29,10 @@ import (
     "time"
 
     "github.com/google/uuid"
+{% endif %}
 )
 
+{% if transport == "logging" %}
 // log type string used to identify logs to process in the Moz Data Pipeline
 var gleanEventMozlogType string = "glean-server-event"
 
@@ -32,6 +46,49 @@ type GleanEventsLogger struct {
     AppChannel        string // Channel to differentiate logs from prod/beta/staging/devel
     Writer            io.Writer // Writer to output to. Normal operation expects os.Stdout
 }
+{% else %}
+// GleanEventsBuilder constructs Pub/Sub messages carrying Glean pings.
+// Builder is stateless beyond its app-identity fields; callers own the
+// pubsub.Client, the pubsub.Publisher, batching settings, retries, shutdown sequencing, and any
+// publish-result metrics
+type GleanEventsBuilder struct {
+    AppID             string // Application ID to identify application per Glean standards
+    AppDisplayVersion string // Version of application emitting the event
+    AppChannel        string // Channel to differentiate logs from prod/beta/staging/devel
+}
+
+// gzipPool reuses gzip.Writer instances across calls. gzip.NewWriter()
+// allocates ~800 KB internally; pooling + Reset() drops per-message
+// allocations to near zero at high publish volumes.
+var gzipPool = sync.Pool{
+    New: func() interface{} {
+        return gzip.NewWriter(io.Discard)
+    },
+}
+
+// compressPayload gzips data using the package-level writer pool. The
+// returned slice is caller-owned; only the *gzip.Writer is returned to the
+// pool.
+func compressPayload(data []byte) ([]byte, error) {
+    var buf bytes.Buffer
+    // Optimistic preallocation: gzip on small JSON typically achieves ~2x ratio.
+    buf.Grow(len(data) / 2)
+
+    gz := gzipPool.Get().(*gzip.Writer)
+    gz.Reset(&buf)
+
+    if _, err := gz.Write(data); err != nil {
+        gzipPool.Put(gz)
+        return nil, fmt.Errorf("gzip write failed: %w", err)
+    }
+    if err := gz.Close(); err != nil {
+        gzipPool.Put(gz)
+        return nil, fmt.Errorf("gzip close failed: %w", err)
+    }
+    gzipPool.Put(gz)
+    return buf.Bytes(), nil
+}
+{% endif %}
 
 // exported type for public method parameters
 type RequestInfo struct {
@@ -63,6 +120,7 @@ type pingInfo struct {
     EndTime   string `json:"end_time"`
 }
 
+{% if transport == "logging" %}
 type ping struct {
     DocumentNamespace string `json:"document_namespace"`
     DocumentType      string `json:"document_type"`
@@ -72,6 +130,7 @@ type ping struct {
     IpAddress         string `json:"ip_address,omitempty"`
     Payload           string `json:"payload"`
 }
+{% endif %}
 
 type metrics map[string]map[string]any
 
@@ -89,14 +148,20 @@ type gleanEvent struct {
     Extra     map[string]string `json:"extra"`
 }
 
+{% if transport == "logging" %}
 type logEnvelope struct {
     Timestamp string
     Logger    string
     Type      string
     Fields    ping
 }
+{% endif %}
 
+{% if transport == "pubsub" %}
+func (g GleanEventsBuilder) createClientInfo() clientInfo {
+{% else %}
 func (g GleanEventsLogger) createClientInfo() clientInfo {
+{% endif %}
     // Fields with default values are required in the Glean schema, but not used in server context
     return clientInfo{
         TelemetrySDKBuild: "glean_parser v{{ parser_version }}",
@@ -120,6 +185,7 @@ func createPingInfo() pingInfo {
     }
 }
 
+{% if transport == "logging" %}
 func (g GleanEventsLogger) createPing(documentType string, config RequestInfo, payload pingPayload) (ping, error) {
     payloadJson, err := json.Marshal(payload)
     if err != nil {
@@ -141,7 +207,9 @@ func (g GleanEventsLogger) createPing(documentType string, config RequestInfo, p
         Payload:           string(payloadJson),
     }, nil
 }
+{% endif %}
 
+{% if transport == "logging" %}
 // method called by each ping-specific record method.
 // construct the ping, wrap it in the envelope, and print to stdout
 func (g GleanEventsLogger) record(
@@ -180,6 +248,7 @@ func (g GleanEventsLogger) record(
     fmt.Fprintln(g.Writer, string(envelopeJson))
     return nil
 }
+{% endif %}
 {# if any ping has an event metric, create methods and types for them #}
 {% if events %}
 
@@ -265,6 +334,101 @@ type {{ ping|ping_type_name }} struct {
     {% endif %}
 }
 
+{% if transport == "pubsub" %}
+// Build{{ ping|ping_type_name }}Message constructs a Pub/Sub message carrying
+// the given `{{ ping }}` ping. The caller publishes the returned message
+// (e.g., topic.Publish(ctx, msg)) and owns batching, retries, shutdown
+// sequencing, and any publish-result metrics.
+//
+// Wire-format contract: see
+// docs/architecture/decoder_service_specification.md in mozilla/gcp-ingestion.
+func (g GleanEventsBuilder) Build{{ ping|ping_type_name }}Message(
+    requestInfo RequestInfo,
+    params {{ ping|ping_type_name }},
+) (*pubsub.Message, error) {
+    {% if metrics_by_type['string_list'] %}
+    {% for metric in metrics_by_type['string_list'] %}
+    // Ensure nil string_list metrics serialize as empty arrays, not null
+    if params.{{ metric|metric_argument_name }} == nil {
+        params.{{ metric|metric_argument_name }} = []string{}
+    }
+    {% endfor %}
+    {% endif %}
+    metrics := metrics{
+    {% for metric_type, metrics in metrics_by_type.items() %}
+    {% if metric_type != 'event' %}
+        "{{ metric_type }}": {
+        {% for metric in metrics %}
+            {% if metric_type == 'datetime' %}
+            "{{ metric|metric_name }}": params.{{ metric|metric_argument_name }}.Format("2006-01-02T15:04:05.000Z"),
+            {% else %}
+            "{{ metric|metric_name }}": params.{{ metric|metric_argument_name }},
+            {% endif %}
+        {% endfor %}
+        },
+    {% endif %}
+    {% endfor %}
+    }
+
+    events := []gleanEvent{}
+    {% if metrics_by_type['event'] %}
+    if params.Event != nil {
+        events = append(events, params.Event.gleanEvent())
+    }
+    {% endif %}
+
+    payload := pingPayload{
+        ClientInfo: g.createClientInfo(),
+        PingInfo:   createPingInfo(),
+        Metrics:    metrics,
+        Events:     events,
+    }
+
+    payloadJSON, err := json.Marshal(payload)
+    if err != nil {
+        return nil, fmt.Errorf("marshal ping payload: %w", err)
+    }
+    compressed, err := compressPayload(payloadJSON)
+    if err != nil {
+        return nil, fmt.Errorf("compress payload: %w", err)
+    }
+
+    documentID, err := uuid.NewRandom()
+    if err != nil {
+        return nil, fmt.Errorf("generate document_id: %w", err)
+    }
+
+    attributes := map[string]string{
+        "document_namespace": g.AppID,
+        "document_type":      "{{ ping }}",
+        "document_version":   "1",
+        "document_id":        documentID.String(),
+    }
+    // Skip empty optional attributes; the decoder treats missing and empty
+    // the same, and Pub/Sub charges for attribute bytes. The publisher does
+    // not set submission_timestamp; the decoder stamps it from publishTime.
+    if requestInfo.UserAgent != "" {
+        attributes["user_agent"] = requestInfo.UserAgent
+    }
+    if requestInfo.IpAddress != "" {
+        attributes["x_forwarded_for"] = requestInfo.IpAddress
+    }
+
+    return &pubsub.Message{
+        Data:       compressed,
+        Attributes: attributes,
+    }, nil
+}
+
+// Build{{ ping|ping_type_name }}MessageWithoutUserInfo constructs a Pub/Sub
+// message carrying the given `{{ ping }}` ping with no request-derived
+// attributes.
+func (g GleanEventsBuilder) Build{{ ping|ping_type_name }}MessageWithoutUserInfo(
+    params {{ ping|ping_type_name }},
+) (*pubsub.Message, error) {
+    return g.Build{{ ping|ping_type_name }}Message(defaultRequestInfo, params)
+}
+{% else %}
 // Record and submit `{{ ping }}` ping
 func (g GleanEventsLogger) Record{{ ping|ping_type_name }}(
     requestInfo RequestInfo,
@@ -309,4 +473,5 @@ func (g GleanEventsLogger) Record{{ ping|ping_type_name}}WithoutUserInfo(
 ) error {
     return g.Record{{ ping|ping_type_name }}(defaultRequestInfo, params)
 }
+{% endif %}
 {% endfor %}

--- a/glean_parser/translate.py
+++ b/glean_parser/translate.py
@@ -57,7 +57,8 @@ class Outputter:
 
 
 OUTPUTTERS = {
-    "go_server": Outputter(go_server.output_go, []),
+    "go_server": Outputter(go_server.output_go_logger, []),
+    "go_server_pubsub": Outputter(go_server.output_go_pubsub, []),
     "javascript": Outputter(javascript.output_javascript, []),
     "typescript": Outputter(javascript.output_typescript, []),
     "javascript_server": Outputter(javascript_server.output_javascript, []),

--- a/tests/test-go/test_publisher.go.tmpl
+++ b/tests/test-go/test_publisher.go.tmpl
@@ -1,0 +1,103 @@
+package main
+
+import (
+    "context"
+    "encoding/base64"
+    "encoding/json"
+    "fmt"
+    "glean/glean"
+    "os"
+    "time"
+    /* IMPORTS */
+
+    pubsub "cloud.google.com/go/pubsub/v2"
+    "cloud.google.com/go/pubsub/v2/apiv1/pubsubpb"
+    "cloud.google.com/go/pubsub/v2/pstest"
+    "google.golang.org/api/option"
+    "google.golang.org/grpc"
+    "google.golang.org/grpc/credentials/insecure"
+)
+
+func main() {
+    ctx := context.Background()
+
+    // In-process Pub/Sub fake. The Go pubsub client picks up PUBSUB_EMULATOR_HOST
+    // automatically; pstest exposes its bound address via srv.Addr.
+    srv := pstest.NewServer()
+    defer srv.Close()
+    os.Setenv("PUBSUB_EMULATOR_HOST", srv.Addr)
+
+    // Pre-create the topic on the fake server. Use a transient client; the
+    // test code below opens its own client to mirror normal app usage.
+    setupConn, err := grpc.Dial(srv.Addr,
+        grpc.WithTransportCredentials(insecure.NewCredentials()))
+    if err != nil {
+        fmt.Fprintln(os.Stderr, "dial:", err)
+        os.Exit(1)
+    }
+    setupClient, err := pubsub.NewClient(ctx, "test-project", option.WithGRPCConn(setupConn))
+    if err != nil {
+        fmt.Fprintln(os.Stderr, "setup-client:", err)
+        os.Exit(1)
+    }
+    if _, err := setupClient.TopicAdminClient.CreateTopic(ctx, &pubsubpb.Topic{
+        Name: "projects/test-project/topics/test-topic",
+    }); err != nil {
+        fmt.Fprintln(os.Stderr, "create-topic:", err)
+        os.Exit(1)
+    }
+    setupClient.Close()
+    setupConn.Close()
+
+    // Client + publisher used by the test snippet to publish.
+    client, err := pubsub.NewClient(ctx, "test-project")
+    if err != nil {
+        fmt.Fprintln(os.Stderr, "client:", err)
+        os.Exit(1)
+    }
+    topic := client.Publisher("test-topic")
+
+    builder := glean.GleanEventsBuilder{
+        AppID:             "glean.test",
+        AppDisplayVersion: "0.0.1",
+        AppChannel:        "nightly",
+    }
+    _ = builder // suppress unused warning if the snippet does not reference it
+
+    // The injected snippet must assign `msg, err` by calling a builder
+    // Build<Ping>Message method; the harness owns publish + result handling.
+    /* CODE */
+
+    if err != nil {
+        fmt.Fprintln(os.Stderr, "build:", err)
+        os.Exit(1)
+    }
+    result := topic.Publish(ctx, msg)
+    if _, err := result.Get(ctx); err != nil {
+        fmt.Fprintln(os.Stderr, "publish:", err)
+        os.Exit(1)
+    }
+
+    // Drain whatever was queued, then release the client. topic.Stop
+    // blocks until the batcher flushes; client.Close releases the gRPC conn.
+    // result.Get above already confirmed the server acked the message, so it
+    // is durably in pstest by the time we read srv.Messages below.
+    topic.Stop()
+    if err := client.Close(); err != nil {
+        fmt.Fprintln(os.Stderr, "client close:", err)
+        os.Exit(1)
+    }
+
+    msgs := srv.Messages()
+    out := make([]map[string]interface{}, 0, len(msgs))
+    for _, m := range msgs {
+        out = append(out, map[string]interface{}{
+            "data":       base64.StdEncoding.EncodeToString(m.Data),
+            "attributes": m.Attributes,
+        })
+    }
+    if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+        fmt.Fprintln(os.Stderr, "encode:", err)
+        os.Exit(1)
+    }
+}

--- a/tests/test_go_server_pubsub.py
+++ b/tests/test_go_server_pubsub.py
@@ -1,0 +1,344 @@
+# -*- coding: utf-8 -*-
+
+# Any copyright is dedicated to the Public Domain.
+# http://creativecommons.org/publicdomain/zero/1.0/
+
+"""
+Tests for the `go_server_pubsub` outputter and its runtime behavior.
+"""
+
+from pathlib import Path
+import base64
+import gzip
+import io
+import json
+import pytest
+import subprocess
+import uuid
+
+from glean_parser import translate
+from glean_parser import validate_ping
+
+ROOT = Path(__file__).parent
+
+SCHEMA_URL = (
+    "https://raw.githubusercontent.com/mozilla-services/"
+    "mozilla-pipeline-schemas/main/"
+    "schemas/glean/glean/glean.1.schema.json"
+)
+
+# YAML fixture lists shared across pubsub scenarios.
+YAML_EVENTS_PING = ["go_server_events_only_metrics.yaml"]
+YAML_CUSTOM_PING = [
+    "go_server_custom_ping_only_metrics.yaml",
+    "go_server_custom_ping_only_pings.yaml",
+]
+
+
+# Helpers
+
+
+def _translate(glean_module_path, yaml_filenames):
+    """Translate the given YAML fixtures with the pubsub outputter."""
+    yaml_files = [ROOT / "data" / name for name in yaml_filenames]
+    translate.translate(yaml_files, "go_server_pubsub", glean_module_path)
+
+
+def _gofmt_parse_ok(path):
+    """Syntax validation of generated Go code.
+
+    go_server templates emit space-indented code which is valid
+    Go but not gofmt-formatted, so we assert that gofmt can parse it
+    (`gofmt -e` exits non-zero on a parse error).
+    """
+    result = subprocess.run(["gofmt", "-e", str(path)], capture_output=True, text=True)
+    assert result.returncode == 0, (
+        f"gofmt could not parse generated Go:\n{result.stderr}"
+    )
+
+
+def _run_publisher(code_dir, code, imports=""):
+    """Compile and run the test Go program against an in-process Pub/Sub
+    fake (pstest). Returns the captured messages as a list of
+    {"data": base64, "attributes": dict}."""
+    with open(ROOT / "test-go" / "test_publisher.go.tmpl", "r") as fp:
+        tmpl_code = fp.read()
+    tmpl_code = tmpl_code.replace("/* CODE */", code).replace("/* IMPORTS */", imports)
+
+    with open(code_dir / "test.go", "w") as fp:
+        fp.write(tmpl_code)
+
+    subprocess.check_call(["go", "mod", "init", "glean"], cwd=code_dir)
+    subprocess.check_call(["go", "mod", "tidy"], cwd=code_dir)
+
+    out = subprocess.check_output(["go", "run", "test.go"], cwd=code_dir)
+    return json.loads(out.decode("utf-8"))
+
+
+def _validate_payload_against_schema(payload_bytes):
+    """Validate the inner Glean ping JSON against the pipeline schema."""
+    input = io.StringIO(payload_bytes.decode("utf-8"))
+    output = io.StringIO()
+    assert validate_ping.validate_ping(input, output, schema_url=SCHEMA_URL) == 0, (
+        output.getvalue()
+    )
+
+
+# Code generation tests
+
+
+def test_parser_pubsub_ping_no_metrics(tmp_path, capsys):
+    """No files are generated if only ping definitions are provided
+    without any metrics."""
+    translate.translate(
+        ROOT / "data" / "server_pings.yaml",
+        "go_server_pubsub",
+        tmp_path,
+    )
+    assert all(False for _ in tmp_path.iterdir())
+
+
+def test_parser_pubsub_metrics_unsupported_type(tmp_path, capsys):
+    """No files are generated with unsupported metric types; warnings are
+    emitted for each unsupported type."""
+    translate.translate(
+        [ROOT / "data" / "go_server_metrics_unsupported.yaml"],
+        "go_server_pubsub",
+        tmp_path,
+    )
+    captured = capsys.readouterr()
+    assert "Ignoring unsupported metric type" in captured.out
+    unsupported_types = ["labeled_string", "timespan", "uuid", "url"]
+    for t in unsupported_types:
+        assert t in captured.out
+
+
+def test_parser_pubsub_labeled_boolean_without_labels(tmp_path, capsys):
+    """labeled_boolean without static labels is rejected."""
+    translate.translate(
+        [ROOT / "data" / "go_server_metrics_unsupported.yaml"],
+        "go_server_pubsub",
+        tmp_path,
+    )
+    captured = capsys.readouterr()
+    assert "Ignoring labeled_boolean metric without static labels" in captured.out
+
+
+@pytest.mark.go_dependency
+def test_parser_pubsub_labeled_boolean(tmp_path):
+    """labeled_boolean metrics generate proper struct types."""
+    translate.translate(
+        ROOT / "data" / "go_server_labeled_boolean_metrics.yaml",
+        "go_server_pubsub",
+        tmp_path,
+    )
+
+    assert set(x.name for x in tmp_path.iterdir()) == set(["server_events.go"])
+
+    with (tmp_path / "server_events.go").open("r", encoding="utf-8") as fd:
+        content = fd.read()
+
+    # The labeled_boolean struct type is generated.
+    assert "type TelemetryFeatureFlags struct {" in content
+    assert "FeatureOne *bool" in content
+    assert "FeatureTwo *bool" in content
+    assert "FeatureThree *bool" in content
+
+    # ...and used in the ping struct.
+    assert "TelemetryFeatureFlags TelemetryFeatureFlags" in content
+
+    _gofmt_parse_ok(tmp_path / "server_events.go")
+
+
+@pytest.mark.go_dependency
+def test_parser_pubsub_generation(tmp_path):
+    """The pubsub outputter generates a stateless GleanEventsBuilder, not a
+    publisher with transport lifecycle.
+
+    This guards the one thing the runtime test (test_run_record_pubsub)
+    cannot: that we don't also emit unwanted but valid generated code. The
+    runtime test exercises only the builder happy path, so a stray publisher
+    struct, lifecycle methods, Prometheus instrumentation, or a MozLog
+    envelope would compile and pass there unnoticed. Everything observable in
+    the published message (attributes, gzipped body, document_id shape,
+    absent submission_timestamp) is asserted in the runtime test instead, so
+    we don't re-check it here."""
+    translate.translate(
+        ROOT / "data" / "go_server_events_only_metrics.yaml",
+        "go_server_pubsub",
+        tmp_path,
+    )
+
+    assert set(x.name for x in tmp_path.iterdir()) == set(["server_events.go"])
+
+    with (tmp_path / "server_events.go").open("r", encoding="utf-8") as fd:
+        content = fd.read()
+
+    # Positive contract: a builder that returns *pubsub.Message.
+    assert "type GleanEventsBuilder struct" in content
+    assert "func (g GleanEventsBuilder) BuildEventsPingMessage(" in content
+    assert "(*pubsub.Message, error)" in content
+
+    # Negative: no other transport's shape
+    assert "type GleanEventsPublisher struct" not in content
+    assert "type GleanEventsLogger struct" not in content
+    # No MozLog envelope (logging path) or envelope-ping wrapper
+    assert "type logEnvelope struct" not in content
+    assert "RecordEventsPing(" not in content
+
+    _gofmt_parse_ok(tmp_path / "server_events.go")
+
+
+# Runtime tests
+#
+# Each scenario builds a *pubsub.Message via the generated
+# `Build<Ping>Message` method, publishes it via topic.Publish, and asserts
+# the message arrives at the pstest fake. Routing fields live on the
+# message's Attributes; the body is the inner Glean ping gzipped.
+
+PUBSUB_SCENARIOS = {
+    "events_ping": {
+        "yaml": YAML_EVENTS_PING,
+        "code": """
+        msg, err := builder.BuildEventsPingMessage(
+            glean.RequestInfo{
+                UserAgent: "glean-test/1.0",
+                IpAddress: "127.0.0.1",
+            },
+            glean.EventsPing{
+                MetricName:              "string value",
+                MetricRequestBool:       true,
+                MetricRequestCount:      10,
+                MetricRequestDatetime:   time.Now(),
+                MetricRequestStringList: []string{"list", "of", "strings"},
+                Event: glean.BackendTestEventEvent{
+                    EventFieldString:   "event extra string value",
+                    EventFieldQuantity: 100,
+                    EventFieldBool:     false,
+                },
+            },
+        )
+        """,
+        "expected_doc_type": "events",
+        "expected_event_count": 1,
+    },
+    "custom_ping_without_event": {
+        "yaml": YAML_CUSTOM_PING,
+        "code": """
+        msg, err := builder.BuildServerTelemetryScenarioOnePingMessage(
+            glean.RequestInfo{
+                UserAgent: "glean-test/1.0",
+                IpAddress: "127.0.0.1",
+            },
+            glean.ServerTelemetryScenarioOnePing{
+                MetricName:              "string value",
+                MetricRequestBool:       true,
+                MetricRequestCount:      20,
+                MetricRequestDatetime:   time.Now(),
+                MetricRequestStringList: []string{"list", "of", "strings"},
+            },
+        )
+        """,
+        "expected_doc_type": "server-telemetry-scenario-one",
+        "expected_event_count": 0,
+    },
+    "custom_ping_with_event": {
+        "yaml": YAML_CUSTOM_PING,
+        "code": """
+        msg, err := builder.BuildServerTelemetryScenarioOnePingMessage(
+            glean.RequestInfo{
+                UserAgent: "glean-test/1.0",
+                IpAddress: "127.0.0.1",
+            },
+            glean.ServerTelemetryScenarioOnePing{
+                MetricName:              "string value",
+                MetricRequestBool:       true,
+                MetricRequestCount:      20,
+                MetricRequestDatetime:   time.Now(),
+                MetricRequestStringList: []string{"list", "of", "strings"},
+                Event: glean.BackendSpecialEventEvent{
+                    EventFieldString:   "extra value string",
+                    EventFieldQuantity: 30,
+                    EventFieldBool:     true,
+                },
+            },
+        )
+        """,
+        "expected_doc_type": "server-telemetry-scenario-one",
+        "expected_event_count": 1,
+    },
+}
+
+
+@pytest.mark.go_dependency
+@pytest.mark.parametrize("scenario_name", list(PUBSUB_SCENARIOS))
+def test_run_record_pubsub(tmp_path, scenario_name):
+    """Build a Pub/Sub message and publish it via topic.Publish;
+    Then assert the wire format on the captured message."""
+    scenario = PUBSUB_SCENARIOS[scenario_name]
+    glean_module_path = tmp_path / "glean"
+    _translate(glean_module_path, scenario["yaml"])
+
+    msgs = _run_publisher(tmp_path, scenario["code"])
+    assert len(msgs) == 1, f"expected one published message, got {len(msgs)}"
+    attrs = msgs[0]["attributes"]
+    payload_bytes = gzip.decompress(base64.b64decode(msgs[0]["data"]))
+    payload = json.loads(payload_bytes)
+
+    # Pub/Sub attributes carry ping metadata.
+    # submission_timestamp is set by the decoder from publishTime, not by the publisher.
+    assert attrs["document_namespace"] == "glean.test"
+    assert attrs["document_type"] == scenario["expected_doc_type"]
+    assert attrs["document_version"] == "1"
+    assert attrs["user_agent"] == "glean-test/1.0"
+    assert attrs["x_forwarded_for"] == "127.0.0.1"
+    parsed = uuid.UUID(attrs["document_id"])
+    assert parsed.version == 4
+    assert attrs["document_id"] == attrs["document_id"].lower()
+    assert "submission_timestamp" not in attrs
+
+    assert len(payload["events"]) == scenario["expected_event_count"]
+    assert payload["client_info"]["app_display_version"] == "0.0.1"
+    assert payload["client_info"]["app_channel"] == "nightly"
+
+    _validate_payload_against_schema(payload_bytes)
+
+
+@pytest.mark.go_dependency
+def test_run_pubsub_nil_string_list(tmp_path):
+    """Test that nil string_list metrics serialize as empty arrays, not null."""
+    glean_module_path = tmp_path / "glean"
+    _translate(glean_module_path, YAML_EVENTS_PING)
+
+    code = """
+        msg, err := builder.BuildEventsPingMessage(
+            glean.RequestInfo{
+                UserAgent: "glean-test/1.0",
+                IpAddress: "127.0.0.1",
+            },
+            glean.EventsPing{
+                MetricName:            "string value",
+                MetricRequestBool:     true,
+                MetricRequestCount:    10,
+                MetricRequestDatetime: time.Now(),
+                // MetricRequestStringList intentionally omitted (nil)
+                Event: glean.BackendTestEventEvent{
+                    EventFieldString:   "event extra string value",
+                    EventFieldQuantity: 100,
+                    EventFieldBool:     false,
+                },
+            },
+        )
+        """
+
+    msgs = _run_publisher(tmp_path, code)
+    assert len(msgs) == 1, f"expected one published message, got {len(msgs)}"
+    payload_bytes = gzip.decompress(base64.b64decode(msgs[0]["data"]))
+    payload = json.loads(payload_bytes)
+
+    string_list_value = payload["metrics"]["string_list"]["metric.request_string_list"]
+    assert string_list_value == [], (
+        f"Expected empty array for nil string_list, got: {string_list_value}"
+    )
+
+    _validate_payload_against_schema(payload_bytes)


### PR DESCRIPTION
This adds a Go server template for direct-to-Pub/Sub submissions.
For big picture see https://mozilla-hub.atlassian.net/browse/DENG-9533.
This data will be consumed by new Decoder type landed in https://github.com/mozilla/gcp-ingestion/pull/2857.
Next steps after this lands are to test with MARS in stage, iron out wrinkles, and update our documentation.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
