### PR TITLE
Bug 2052175 - Support `SOURCE_DATE_EPOCH` to use as the date to check expiry against

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Allow to overwrite date to check expiry against using the `SOURCE_DATE_EPOCH` environment variable ([bug 2052175](https://bugzilla.mozilla.org/show_bug.cgi?id=2052175))
+
 ## 20.0.1
 
 - Ensure `in_session` is present for all metrics in the object model, like the other CommonMetricData args ([bug 2046193](https://bugzilla.mozilla.org/show_bug.cgi?id=2046193)).

--- a/glean_parser/util.py
+++ b/glean_parser/util.py
@@ -5,6 +5,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import datetime
+import time
+import os
 import functools
 import json
 from pathlib import Path
@@ -412,6 +414,15 @@ def parse_expiration_version(expires: str) -> int:
         )
 
 
+def now_epoch():
+    try:
+        epoch_ts = int(os.environ.get("SOURCE_DATE_EPOCH", time.time()))
+    except ValueError:
+        raise ValueError("Invalid SOURCE_DATE_EPOCH")
+
+    return datetime.datetime.fromtimestamp(epoch_ts, tz=datetime.timezone.utc)
+
+
 def is_expired(expires: str, major_version: Optional[int] = None) -> bool:
     """
     Parses the `expires` field in a metric or ping and returns whether
@@ -425,7 +436,7 @@ def is_expired(expires: str, major_version: Optional[int] = None) -> bool:
         return parse_expiration_version(expires) <= major_version
     else:
         date = parse_expiration_date(expires)
-        return date <= datetime.datetime.now(datetime.timezone.utc).date()
+        return date <= now_epoch().date()
 
 
 def validate_expires(expires: str, major_version: Optional[int] = None) -> None:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -4,7 +4,9 @@
 # http://creativecommons.org/publicdomain/zero/1.0/
 
 from pathlib import Path
+import datetime
 import json
+import os
 import re
 import textwrap
 
@@ -1450,3 +1452,62 @@ def test_forbid_non_ext_non_object_attribution_distribution():
         "Extended attribution/distribution metrics must be of type 'object'"
         in errors[1]
     )
+
+
+def test_expire_epoch_can_be_overriden():
+    metrics = [
+        {
+            "category": {
+                "metric": {
+                    "type": "boolean",
+                    "expires": "2023-12-31",  # definitely in the past
+                },
+            }
+        }
+    ]
+    metrics = [util.add_required(x) for x in metrics]
+
+    all_metrics = parser.parse_objects(metrics)
+    errors = list(all_metrics)
+    assert len(errors) == 0
+    assert all_metrics.value["category"]["metric"].disabled is True
+
+    # A date definitely before the above expiry.
+    dt = datetime.datetime.strptime("2020-01-01", "%Y-%m-%d")
+    os.environ["SOURCE_DATE_EPOCH"] = str(int(dt.timestamp()))
+
+    all_metrics = parser.parse_objects(metrics)
+    errors = list(all_metrics)
+    assert len(errors) == 0
+    assert all_metrics.value["category"]["metric"].disabled is False
+
+    del os.environ["SOURCE_DATE_EPOCH"]
+
+
+@pytest.mark.parametrize(
+    "invalid_epoch",
+    [
+        "not-a-date",
+        "2020-01-01",
+        "",
+    ],
+)
+def test_overriden_expire_epoch_must_be_valid(invalid_epoch):
+    metrics = [
+        {
+            "category": {
+                "metric": {
+                    "type": "boolean",
+                    "expires": "2023-12-31",  # definitely in the past
+                },
+            }
+        }
+    ]
+    metrics = [util.add_required(x) for x in metrics]
+
+    with pytest.raises(ValueError, match="Invalid SOURCE_DATE_EPOCH"):
+        os.environ["SOURCE_DATE_EPOCH"] = invalid_epoch
+        all_metrics = parser.parse_objects(metrics)
+        list(all_metrics)
+
+    del os.environ["SOURCE_DATE_EPOCH"]


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
