### PR TITLE
Bug 2052480 - Disable COMMON_PREFIX lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Allow to overwrite date to check expiry against using the `SOURCE_DATE_EPOCH` environment variable ([bug 2052175](https://bugzilla.mozilla.org/show_bug.cgi?id=2052175))
+- Disable the `COMMON_PREFIX` lint. ([bug 2052480](https://bugzilla.mozilla.org/show_bug.cgi?id=2052480))
+  This is not a breaking change: We keep the name, but the lint will never trigger.
 
 ## 20.0.1
 

--- a/glean_parser/lint.py
+++ b/glean_parser/lint.py
@@ -84,34 +84,6 @@ def _hamming_distance(str1: str, str2: str) -> int:
     return diffs
 
 
-def check_common_prefix(
-    category_name: str, metrics: Iterable[metrics.Metric]
-) -> LintGenerator:
-    """
-    Check if all metrics begin with a common prefix.
-    """
-    metric_words = sorted([_split_words(metric.name) for metric in metrics])
-
-    if len(metric_words) < 2:
-        return
-
-    first = metric_words[0]
-    last = metric_words[-1]
-
-    for i in range(min(len(first), len(last))):
-        if first[i] != last[i]:
-            break
-
-    if i > 0:
-        common_prefix = "_".join(first[:i])
-        yield (
-            f"Within category '{category_name}', all metrics begin with "
-            f"prefix '{common_prefix}'. "
-            "Remove the prefixes on the metric names and (possibly) "
-            "rename the category."
-        )
-
-
 def check_unit_in_name(
     metric: metrics.Metric, parser_config: Dict[str, Any]
 ) -> LintGenerator:
@@ -465,7 +437,8 @@ def check_name_too_similar(
 CATEGORY_CHECKS: Dict[
     str, Tuple[Callable[[str, Iterable[metrics.Metric]], LintGenerator], CheckType]
 ] = {
-    "COMMON_PREFIX": (check_common_prefix, CheckType.error),
+    # Keeping it to not break when it is listed in `no_lint`
+    "COMMON_PREFIX": (noop, CheckType.error),
     "CATEGORY_GENERIC": (check_category_generic, CheckType.error),
 }
 

--- a/server_telemetry/sdk-metrics-compat.yaml
+++ b/server_telemetry/sdk-metrics-compat.yaml
@@ -47,8 +47,6 @@ glean.error:
     expires: never
     send_in_pings:
       - events
-    no_lint:
-      - COMMON_PREFIX
 
   invalid_label:
     type: labeled_counter
@@ -66,8 +64,6 @@ glean.error:
     expires: never
     send_in_pings:
       - events
-    no_lint:
-      - COMMON_PREFIX
 
   invalid_state:
     type: labeled_counter
@@ -85,8 +81,6 @@ glean.error:
     expires: never
     send_in_pings:
       - events
-    no_lint:
-      - COMMON_PREFIX
 
   invalid_overflow:
     type: labeled_counter
@@ -104,5 +98,3 @@ glean.error:
     expires: never
     send_in_pings:
       - events
-    no_lint:
-      - COMMON_PREFIX

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -20,6 +20,11 @@ ROOT = Path(__file__).parent
 
 
 def test_common_prefix():
+    """
+    The `COMMON_PREFIX` lint has been silenced.
+    This ensures we're not breaking anyone that lists it in `no_lint`
+    """
+
     contents = [
         {
             "telemetry": {
@@ -44,8 +49,7 @@ def test_common_prefix():
 
     nits = lint.lint_metrics(all_metrics.value)
 
-    assert len(nits) == 1
-    assert nits[0].check_name == "COMMON_PREFIX"
+    assert len(nits) == 0
 
     # Now make sure the override works
     contents[0]["no_lint"] = ["COMMON_PREFIX"]
@@ -149,10 +153,8 @@ def test_combined():
 
     nits = lint.lint_metrics(all_metrics.value)
 
-    assert len(nits) == 4
-    assert set(["COMMON_PREFIX", "CATEGORY_GENERIC", "UNIT_IN_NAME"]) == set(
-        v.check_name for v in nits
-    )
+    assert len(nits) == 3
+    assert set(["CATEGORY_GENERIC", "UNIT_IN_NAME"]) == set(v.check_name for v in nits)
 
 
 def test_baseline_restriction():


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
