### PR TITLE
bug 2046193 - Put `in_session` on the object model for all metrics.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Ensure `in_session` is present for all metrics in the object model, like the other CommonMetricData args ([bug 2046193](https://bugzilla.mozilla.org/show_bug.cgi?id=2046193)).
+
 ## 20.0.0
 
 - BREAKING CHANGE: Go server: replaced the `go_server_pubsub` outputter with a `transport` option on `go_server` (`-s transport=logging|pubsub|combined`, default logging); `combined` emits both transports in one file and ping params gain an optional `DocumentID` to share a `document_id` across them for gradual migration ([#849](https://github.com/mozilla/glean_parser/pull/849))

--- a/glean_parser/metrics.py
+++ b/glean_parser/metrics.py
@@ -99,7 +99,7 @@ class Metric:
         self.defined_in = defined_in
         if telemetry_mirror is not None:
             self.telemetry_mirror = telemetry_mirror
-        if in_session:
+        if not hasattr(self, "in_session"):
             self.in_session = in_session
 
         # _validated indicates whether this metric has already been jsonschema

--- a/glean_parser/schemas/metrics.2-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.2-0-0.schema.yaml
@@ -633,9 +633,10 @@ definitions:
           Whether this metric participates in session sampling.
           When `true`, the metric is subject to session-level sampling and
           session metadata is attached to it.
-          When `false` (default), the metric bypasses session sampling entirely.
+          When `false`, the metric bypasses session sampling entirely.
 
           Only valid when `type`_ is `event`.
+          Defaults to `true` when `type`_ is `event`, `false` otherwise.
         type: boolean
         default: false
 

--- a/glean_parser/templates/rust.jinja2
+++ b/glean_parser/templates/rust.jinja2
@@ -102,9 +102,7 @@ CommonMetricData {
     send_in_pings: {{ obj.send_in_pings|rust }},
     lifetime: {{ obj.lifetime|rust }},
     disabled: {{ obj.is_disabled()|rust }},
-    {% if obj.in_session is defined %}
     in_session: {{ obj.in_session|rust }},
-    {% endif %}
     ..Default::default()
 }
 {%- endmacro -%}

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1203,6 +1203,7 @@ def test_no_internal_fields_exposed():
             "disabled": False,
             "expires": "never",
             "gecko_datapoint": "",
+            "in_session": False,
             "keys": None,
             "lifetime": "ping",
             "metadata": {},


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
