### PR TITLE
bug 2062403 - Allow 'subcategories' longer than 29 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - BREAKING CHANGE: Generate labeled {custom|memory|timing} distribution for mobile ([#857](https://github.com/mozilla/glean_parser/pull/857))
+- Allow categories to have subcategories longer than 29 characters ([bug 2062403](https://bugzilla.mozilla.org/show_bug.cgi?id=2062403))
 
 ## 20.2.0
 - Allow renaming of fields when serializing metrics ([mozilla/glean-dictionary#2309](https://github.com/mozilla/glean-dictionary/issues/2309))

--- a/glean_parser/schemas/metrics.2-0-0.schema.yaml
+++ b/glean_parser/schemas/metrics.2-0-0.schema.yaml
@@ -21,7 +21,7 @@ definitions:
 
   dotted_snake_case:
     type: string
-    pattern: "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})*$"
+    pattern: "^[a-z_][a-z0-9_]*(\\.[a-z_][a-z0-9_]*)*$"
     maxLength: 40
 
   event_extra_key:

--- a/tests/data/categories.yaml
+++ b/tests/data/categories.yaml
@@ -1,0 +1,28 @@
+# Any copyright is dedicated to the Public Domain.
+# https://creativecommons.org/publicdomain/zero/1.0/
+
+---
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+
+
+we_used_to_have_subcategory_length:
+  but_we_dont_any_more: &defaults
+    type: counter
+    expires: never
+    description: A test metric
+    bugs: [https://bugzil.la/2062403]
+    data_reviews: [https://www.example.com]
+    notification_emails: [glean-team@mozilla.com]
+
+it.may_matter_that_theres_a_dot_here:
+  so_we_will_test_that_too:
+    <<: *defaults
+
+# Subcategory length 30, Category length 40
+start.abcdefghijklmnopqrstuvwxyzabcd.end:
+  no_problem:
+    <<: *defaults
+
+a.b:
+  really_short_categories_are_allowed:
+    <<: *defaults

--- a/tests/data/schema-violation.yaml
+++ b/tests/data/schema-violation.yaml
@@ -19,7 +19,7 @@ gleantest.lifetime:
     expires: never
     data_reviews: ['http://example.com']
 gleantest.with.way.too.long.category.name:
-  test_event_inv_lt:
+  test_event_inv_lt: &valid_metric
     description: A test metric
     type: boolean
     bugs:
@@ -27,6 +27,9 @@ gleantest.with.way.too.long.category.name:
     notification_emails: ['nobody@example.com']
     expires: never
     data_reviews: ['http://example.com']
+gleantest_with_way_too_long_category_name_and_no_subcategories:
+  test_metric:
+    <<: *valid_metric
 gleantest.short.category:
   very_long_metric_name_this_is_too_long_as_well_since_it_has_sooooo_many_characters:
     description: A test metric

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -357,6 +357,18 @@ def test_parser_schema_violation():
                 - `description`: **Required.** A description of the key.
             Valid when `type`_ is `event`.
         """,
+        """
+        ```
+        gleantest_with_way_too_long_category_name_and_no_subcategories
+        ...
+        ```
+
+        'gleantest_with_way_too_long_category_name_and_no_subcategories' is not valid under any of
+        the given schemas
+        'gleantest_with_way_too_long_category_name_and_no_subcategories' is too long
+        'gleantest_with_way_too_long_category_name_and_no_subcategories' is not one of
+        ['$schema', '$tags']
+        """,
     ]
 
     expected_errors = set(
@@ -370,6 +382,14 @@ def test_parser_schema_violation():
 
     for found_error, expected_error in zip(found, expected):
         assert found_error == expected_error
+
+    # If there are new errors and they're sorted after the expected list,
+    # the above checks won't find them. Log 'em, then assert 'em.
+    if len(found) > len(expected):
+        for i in range(len(expected), len(found)):
+            print(f"Unexpected error: {found[i]}")
+
+    assert len(found) == len(expected)
 
 
 def test_parser_empty():
@@ -1593,3 +1613,14 @@ def test_overriden_expire_epoch_must_be_valid(invalid_epoch):
         list(all_metrics)
 
     del os.environ["SOURCE_DATE_EPOCH"]
+
+
+def test_categories():
+    """Test the basics of parsing oddly-named-or-structured categories."""
+    all_metrics = parser.parse_objects(
+        [ROOT / "data" / "categories.yaml"],
+        config={"allow_reserved": False},
+    )
+
+    errs = list(all_metrics)
+    assert len(errs) == 0


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `make test` runs without emitting any warnings
  - `make lint` runs without emitting any errors
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - Any breaking changes to language binding APIs are noted explicitly
