### PR TITLE
Use JSON serialization for caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Use JSON serialization for on-disk caching
+
 ## 19.1.0
 
 - Go server: Add support for `labeled_boolean` metrics with static labels ([AE-1250](https://mozilla-hub.atlassian.net/browse/AE-1250))

--- a/glean_parser/util.py
+++ b/glean_parser/util.py
@@ -298,14 +298,14 @@ def fetch_remote_url(url: str, cache: bool = True):
 
     if cache:
         cache_dir = platformdirs.user_cache_dir("glean_parser", "mozilla")
-        with diskcache.Cache(cache_dir) as dc:
+        with diskcache.Cache(cache_dir, disk=diskcache.JSONDisk) as dc:
             if key in dc:
                 return dc[key]
 
-    contents: str = urllib.request.urlopen(url).read()
+    contents = urllib.request.urlopen(url).read().decode("utf-8")
 
     if cache:
-        with diskcache.Cache(cache_dir) as dc:
+        with diskcache.Cache(cache_dir, disk=diskcache.JSONDisk) as dc:
             dc[key] = contents
 
     return contents


### PR DESCRIPTION
Mitigates CVE-2025-69872.

See 
* https://github.com/mozilla/glean/security/dependabot/43
* https://github.com/EthanKim88/ethan-cve-disclosures/blob/cc7e259d241a709d06f3810833cd8d7c4d904365/CVE-2025-69872-DiskCache-Pickle-Deserialization.md